### PR TITLE
chore: add dSYM debug symbol bundles to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,9 @@ out/
 # MacOS DS_Store
 .DS_Store
 
+# macOS debug symbol bundles
+*.dSYM/
+
 # Adora auth token (generated at runtime)
 .adora-token
 .daemon-id


### PR DESCRIPTION
## Summary

- Add `*.dSYM/` pattern to `.gitignore` to exclude macOS debug symbol bundles

🤖 Generated with [Claude Code](https://claude.com/claude-code)