### PR TITLE
fix(shared-memory-server): prevent subtraction overflow in send_raw

### DIFF
--- a/libraries/shared-memory-server/src/channel.rs
+++ b/libraries/shared-memory-server/src/channel.rs
@@ -108,11 +108,12 @@ impl ShmemChannel {
     }
 
     fn send_raw(&mut self, msg: &[u8]) -> Result<(), eyre::ErrReport> {
-        if msg.len() > self.memory.len() - self.data_offset {
+        let capacity = self.memory.len().saturating_sub(self.data_offset);
+        if msg.len() > capacity {
             bail!(
                 "message too large for shared memory: {} > {}",
                 msg.len(),
-                self.memory.len() - self.data_offset
+                capacity
             );
         }
         // write data first


### PR DESCRIPTION
## Summary

- Fix integer underflow in `ShmemChannel::send_raw()` when `data_offset > memory.len()` (e.g. small 256-byte region where headers consume all available space)
- Use `saturating_sub()` instead of direct subtraction to return 0 capacity instead of panicking

## Test plan

- [x] `cargo test -p shared-memory-server --lib` — all 4 tests pass, including `oversized_message_error`
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)