### PR TITLE
fix(coordinator): fix Windows CI flaky artifact drop test

### DIFF
--- a/binaries/coordinator/src/artifacts.rs
+++ b/binaries/coordinator/src/artifacts.rs
@@ -99,8 +99,14 @@ mod tests {
 
     #[test]
     fn drop_cleans_up_temp_dir() {
+        // Use a unique directory to avoid races with parallel tests that
+        // also create/drop ArtifactStore (they share the same base path).
         let dir = {
-            let store = ArtifactStore::new().unwrap();
+            let store = ArtifactStore {
+                base_dir: std::env::temp_dir()
+                    .join(format!("adora-artifacts-test-{}", Uuid::new_v4())),
+            };
+            std::fs::create_dir_all(&store.base_dir).unwrap();
             let dir = store.base_dir.clone();
             // Write a file so the dir is non-empty
             let build_dir = dir.join("test-build");


### PR DESCRIPTION
## Summary

- Fix `drop_cleans_up_temp_dir` test failing on Windows CI due to parallel test race condition
- All artifact tests share the fixed path `adora-artifacts` via `ArtifactStore::new()`. When tests run in parallel, one test dropping its store deletes the directory while another test is writing to it
- Fix: the drop test now uses its own UUID-based temp directory, isolated from other tests

## Test plan

- [x] `cargo test -p adora-coordinator --lib artifacts::tests` passes locally
- [ ] Windows CI passes

Generated with [Claude Code](https://claude.com/claude-code)
