### PR TITLE
docs: fix Python build-from-source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ cd adora
 cargo build --release -p adora-cli
 PATH=$PATH:$(pwd)/target/release
 
-# Python API (requires maturin: pip install maturin)
-maturin develop -m apis/python/node/Cargo.toml
-maturin develop -m apis/python/operator/Cargo.toml
+# Python API (requires maturin >= 1.8: pip install maturin)
+# Must run from the package directory for dependency resolution
+cd apis/python/node && maturin develop --uv && cd ../../..
 ```
 
 ### Platform installers

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,8 +71,8 @@ Adora is built on four core principles:
 | `apis/rust/operator` | adora-operator-api | Rust |
 | `apis/rust/operator/macros` | adora-operator-api-macros | Rust (proc-macro) |
 | `apis/rust/operator/types` | adora-operator-api-types | Rust (FFI-safe types) |
-| `apis/python/node` | adora-node-api-python | Python (PyO3) |
-| `apis/python/operator` | adora-operator-api-python | Python (PyO3) |
+| `apis/python/node` | adora-node-api-python | Python (PyO3) -- builds the `adora` module |
+| `apis/python/operator` | adora-operator-api-python | Python (PyO3) -- compiled into adora-node-api-python |
 | `apis/c/node` | adora-node-api-c | C |
 | `apis/c/operator` | adora-operator-api-c | C/C++ |
 

--- a/docs/python-guide.md
+++ b/docs/python-guide.md
@@ -14,10 +14,11 @@ The `adora-rs` package includes `pyarrow` as a dependency.
 **Building from source** (instead of `pip install adora-rs`):
 
 ```bash
-pip install maturin
-maturin develop -m apis/python/node/Cargo.toml
-maturin develop -m apis/python/operator/Cargo.toml
+pip install maturin  # requires >= 1.8
+cd apis/python/node && maturin develop --uv && cd ../../..
 ```
+
+The operator API is compiled into the `adora` Python module automatically -- there is no separate install step for it.
 
 ## Hello World: Sender and Receiver
 

--- a/guide/src/getting-started/installation.md
+++ b/guide/src/getting-started/installation.md
@@ -21,9 +21,9 @@ cd adora
 cargo build --release -p adora-cli
 PATH=$PATH:$(pwd)/target/release
 
-# Python API (requires maturin: pip install maturin)
-maturin develop -m apis/python/node/Cargo.toml
-maturin develop -m apis/python/operator/Cargo.toml
+# Python API (requires maturin >= 1.8: pip install maturin)
+# Must run from the package directory for dependency resolution
+cd apis/python/node && maturin develop --uv && cd ../../..
 ```
 
 ## Platform installers

--- a/guide/src/getting-started/quickstart.md
+++ b/guide/src/getting-started/quickstart.md
@@ -14,9 +14,8 @@ The `adora-rs` package includes `pyarrow` as a dependency.
 **Building from source** (instead of `pip install adora-rs`):
 
 ```bash
-pip install maturin
-maturin develop -m apis/python/node/Cargo.toml
-maturin develop -m apis/python/operator/Cargo.toml
+pip install maturin  # requires >= 1.8
+cd apis/python/node && maturin develop --uv && cd ../../..
 ```
 
 ## Hello World: Sender and Receiver


### PR DESCRIPTION
## Summary

- Remove incorrect `maturin develop -m apis/python/operator/Cargo.toml` from all docs -- the operator crate is compiled into the node crate, not installed separately
- Fix maturin command to run from the package directory (`cd apis/python/node`) so `pyproject.toml` is found for `[dependency-groups]` resolution
- Add `--uv` flag and maturin >= 1.8 requirement
- Clarify in architecture docs that `adora-operator-api-python` is compiled into `adora-node-api-python`

## Test plan

- [x] Verified `cd apis/python/node && maturin develop --uv` builds successfully
- [x] Confirmed the operator API is included in the built `adora` module

🤖 Generated with [Claude Code](https://claude.com/claude-code)