### PR TITLE
feat(examples): add multi-client service and action examples

### DIFF
--- a/examples/action-example/README.md
+++ b/examples/action-example/README.md
@@ -1,27 +1,31 @@
 # Action Example
 
-Demonstrates the **action** communication pattern: a client sends goals to a server, receives intermediate feedback, and gets a final result. Supports cancellation of in-progress goals.
+Demonstrates the **action** communication pattern with **multiple clients**: two clients send goals to a single server, receive intermediate feedback, and get final results. Each client filters responses by its own tracked goal IDs. Supports cancellation of in-progress goals.
 
 ## Architecture
 
 ```
-timer (2s) --> action-client --> goal     --> action-server
-                              <- feedback <--
-                              <- result   <--
-               action-client --> cancel   --> action-server
+timer (2s) --> action-client-1 --> goal   --> action-server --> feedback --> action-client-1
+                                                            --> result   --> action-client-1
+timer (3s) --> action-client-2 --> goal   -->               --> feedback --> action-client-2
+                                                            --> result   --> action-client-2
 ```
+
+Both clients use the same binary -- the YAML wires them as separate nodes with different timers. Feedback and results fan out to all clients; each filters by its own tracked `GOAL_ID`.
 
 ## Nodes
 
-**action-client** (Rust) -- Sends a new goal every 2 seconds with a countdown value. Tracks active goals by `GOAL_ID` in a HashMap. Receives feedback (progress updates) and result (final value). A `cancel` output is wired in the YAML for extensibility but is not exercised in the current client code.
+**action-client-1 / action-client-2** (Rust, same binary) -- Sends goals at 2s / 3s intervals with a countdown value. Tracks active goals by `GOAL_ID` in a HashMap. Receives feedback (progress updates) and result (final status). Logs are prefixed with the node ID (`ADORA_NODE_ID`) to distinguish output.
 
-**action-server** (Rust) -- Manages up to 64 active goals and 128 pending cancellations. On each input event, decrements the countdown for all active goals, sends feedback with current progress. When a goal reaches zero, sends a result with `GOAL_STATUS_SUCCEEDED`. Accepts `cancel` input for goal cancellation.
+**action-server** (Rust) -- Manages up to 64 active goals and 128 pending cancellations from any number of clients. On each input event, decrements the countdown for all active goals, sends feedback with current progress. When a goal reaches zero, sends a result with `GOAL_STATUS_SUCCEEDED`. Accepts `cancel` inputs for goal cancellation. Uses prefix matching (`starts_with("goal")` / `starts_with("cancel")`) to handle multiple named inputs.
 
 ## Key Concepts
 
+- **Multi-client fan-in/fan-out**: multiple clients share one server; feedback/results fan out, clients correlate by ID
 - **Goal ID**: unique identifier created via `AdoraNode::new_goal_id()` (UUID v7)
 - **Metadata keys**: `GOAL_ID` and `GOAL_STATUS` propagated on all action messages
 - **Bidirectional**: server outputs feed back to client inputs
+- **Same binary, multiple nodes**: YAML declares distinct nodes pointing to the same executable
 
 See [docs/patterns.md](../../docs/patterns.md#3-action-goalfeedbackresult) for the full pattern specification.
 
@@ -45,8 +49,9 @@ adora stop --all && adora down
 
 | Feature | Where |
 |---------|-------|
-| Action pattern (goal/feedback/result) | Both nodes |
+| Multi-client action pattern | Two clients, one server |
 | `new_goal_id()` for unique goal IDs | Client |
 | `GOAL_ID` / `GOAL_STATUS` metadata | YAML + both nodes |
 | Cancel wiring (extensibility) | YAML declares cancel output/input |
 | Concurrent goal tracking | Server HashMap with max 64 goals |
+| Same binary, multiple nodes | YAML dataflow |

--- a/examples/action-example/client/src/main.rs
+++ b/examples/action-example/client/src/main.rs
@@ -9,6 +9,7 @@ use adora_node_api::{
 fn main() -> eyre::Result<()> {
     let (mut node, mut events) = AdoraNode::init_from_env()?;
 
+    let node_id = std::env::var("ADORA_NODE_ID").unwrap_or_else(|_| "client".into());
     let mut active_goals: HashMap<String, i64> = HashMap::new();
     let mut tick_count: i64 = 0;
 
@@ -26,7 +27,7 @@ fn main() -> eyre::Result<()> {
                     let data = Int64Array::from(vec![start_value]);
                     node.send_output("goal".into(), params, data)?;
 
-                    println!("[client] sent goal {goal_id}: countdown from {start_value}");
+                    println!("[{node_id}] sent goal {goal_id}: countdown from {start_value}");
                     active_goals.insert(goal_id, start_value);
                 }
                 "feedback" => {
@@ -37,7 +38,7 @@ fn main() -> eyre::Result<()> {
                         .map(|a| a.value(0));
 
                     if let (Some(gid), Some(val)) = (gid, fb_array) {
-                        println!("[client] feedback {gid}: {val}");
+                        println!("[{node_id}] feedback {gid}: {val}");
                     }
                 }
                 "result" => {
@@ -46,7 +47,7 @@ fn main() -> eyre::Result<()> {
 
                     if let Some(gid) = gid {
                         let status = status.unwrap_or("unknown");
-                        println!("[client] result {gid}: {status}");
+                        println!("[{node_id}] result {gid}: {status}");
                         active_goals.remove(gid);
                     }
                 }

--- a/examples/action-example/dataflow.yml
+++ b/examples/action-example/dataflow.yml
@@ -1,5 +1,5 @@
 nodes:
-  - id: action-client
+  - id: action-client-1
     build: cargo build -p action-example-client
     path: ../../target/debug/action-example-client
     inputs:
@@ -10,12 +10,25 @@ nodes:
       - goal
       - cancel
 
+  - id: action-client-2
+    build: cargo build -p action-example-client
+    path: ../../target/debug/action-example-client
+    inputs:
+      tick: adora/timer/millis/3000
+      feedback: action-server/feedback
+      result: action-server/result
+    outputs:
+      - goal
+      - cancel
+
   - id: action-server
     build: cargo build -p action-example-server
     path: ../../target/debug/action-example-server
     inputs:
-      goal: action-client/goal
-      cancel: action-client/cancel
+      goal-1: action-client-1/goal
+      cancel-1: action-client-1/cancel
+      goal-2: action-client-2/goal
+      cancel-2: action-client-2/cancel
     outputs:
       - feedback
       - result

--- a/examples/action-example/server/src/main.rs
+++ b/examples/action-example/server/src/main.rs
@@ -20,7 +20,7 @@ fn main() -> eyre::Result<()> {
     while let Some(event) = events.recv() {
         match event {
             Event::Input { id, metadata, data } => match id.as_str() {
-                "goal" => {
+                _id if _id.starts_with("goal") => {
                     let goal_id =
                         get_string_param(&metadata.parameters, GOAL_ID).map(str::to_owned);
                     let start = data
@@ -37,7 +37,7 @@ fn main() -> eyre::Result<()> {
                         active_goals.insert(goal_id, start);
                     }
                 }
-                "cancel" => {
+                _id if _id.starts_with("cancel") => {
                     let goal_id =
                         get_string_param(&metadata.parameters, GOAL_ID).map(str::to_owned);
                     if let Some(goal_id) = goal_id {

--- a/examples/service-example/README.md
+++ b/examples/service-example/README.md
@@ -1,25 +1,29 @@
 # Service Example
 
-Demonstrates the **service** communication pattern: a client sends structured requests and receives correlated responses via `REQUEST_ID` metadata.
+Demonstrates the **service** communication pattern with **multiple clients**: two clients send structured requests to a single server and receive correlated responses via `REQUEST_ID` metadata. Each client filters responses by its own tracked request IDs.
 
 ## Architecture
 
 ```
-timer (500ms) --> service-client --> request  --> service-server
-                                  <- response <--
+timer (500ms) --> service-client-1 --> request --> service-server --> response --> service-client-1
+timer (700ms) --> service-client-2 --> request -->                --> response --> service-client-2
 ```
+
+Both clients use the same binary -- the YAML wires them as separate nodes with different timers. Responses fan out to all clients; each filters by its own tracked `REQUEST_ID`.
 
 ## Nodes
 
-**service-client** (Rust) -- Every 500ms, sends a request containing a `StructArray` with fields `a` (sequential counter) and `b` (counter + 10). Uses `node.send_service_request()` which automatically generates a `REQUEST_ID` and embeds it in metadata. Tracks pending requests by ID in a HashMap and matches responses.
+**service-client-1 / service-client-2** (Rust, same binary) -- Sends requests at 500ms / 700ms intervals containing a `StructArray` with fields `a` (sequential counter) and `b` (counter + 10). Uses `node.send_service_request()` which automatically generates a `REQUEST_ID` and embeds it in metadata. Tracks pending requests by ID in a HashMap and matches responses. Logs are prefixed with the node ID (`ADORA_NODE_ID`) to distinguish output.
 
-**service-server** (Rust) -- Receives requests, extracts fields `a` and `b`, computes `sum = a + b`, and returns a response `StructArray` with the `sum` field. Uses `node.send_service_response()` which propagates the `REQUEST_ID` from the incoming metadata.
+**service-server** (Rust) -- Receives requests from both clients (via separate named inputs), extracts fields `a` and `b`, computes `sum = a + b`, and returns a response `StructArray` with the `sum` field. Uses `node.send_service_response()` which propagates the `REQUEST_ID` from the incoming metadata.
 
 ## Key Concepts
 
+- **Multi-client fan-in/fan-out**: multiple clients share one server; responses fan out, clients correlate by ID
 - **Request ID**: unique UUID v7 identifier, generated internally by `send_service_request()`
 - **Metadata key**: `REQUEST_ID` automatically managed by helper methods
 - **Arrow StructArray**: typed structured data for request/response payloads
+- **Same binary, multiple nodes**: YAML declares distinct nodes pointing to the same executable
 
 See [docs/patterns.md](../../docs/patterns.md#2-service-requestreply) for the full pattern specification.
 
@@ -43,8 +47,9 @@ adora stop --all && adora down
 
 | Feature | Where |
 |---------|-------|
-| Service pattern (request/response) | Both nodes |
+| Multi-client service pattern | Two clients, one server |
 | `send_service_request()` / `send_service_response()` | Client / Server |
 | `REQUEST_ID` metadata correlation | Automatic via helpers |
 | Arrow `StructArray` for typed payloads | Both nodes |
 | Pending request tracking | Client HashMap |
+| Same binary, multiple nodes | YAML dataflow |

--- a/examples/service-example/client/src/main.rs
+++ b/examples/service-example/client/src/main.rs
@@ -10,6 +10,7 @@ use eyre::Context;
 fn main() -> eyre::Result<()> {
     let (mut node, mut events) = AdoraNode::init_from_env()?;
 
+    let node_id = std::env::var("ADORA_NODE_ID").unwrap_or_else(|_| "client".into());
     let mut in_flight: HashMap<String, (i64, i64)> = HashMap::new();
     let mut tick_count: i64 = 0;
 
@@ -45,7 +46,7 @@ fn main() -> eyre::Result<()> {
                         )
                         .context("failed to send request")?;
 
-                    println!("[client] sent request {request_id}: {a} + {b}");
+                    println!("[{node_id}] sent request {request_id}: {a} + {b}");
                     in_flight.insert(request_id, (a, b));
                 }
                 "response" => {
@@ -59,7 +60,7 @@ fn main() -> eyre::Result<()> {
                             .map(|a| a.value(0));
 
                         if let (Some((a, b)), Some(sum)) = (in_flight.remove(rid), sum_col) {
-                            println!("[client] response {rid}: {a} + {b} = {sum}");
+                            println!("[{node_id}] response {rid}: {a} + {b} = {sum}");
                             assert_eq!(sum, a + b, "sum mismatch");
                         }
                     }

--- a/examples/service-example/dataflow.yml
+++ b/examples/service-example/dataflow.yml
@@ -1,5 +1,5 @@
 nodes:
-  - id: service-client
+  - id: service-client-1
     build: cargo build -p service-example-client
     path: ../../target/debug/service-example-client
     inputs:
@@ -8,10 +8,20 @@ nodes:
     outputs:
       - request
 
+  - id: service-client-2
+    build: cargo build -p service-example-client
+    path: ../../target/debug/service-example-client
+    inputs:
+      tick: adora/timer/millis/700
+      response: service-server/response
+    outputs:
+      - request
+
   - id: service-server
     build: cargo build -p service-example-server
     path: ../../target/debug/service-example-server
     inputs:
-      request: service-client/request
+      request-1: service-client-1/request
+      request-2: service-client-2/request
     outputs:
       - response


### PR DESCRIPTION
## Summary

- Add a second client node to both service and action examples, demonstrating N-clients-to-1-server pattern
- Both clients reuse the same binary -- YAML wires them as separate nodes with different timers (500ms/700ms for service, 2s/3s for action)
- Clients filter fan-out responses by their own tracked request/goal IDs; server uses prefix matching for multiple named inputs

## Test plan

- [x] `cargo build` all four example crates
- [x] `cargo clippy` clean (zero warnings)
- [x] `cargo test --test example-smoke -- smoke_local_service_example smoke_local_action_example --test-threads=1` (2 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)