### PR TITLE
feat(core): add optional type annotations with static and runtime validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ name = "adora-core"
 version = "0.4.1"
 dependencies = [
  "adora-message",
+ "arrow-schema",
  "dunce",
  "eyre",
  "fs_extra",

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 ### Developer experience
 
 - **Single CLI, full lifecycle** -- `adora run` for local dev, `adora up/start` for distributed prod, plus build, logs, monitoring, record/replay all from one tool
-- **Declarative YAML dataflows** -- define pipelines as directed graphs, connect nodes through typed inputs/outputs, override with environment variables
+- **Declarative YAML dataflows** -- define pipelines as directed graphs, connect nodes through typed inputs/outputs, optional [type annotations](docs/types.md) with static validation, override with environment variables
 - **Multi-language nodes** -- write nodes in Rust, Python, C, or C++ with native APIs (not wrappers); mix languages freely in one dataflow
 - **[Reusable modules](docs/modules.md)** -- compose sub-graphs as standalone YAML files with typed inputs/outputs, parameters, optional ports, and nested composition (compile-time expansion, zero runtime overhead)
 - **Hot reload** -- live-reload Python operators without restarting the dataflow
@@ -251,6 +251,7 @@ See the [Distributed Deployment Guide](docs/distributed-deployment.md) for clust
 | `adora new` | Generate a new project or node |
 | `adora graph <PATH>` | Visualize a dataflow (Mermaid or HTML) |
 | `adora expand <PATH>` | Expand module references and print flat YAML |
+| `adora validate <PATH>` | Validate dataflow YAML and check [type annotations](docs/types.md) |
 | `adora system` | System management (daemon/coordinator control) |
 | `adora completion <SHELL>` | Generate shell completions |
 | `adora self update` | Update adora CLI |
@@ -294,6 +295,24 @@ nodes:
 **Built-in timer nodes:** `adora/timer/millis/<N>` and `adora/timer/hz/<N>`.
 
 **Input format:** `<node-id>/<output-name>` to subscribe to another node's output.
+
+**Type annotations:** Optionally annotate ports with type URNs for static and runtime validation. See the [Type Annotations Guide](docs/types.md) for the full type library.
+
+```yaml
+nodes:
+  - id: camera
+    path: camera.py
+    outputs:
+      - image
+    output_types:
+      image: std/media/v1/Image
+```
+
+```bash
+adora validate dataflow.yml                        # static check (warnings)
+adora validate --strict dataflow.yml               # fail on warnings (CI)
+ADORA_RUNTIME_TYPE_CHECK=warn adora run dataflow.yml  # runtime check
+```
 
 **Modules:** Extract reusable sub-graphs into separate files with `module:` instead of `path:`. See the [Modules Guide](docs/modules.md) for details.
 
@@ -402,6 +421,7 @@ examples/               # Example dataflows
 | Example | Language | Description |
 |---------|----------|-------------|
 | [module-dataflow](examples/module-dataflow) | Python | Reusable module composition |
+| [typed-dataflow](examples/typed-dataflow) | Python | Type annotations with `adora validate` |
 
 ### Communication patterns
 

--- a/adora-schema.json
+++ b/adora-schema.json
@@ -83,6 +83,16 @@
           "items": { "type": "string" },
           "uniqueItems": true
         },
+        "output_types": {
+          "description": "Optional type annotations for outputs. Maps output IDs to type URNs (e.g. `std/media/v1/Image`).",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "input_types": {
+          "description": "Optional type annotations for inputs. Maps input IDs to expected type URNs for validation.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
         "env": {
           "description": "Environment variables for build and execution. Values can be strings, numbers, or booleans. Use `__adora_env` to read from host environment.",
           "type": "object",
@@ -247,6 +257,16 @@
           "items": { "type": "string" },
           "uniqueItems": true
         },
+        "output_types": {
+          "description": "Optional type annotations for outputs.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "input_types": {
+          "description": "Optional type annotations for inputs.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
         "shared-library": {
           "description": "Path to a shared library (.so/.dylib/.dll) implementing the operator.",
           "type": "string"
@@ -314,6 +334,16 @@
           "type": "array",
           "items": { "type": "string" },
           "uniqueItems": true
+        },
+        "output_types": {
+          "description": "Optional type annotations for outputs.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "input_types": {
+          "description": "Optional type annotations for inputs.",
+          "type": "object",
+          "additionalProperties": { "type": "string" }
         },
         "shared-library": {
           "description": "Path to a shared library implementing the operator.",

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -17,6 +17,7 @@ use adora_core::{
     descriptor::Descriptor,
     metadata::ArrowTypeInfoExt,
     topics::{ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST},
+    types::TypeRegistry,
     uhlc,
 };
 use adora_message::{
@@ -51,6 +52,34 @@ use tracing::{info, warn};
 pub mod arrow_utils;
 mod control_channel;
 mod drop_stream;
+
+/// Runtime type checking mode, controlled by `ADORA_RUNTIME_TYPE_CHECK` env var.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeTypeCheck {
+    /// No runtime type checking (default).
+    Off,
+    /// Log warnings on type mismatches.
+    Warn,
+    /// Return errors on type mismatches.
+    Error,
+}
+
+impl RuntimeTypeCheck {
+    fn from_env() -> Self {
+        match std::env::var("ADORA_RUNTIME_TYPE_CHECK").as_deref() {
+            Ok("error") => Self::Error,
+            Ok("1" | "warn" | "true") => Self::Warn,
+            Ok("") | Err(_) => Self::Off,
+            Ok(other) => {
+                tracing::warn!(
+                    "unknown ADORA_RUNTIME_TYPE_CHECK value \"{other}\", \
+                     expected \"warn\" or \"error\"; disabling runtime type check"
+                );
+                Self::Off
+            }
+        }
+    }
+}
 
 /// The data size threshold at which we start using shared memory.
 ///
@@ -87,6 +116,10 @@ pub struct AdoraNode {
     warned_unknown_output: BTreeSet<DataId>,
     interactive: bool,
     restart_count: u32,
+
+    /// Runtime type checking state. `None` when off (zero overhead).
+    /// When `Some`, holds the mode (Warn/Error) and a map of output DataId -> expected Arrow DataType.
+    runtime_type_checks: Option<(RuntimeTypeCheck, HashMap<DataId, arrow_schema::DataType>)>,
 }
 
 impl AdoraNode {
@@ -375,6 +408,8 @@ impl AdoraNode {
             run_config: NodeRunConfig {
                 inputs: Default::default(),
                 outputs: Default::default(),
+                output_types: Default::default(),
+                input_types: Default::default(),
             },
             daemon_communication: Some(DaemonCommunication::Interactive),
             dataflow_descriptor: serde_yaml::Value::Null,
@@ -407,6 +442,8 @@ impl AdoraNode {
             run_config: NodeRunConfig {
                 inputs: Default::default(),
                 outputs: Default::default(),
+                output_types: Default::default(),
+                input_types: Default::default(),
             },
             daemon_communication: None,
             dataflow_descriptor: serde_yaml::Value::Null,
@@ -499,6 +536,33 @@ impl AdoraNode {
         let control_channel =
             ControlChannel::init(dataflow_id, &node_id, &daemon_communication, clock.clone())
                 .wrap_err("failed to init control channel")?;
+        let runtime_type_checks = match RuntimeTypeCheck::from_env() {
+            RuntimeTypeCheck::Off => None,
+            mode => {
+                let registry = TypeRegistry::new();
+                let mut checks = HashMap::new();
+                for (id, urn) in &run_config.output_types {
+                    match registry.resolve_arrow_type(urn) {
+                        Some(dt) => {
+                            checks.insert(id.clone(), dt);
+                        }
+                        None => {
+                            if registry.resolve(urn).is_some() {
+                                info!(
+                                    "runtime type check: skipping complex type \"{urn}\" on output \"{id}\""
+                                );
+                            } else {
+                                warn!(
+                                    "runtime type check: unknown type URN \"{urn}\" on output \"{id}\""
+                                );
+                            }
+                        }
+                    }
+                }
+                Some((mode, checks))
+            }
+        };
+
         let node = Self {
             id: node_id,
             dataflow_id,
@@ -512,6 +576,7 @@ impl AdoraNode {
             warned_unknown_output: BTreeSet::new(),
             interactive: false,
             restart_count,
+            runtime_type_checks,
         };
 
         if dynamic {
@@ -619,6 +684,27 @@ impl AdoraNode {
         };
 
         let arrow_array = data.to_data();
+
+        // Runtime type check (only when ADORA_RUNTIME_TYPE_CHECK is set)
+        if let Some((mode, checks)) = &self.runtime_type_checks {
+            if let Some(expected) = checks.get(&output_id) {
+                let actual = arrow_array.data_type();
+                if actual != expected {
+                    let msg = format!(
+                        "output \"{output_id}\": expected Arrow type {expected:?}, got {actual:?}"
+                    );
+                    match mode {
+                        RuntimeTypeCheck::Error => {
+                            return Err(NodeError::Output(msg));
+                        }
+                        RuntimeTypeCheck::Warn => {
+                            warn!("type mismatch: {msg}");
+                        }
+                        RuntimeTypeCheck::Off => unreachable!(),
+                    }
+                }
+            }
+        }
 
         let total_len = required_data_size(&arrow_array);
 

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -24,6 +24,7 @@ mod system;
 mod topic;
 mod trace;
 mod up;
+mod validate;
 
 pub use build::build;
 pub use run::{Run, run};
@@ -53,6 +54,7 @@ use system::System;
 use topic::Topic;
 use trace::Trace;
 use up::Up;
+use validate::Validate;
 
 /// adora-rs cli client
 #[derive(Debug, clap::Subcommand)]
@@ -123,8 +125,11 @@ pub enum Command {
     /// Expand module references and print the flat dataflow YAML
     #[clap(display_order = 23)]
     Expand(Expand),
+    /// Validate a dataflow YAML file and check type annotations
+    #[clap(display_order = 24)]
+    Validate(Validate),
     /// System management commands
-    #[clap(subcommand, display_order = 24)]
+    #[clap(subcommand, display_order = 25)]
     System(System),
 
     // -- Utility --
@@ -190,6 +195,7 @@ impl Executable for Command {
             Command::New(args) => args.execute(),
             Command::Graph(args) => args.execute(),
             Command::Expand(args) => args.execute(),
+            Command::Validate(args) => args.execute(),
             Command::System(args) => args.execute(),
             Command::Completion(args) => args.execute(),
             Command::Self_ { command } => command.execute(),
@@ -275,6 +281,16 @@ mod tests {
     #[test]
     fn parse_expand_module() {
         parse_ok(&["adora", "expand", "--module", "module.yml"]);
+    }
+
+    #[test]
+    fn parse_validate() {
+        parse_ok(&["adora", "validate", "dataflow.yml"]);
+    }
+
+    #[test]
+    fn parse_validate_strict() {
+        parse_ok(&["adora", "validate", "--strict", "dataflow.yml"]);
     }
 
     #[test]

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -1,0 +1,55 @@
+use super::Executable;
+use adora_core::{
+    descriptor::{Descriptor, DescriptorExt, validate::check_type_annotations},
+    types::TypeRegistry,
+};
+use eyre::{Context, bail};
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Args)]
+/// Validate a dataflow YAML file and check type annotations
+pub struct Validate {
+    /// Path to the dataflow descriptor file
+    #[clap(value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
+    dataflow: PathBuf,
+    /// Treat warnings as errors (non-zero exit code)
+    #[clap(long, action)]
+    strict: bool,
+}
+
+impl Executable for Validate {
+    fn execute(self) -> eyre::Result<()> {
+        let working_dir = self
+            .dataflow
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
+
+        println!("Validating {}...", self.dataflow.display());
+
+        // Parse and expand modules (no runtime needed)
+        let descriptor = Descriptor::blocking_read(&self.dataflow)
+            .with_context(|| format!("failed to read dataflow at `{}`", self.dataflow.display()))?
+            .expand(working_dir)
+            .context("failed to expand modules")?;
+
+        // Run type annotation checks
+        let registry = TypeRegistry::new();
+        let warnings = check_type_annotations(&descriptor, &registry);
+
+        if warnings.is_empty() {
+            println!("All type annotations OK.");
+        } else {
+            println!("Type warnings:");
+            for w in &warnings {
+                println!("  - {w}");
+            }
+            let count = warnings.len();
+            println!("{count} type warning(s) found.");
+            if self.strict {
+                bail!("{count} type warning(s) found (--strict mode)");
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3304,6 +3304,8 @@ mod fault_tolerance_tests {
                 run_config: NodeRunConfig {
                     inputs: BTreeMap::new(),
                     outputs: BTreeSet::new(),
+                    output_types: BTreeMap::new(),
+                    input_types: BTreeMap::new(),
                 },
                 daemon_communication: None,
                 dataflow_descriptor: serde_yaml::Value::Null,
@@ -3721,6 +3723,8 @@ impl CoreNodeKindExt for CoreNodeKind {
             CoreNodeKind::Runtime(n) => NodeRunConfig {
                 inputs: runtime_node_inputs(n),
                 outputs: runtime_node_outputs(n),
+                output_types: BTreeMap::new(),
+                input_types: BTreeMap::new(),
             },
             CoreNodeKind::Custom(n) => n.run_config.clone(),
         }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -763,7 +763,7 @@ adora graph <PATH> [OPTIONS]
 | `--mermaid` | false | Output Mermaid diagram text |
 | `--open` | false | Open HTML in browser |
 
-Without `--mermaid`, generates an interactive HTML file using mermaid.js.
+Without `--mermaid`, generates an interactive HTML file using mermaid.js. When outputs have type annotations, edge labels include the type name (e.g. `image [Image]`).
 
 ```bash
 # Generate HTML
@@ -772,6 +772,34 @@ adora graph dataflow.yml --open
 # Generate Mermaid for GitHub markdown
 adora graph dataflow.yml --mermaid
 ```
+
+#### `adora validate`
+
+Validate a dataflow YAML file and check type annotations.
+
+```
+adora validate <PATH> [OPTIONS]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<PATH>` | required | Dataflow descriptor path |
+| `--strict` | false | Treat warnings as errors (non-zero exit code for CI) |
+
+Checks:
+1. `output_types`/`input_types` keys exist in the corresponding `outputs`/`inputs` lists
+2. All type URNs resolve in the standard type library
+3. Connected edges have matching types when both sides are annotated
+
+```bash
+# Validate with warnings
+adora validate dataflow.yml
+
+# Strict mode for CI (exit 1 on warnings)
+adora validate --strict dataflow.yml
+```
+
+See the [Type Annotations Guide](types.md) for the full type library and usage details.
 
 ---
 
@@ -848,6 +876,7 @@ All environment variables serve as fallbacks. CLI flags always take precedence.
 | `ADORA_LOG_FORMAT` | `pretty` | `run`, `logs` | Default output format |
 | `ADORA_LOG_FILTER` | | `run`, `logs` | Default per-node level overrides |
 | `ADORA_ALLOW_SHELL_NODES` | | `run` | Enable shell node execution |
+| `ADORA_RUNTIME_TYPE_CHECK` | | `run`, `start` | Runtime type checking: `warn` (log mismatches) or `error` (fail on mismatch). See [Type Annotations](types.md#runtime-type-checking) |
 
 ```bash
 # Set defaults for a development session

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,166 @@
+# Type Annotations
+
+Optional type annotations on dataflow inputs and outputs. Types are never required -- unannotated ports remain fully dynamic. Type checking is static only (no runtime overhead).
+
+## Quick Start
+
+```yaml
+nodes:
+  - id: camera
+    path: camera.py
+    outputs:
+      - image
+    output_types:
+      image: std/media/v1/Image
+
+  - id: detector
+    path: detect.py
+    inputs:
+      image: camera/image
+    input_types:
+      image: std/media/v1/Image
+    outputs:
+      - bbox
+    output_types:
+      bbox: std/vision/v1/BoundingBox
+```
+
+Validate with:
+
+```bash
+adora validate dataflow.yml
+
+# Fail with non-zero exit code on warnings (for CI)
+adora validate --strict dataflow.yml
+```
+
+## Type URN Format
+
+Type URNs follow the pattern `std/<category>/v<version>/<TypeName>`:
+
+```
+std/core/v1/Float32
+std/media/v1/Image
+std/vision/v1/BoundingBox
+```
+
+## Standard Type Library
+
+### `std/core/v1`
+
+| Type | Arrow Type | Description |
+|------|-----------|-------------|
+| `Float32` | Float32 | 32-bit float |
+| `Float64` | Float64 | 64-bit float |
+| `Int32` | Int32 | 32-bit signed integer |
+| `Int64` | Int64 | 64-bit signed integer |
+| `UInt8` | UInt8 | 8-bit unsigned integer |
+| `UInt32` | UInt32 | 32-bit unsigned integer |
+| `UInt64` | UInt64 | 64-bit unsigned integer |
+| `String` | Utf8 | UTF-8 string |
+| `Bytes` | LargeBinary | Raw bytes |
+| `Bool` | Boolean | Boolean |
+
+### `std/math/v1`
+
+| Type | Arrow Type | Description |
+|------|-----------|-------------|
+| `Vector3` | Struct | 3D vector (x, y, z Float64) |
+| `Quaternion` | Struct | Quaternion (x, y, z, w Float64) |
+| `Pose` | Struct | 6-DOF pose (position + orientation) |
+| `Transform` | Struct | Coordinate transform (translation + rotation) |
+
+### `std/control/v1`
+
+| Type | Arrow Type | Description |
+|------|-----------|-------------|
+| `Twist` | Struct | Linear and angular velocity |
+| `JointState` | Struct | Joint positions, velocities, efforts |
+| `Odometry` | Struct | Pose + Twist in a reference frame |
+
+### `std/media/v1`
+
+| Type | Arrow Type | Description |
+|------|-----------|-------------|
+| `Image` | Struct | Raw image (width, height, encoding, data) |
+| `CompressedImage` | LargeBinary | JPEG/PNG compressed image |
+| `PointCloud` | Struct | 3D point cloud |
+| `AudioFrame` | Struct | Audio samples |
+
+### `std/vision/v1`
+
+| Type | Arrow Type | Description |
+|------|-----------|-------------|
+| `BoundingBox` | Struct | 2D bounding box with confidence and label |
+| `Detection` | Struct | Object detection result (list of BoundingBox) |
+| `Segmentation` | Struct | Pixel-level segmentation mask |
+
+## Validation Rules
+
+`adora validate` checks:
+
+1. **Key existence**: `output_types` keys must appear in `outputs`, `input_types` keys must appear in `inputs`
+2. **URN resolution**: All type URNs must exist in the standard library
+3. **Edge compatibility**: When a connected output and input both have types, they must match
+
+All checks produce warnings (non-fatal by default). Use `--strict` to treat warnings as errors for CI pipelines. Typos get suggestions:
+
+```
+Type warnings:
+  - node "camera": output_types key "framez" not found in outputs list
+  - node "detector": unknown type "std/vision/v1/BoundingBx" on output "bbox"
+    (did you mean "std/vision/v1/BoundingBox"?)
+  - node "detector": type mismatch on input "image": upstream camera/image
+    declares "std/core/v1/Bytes", but expected "std/media/v1/Image"
+```
+
+## Runtime Type Checking
+
+In addition to static validation, Adora supports optional runtime type checking on `send_output()`. When enabled, the actual Arrow data type is compared against the declared `output_types` at send time.
+
+Enable via environment variable:
+
+```bash
+# Warn on mismatches (log and continue)
+ADORA_RUNTIME_TYPE_CHECK=warn adora run dataflow.yml
+
+# Error on mismatches (node returns error)
+ADORA_RUNTIME_TYPE_CHECK=error adora run dataflow.yml
+```
+
+Valid values: `1`, `warn`, `true` (warn mode), `error` (error mode). Unset or any other value disables checking (zero overhead).
+
+**Scope:**
+- Validates `output_types` on the sender side (`send_output()` calls). `input_types` are checked statically by `adora validate` but not enforced at runtime
+- Covers all languages that send Arrow arrays (Rust, Python, C++ Arrow path)
+- Raw byte sends (`send_output_bytes`, C nodes) are untyped and skip checking
+- Complex types (Struct-based: Image, Vector3, etc.) are skipped — only primitive types, String, Bytes, and Bool are validated at runtime
+
+## Graph Visualization
+
+When outputs have type annotations, `adora graph` shows the type on edge labels:
+
+```bash
+adora graph dataflow.yml --open
+```
+
+Edges display as `output_name [TypeName]` (e.g. `image [Image]`).
+
+## Operators
+
+Operators support the same `output_types` and `input_types` fields:
+
+```yaml
+- id: runtime-node
+  operators:
+    - id: preprocessor
+      python: preprocess.py
+      inputs:
+        raw: sensor/data
+      input_types:
+        raw: std/core/v1/Bytes
+      outputs:
+        - processed
+      output_types:
+        processed: std/media/v1/Image
+```

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -124,6 +124,48 @@ outputs:
   - metadata
 ```
 
+### Type Annotations
+
+Optional type annotations for inputs and outputs. Types are never required -- unannotated ports remain fully dynamic.
+
+```yaml
+- id: camera
+  path: camera.py
+  outputs:
+    - image
+    - depth
+  output_types:
+    image: std/media/v1/Image
+    depth: std/media/v1/Image
+
+- id: detector
+  path: detect.py
+  inputs:
+    image: camera/image
+  input_types:
+    image: std/media/v1/Image
+  outputs:
+    - bbox
+  output_types:
+    bbox: std/vision/v1/BoundingBox
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `output_types` | object | `{}` | Maps output IDs to type URNs. Keys must match entries in `outputs` |
+| `input_types` | object | `{}` | Maps input IDs to expected type URNs. Keys must match entries in `inputs` |
+
+Type URNs use the format `std/<category>/v<version>/<TypeName>`. See the [Type Annotations Guide](types.md) for the full standard type library.
+
+Run `adora validate <file>` to check type annotations statically. For runtime checking, set `ADORA_RUNTIME_TYPE_CHECK=warn` or `error`:
+
+```bash
+adora validate dataflow.yml
+ADORA_RUNTIME_TYPE_CHECK=warn adora run dataflow.yml
+```
+
+Types also appear on `adora graph` edge labels when annotated.
+
 ### Module Parameters
 
 When using `module:`, pass configuration values via `params:`:

--- a/examples/rust-dataflow/dataflow.yml
+++ b/examples/rust-dataflow/dataflow.yml
@@ -6,6 +6,8 @@ nodes:
       tick: adora/timer/millis/10
     outputs:
       - random
+    output_types:
+      random: std/core/v1/UInt64
 
   - id: rust-status-node
     build: cargo build -p rust-dataflow-example-status-node
@@ -13,11 +15,17 @@ nodes:
     inputs:
       tick: adora/timer/millis/100
       random: rust-node/random
+    input_types:
+      random: std/core/v1/UInt64
     outputs:
       - status
+    output_types:
+      status: std/core/v1/String
 
   - id: rust-sink
     build: cargo build -p rust-dataflow-example-sink
     path: ../../target/debug/rust-dataflow-example-sink
     inputs:
       message: rust-status-node/status
+    input_types:
+      message: std/core/v1/String

--- a/examples/typed-dataflow/dataflow.yml
+++ b/examples/typed-dataflow/dataflow.yml
@@ -1,0 +1,31 @@
+# Typed dataflow example -- same as python-dataflow but with type annotations.
+#
+# Validate types:   adora validate dataflow.yml
+# Strict (for CI):  adora validate --strict dataflow.yml
+# Visualize:        adora graph dataflow.yml --open
+# Run:              adora run dataflow.yml --uv
+nodes:
+  - id: sensor
+    path: sensor.py
+    outputs:
+      - reading
+    output_types:
+      reading: std/core/v1/Float64
+
+  - id: processor
+    path: processor.py
+    inputs:
+      reading: sensor/reading
+    input_types:
+      reading: std/core/v1/Float64
+    outputs:
+      - result
+    output_types:
+      result: std/core/v1/String
+
+  - id: sink
+    path: sink.py
+    inputs:
+      result: processor/result
+    input_types:
+      result: std/core/v1/String

--- a/examples/typed-dataflow/processor.py
+++ b/examples/typed-dataflow/processor.py
@@ -1,0 +1,28 @@
+"""Processor node that converts float readings to string labels."""
+
+import logging
+
+import pyarrow as pa
+from adora import Node
+
+
+def main():
+    node = Node()
+
+    for event in node:
+        if event["type"] == "INPUT":
+            value = event["value"].to_pylist()[0]
+            if value > 22.0:
+                label = f"HIGH: {value:.1f}"
+            elif value < 18.0:
+                label = f"LOW: {value:.1f}"
+            else:
+                label = f"OK: {value:.1f}"
+            node.send_output("result", pa.array([label]))
+            logging.info("Processed %.1f -> %s", value, label)
+        elif event["type"] == "STOP":
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/typed-dataflow/sensor.py
+++ b/examples/typed-dataflow/sensor.py
@@ -1,0 +1,20 @@
+"""Sensor node that emits float readings."""
+
+import random
+import time
+
+import pyarrow as pa
+from adora import Node
+
+
+def main():
+    node = Node()
+
+    for i in range(50):
+        value = 20.0 + random.gauss(0, 2.0)  # temperature-like reading
+        node.send_output("reading", pa.array([value], type=pa.float64()))
+        time.sleep(0.1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/typed-dataflow/sink.py
+++ b/examples/typed-dataflow/sink.py
@@ -1,0 +1,21 @@
+"""Sink node that prints string results."""
+
+import logging
+
+from adora import Node
+
+
+def main():
+    node = Node()
+
+    for event in node:
+        if event["type"] == "INPUT":
+            label = event["value"].to_pylist()[0]
+            print(f"[sink] {label}")
+        elif event["type"] == "STOP":
+            logging.info("Sink stopping")
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -20,6 +20,7 @@ adora-message = { workspace = true }
 eyre = "0.6.8"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_yaml = { workspace = true }
+arrow-schema = { workspace = true }
 once_cell = "1.13.0"
 which = "5.0.0"
 uuid = { version = "1.7", features = ["serde", "v7"] }

--- a/libraries/core/adora-schema.json
+++ b/libraries/core/adora-schema.json
@@ -1,9 +1,18 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "adora-rs specification",
-  "description": "The main configuration structure for defining a Adora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Communication**: Optional communication configuration\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: dora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
+  "description": "The main configuration structure for defining a Adora dataflow. Dataflows are\nspecified through YAML files that describe the nodes, their connections, and\nexecution parameters.\n\n## Structure\n\nA dataflow consists of:\n- **Nodes**: The computational units that process data\n- **Communication**: Optional communication configuration\n- **Deployment**: Optional deployment configuration (unstable)\n- **Debug options**: Optional development and debugging settings (unstable)\n\n## Example\n\n```yaml\nnodes:\n - id: webcam\n    operator:\n      python: webcam.py\n      inputs:\n        tick: adora/timer/millis/100\n      outputs:\n        - image\n  - id: plot\n    operator:\n      python: plot.py\n      inputs:\n        image: webcam/image\n```",
   "type": "object",
   "properties": {
+    "health_check_interval": {
+      "description": "How often the daemon checks node health (in seconds).\n\nDefaults to 5.0 seconds if not specified. Lower values detect hung nodes\nfaster but add more overhead.",
+      "type": [
+        "number",
+        "null"
+      ],
+      "format": "double",
+      "default": null
+    },
     "nodes": {
       "description": "List of nodes in the dataflow\n\nThis is the most important field of the dataflow specification.\nEach node must be identified by a unique `id`:\n\n## Example\n\n```yaml\nnodes:\n  - id: foo\n    path: path/to/the/executable\n    # ... (see below)\n  - id: bar\n    path: path/to/another/executable\n    # ... (see below)\n```\n\nFor each node, you need to specify the `path` of the executable or script that Adora should run when starting the node.\nMost of the other node fields are optional, but you typically want to specify at least some `inputs` and/or `outputs`.",
       "type": "array",
@@ -44,6 +53,21 @@
             "$ref": "#/$defs/EnvValue"
           }
         },
+        "health_check_timeout": {
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "input_types": {
+          "description": "Optional type annotations for inputs",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "inputs": {
           "description": "Inputs for the nodes as a map from input ID to `node_id/output_id`.\n\ne.g.\n\ninputs:\n\n  example_input: example_node/example_output1",
           "type": "object",
@@ -51,6 +75,51 @@
             "$ref": "#/$defs/Input"
           },
           "default": {}
+        },
+        "max_log_size": {
+          "description": "Maximum log file size before rotation (e.g. \"50MB\", \"1GB\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "max_restart_delay": {
+          "description": "Maximum delay in seconds for exponential backoff.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "max_restarts": {
+          "description": "Maximum number of restart attempts. 0 means unlimited.",
+          "type": "integer",
+          "format": "uint32",
+          "default": 0,
+          "minimum": 0
+        },
+        "max_rotated_files": {
+          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "min_log_level": {
+          "description": "Minimum log level for this node",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_types": {
+          "description": "Optional type annotations for outputs",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "outputs": {
           "description": "List of output IDs.\n\ne.g.\n\noutputs:\n\n - output_1\n\n - output_2",
@@ -65,9 +134,32 @@
           "description": "Path of the source code\n\nIf you want to use a specific `conda` environment.\nProvide the python path within the source.\n\nsource: /home/peter/miniconda3/bin/python\n\nargs: some_node.py\n\nSource can match any executable in PATH.",
           "type": "string"
         },
+        "restart_delay": {
+          "description": "Initial delay in seconds before restarting (exponential backoff).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "restart_policy": {
           "$ref": "#/$defs/RestartPolicy",
           "default": "never"
+        },
+        "restart_window": {
+          "description": "Time window in seconds for counting restarts.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "send_logs_as": {
+          "description": "Redirect structured log entries to a data output as JSON strings",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "send_stdout_as": {
           "description": "Send stdout and stderr to another node",
@@ -173,6 +265,13 @@
         {
           "type": "object",
           "properties": {
+            "input_timeout": {
+              "type": [
+                "number",
+                "null"
+              ],
+              "format": "double"
+            },
             "queue_size": {
               "type": [
                 "integer",
@@ -240,14 +339,14 @@
           ]
         },
         "branch": {
-          "description": "Git branch to checkout after cloning.\n\nThe `branch` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the branch that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/dora.git\n    branch: some-branch-name\n```",
+          "description": "Git branch to checkout after cloning.\n\nThe `branch` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the branch that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/adora.git\n    branch: some-branch-name\n```",
           "type": [
             "string",
             "null"
           ]
         },
         "build": {
-          "description": "Build commands executed during `dora build`. Each line runs separately.\n\nThe `build` key specifies the command that should be invoked for building the node.\nThe key expects a single- or multi-line string.\n\nEach line is run as a separate command.\nSpaces are used to separate arguments.\n\nNote that all the environment variables specified in the [`env`](Self::env) field are also\napplied to the build commands.\n\n## Special treatment of `pip`\n\nBuild lines that start with `pip` or `pip3` are treated in a special way:\nIf the `--uv` argument is passed to the `dora build` command, all `pip`/`pip3` commands are\nrun through the [`uv` package manager](https://docs.astral.sh/uv/).\n\n## Example\n\n```yaml\nnodes:\n- id: build-example\n  build: cargo build -p receive_data --release\n  path: target/release/receive_data\n- id: multi-line-example\n  build: |\n      pip install requirements.txt\n      pip install -e some/local/package\n  path: package\n```\n\nIn the above example, the `pip` commands will be replaced by `uv pip` when run through\n`dora build --uv`.",
+          "description": "Build commands executed during `adora build`. Each line runs separately.\n\nThe `build` key specifies the command that should be invoked for building the node.\nThe key expects a single- or multi-line string.\n\nEach line is run as a separate command.\nSpaces are used to separate arguments.\n\nNote that all the environment variables specified in the [`env`](Self::env) field are also\napplied to the build commands.\n\n## Special treatment of `pip`\n\nBuild lines that start with `pip` or `pip3` are treated in a special way:\nIf the `--uv` argument is passed to the `adora build` command, all `pip`/`pip3` commands are\nrun through the [`uv` package manager](https://docs.astral.sh/uv/).\n\n## Example\n\n```yaml\nnodes:\n- id: build-example\n  build: cargo build -p receive_data --release\n  path: target/release/receive_data\n- id: multi-line-example\n  build: |\n      pip install requirements.txt\n      pip install -e some/local/package\n  path: package\n```\n\nIn the above example, the `pip` commands will be replaced by `uv pip` when run through\n`adora build --uv`.",
           "type": [
             "string",
             "null"
@@ -282,15 +381,30 @@
           }
         },
         "git": {
-          "description": "Git repository URL for downloading nodes.\n\nThe `git` key allows downloading nodes (i.e. their source code) from git repositories.\nThis can be especially useful for distributed dataflows.\n\nWhen a `git` key is specified, `dora build` automatically clones the specified repository\n(or reuse an existing clone).\nThen it checks out the specified [`branch`](Self::branch), [`tag`](Self::tag), or\n[`rev`](Self::rev), or the default branch if none of them are specified.\nAfterwards it runs the [`build`](Self::build) command if specified.\n\nNote that the git clone directory is set as working directory for both the\n[`build`](Self::build) command and the specified [`path`](Self::path).\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/dora.git\n    build: cargo build -p rust-dataflow-example-node\n    path: target/debug/rust-dataflow-example-node\n```\n\nIn the above example, `dora build` will first clone the specified `git` repository and then\nrun the specified `build` inside the local clone directory.\nWhen `dora run` or `dora start` is invoked, the working directory will be the git clone\ndirectory too. So a relative `path` will start from the clone directory.",
+          "description": "Git repository URL for downloading nodes.\n\nThe `git` key allows downloading nodes (i.e. their source code) from git repositories.\nThis can be especially useful for distributed dataflows.\n\nWhen a `git` key is specified, `adora build` automatically clones the specified repository\n(or reuse an existing clone).\nThen it checks out the specified [`branch`](Self::branch), [`tag`](Self::tag), or\n[`rev`](Self::rev), or the default branch if none of them are specified.\nAfterwards it runs the [`build`](Self::build) command if specified.\n\nNote that the git clone directory is set as working directory for both the\n[`build`](Self::build) command and the specified [`path`](Self::path).\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/adora.git\n    build: cargo build -p rust-dataflow-example-node\n    path: target/debug/rust-dataflow-example-node\n```\n\nIn the above example, `adora build` will first clone the specified `git` repository and then\nrun the specified `build` inside the local clone directory.\nWhen `adora run` or `adora start` is invoked, the working directory will be the git clone\ndirectory too. So a relative `path` will start from the clone directory.",
           "type": [
             "string",
             "null"
           ]
         },
+        "health_check_timeout": {
+          "description": "Health check timeout in seconds.\n\nWhen set, the daemon monitors this node for activity. If the node does not\ncommunicate with the daemon within this timeout, it is killed and the restart\npolicy is evaluated.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "id": {
           "description": "Unique node identifier. Must not contain `/` characters.\n\nNode IDs can be arbitrary strings with the following limitations:\n\n- They must not contain any `/` characters (slashes).\n- We do not recommend using whitespace characters (e.g. spaces) in IDs\n\nEach node must have an ID field.\n\n## Example\n\n```yaml\nnodes:\n  - id: camera_node\n  - id: some_other_node\n```",
           "$ref": "#/$defs/NodeId"
+        },
+        "input_types": {
+          "description": "Optional type annotations for inputs.\n\nMaps input identifiers to expected type URNs. Used by `adora validate`\nto check that upstream output types match expectations.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "inputs": {
           "description": "Input data connections from other nodes.\n\nDefines the inputs that this node is subscribing to.\n\nThe `inputs` field should be a key-value map of the following format:\n\n`input_id: source_node_id/source_node_output_id`\n\nThe components are defined as follows:\n\n  - `input_id` is the local identifier that should be used for this input.\n\n    This will map to the `id` field of\n    [`Event::Input`](https://docs.rs/adora-node-api/latest/adora_node_api/enum.Event.html#variant.Input)\n    events sent to the node event loop.\n  - `source_node_id` should be the `id` field of the node that sends the output that we want\n    to subscribe to\n  - `source_node_output_id` should be the identifier of the output that that we want\n    to subscribe to\n\n## Example\n\n```yaml\nnodes:\n  - id: example-node\n    outputs:\n      - one\n      - two\n  - id: receiver\n    inputs:\n        my_input: example-node/two\n```",
@@ -299,6 +413,51 @@
             "$ref": "#/$defs/Input"
           },
           "default": {}
+        },
+        "max_log_size": {
+          "description": "Maximum log file size before rotation (e.g. \"50MB\", \"1GB\").\n\nWhen the JSONL log file exceeds this size, it is rotated. Old files\nare renamed with numeric suffixes (`.1.jsonl`, `.2.jsonl`, etc.) and\nthe oldest are deleted once 5 rotated files exist.\n\n## Example\n\n```yaml\nnodes:\n  - id: sensor\n    path: ./sensor\n    max_log_size: \"100MB\"\n```",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "max_restart_delay": {
+          "description": "Maximum delay in seconds for exponential backoff.\n\nCaps the exponentially growing `restart_delay`. For example, with\n`restart_delay: 1.0` and `max_restart_delay: 30.0`, delays grow as\n1s, 2s, 4s, 8s, 16s, 30s, 30s, ...",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "max_restarts": {
+          "description": "Maximum number of restart attempts. 0 means unlimited.\n\nWhen combined with `restart_window`, this limits restarts within the window period.\nFor example, `max_restarts: 5` with `restart_window: 300` means \"5 restarts per 5 minutes\".",
+          "type": "integer",
+          "format": "uint32",
+          "default": 0,
+          "minimum": 0
+        },
+        "max_rotated_files": {
+          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "min_log_level": {
+          "description": "Minimum log level for this node (error, warn, info, debug, trace, stdout).\n\nLogs below this level are suppressed from file output, coordinator\nforwarding, and `send_logs_as` routing.\n\n## Example\n\n```yaml\nnodes:\n  - id: noisy_sensor\n    path: ./sensor\n    min_log_level: info\n```",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "module": {
+          "description": "Path to a module definition file (e.g. `nav_module.yml`).\n\nA module is a reusable sub-dataflow: a group of nodes with declared\ninputs and outputs. At build time the module is expanded inline —\ninternal node IDs are prefixed with `{module_id}.` and all wiring is\nrewritten so the runtime sees only flat nodes.\n\nMutually exclusive with `path`, `operators`, `operator`, `custom`,\nand `ros2`.\n\n## Example\n\n```yaml\nnodes:\n  - id: nav_stack\n    module: modules/navigation_module.yml\n    inputs:\n      goal_pose: localization/goal\n```",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "description": "Human-readable node name for documentation.\n\nThis optional field can be used to define a more descriptive name in addition to a short\n[`id`](Self::id).\n\n## Example\n\n```yaml\nnodes:\n  - id: camera_node\n    name: \"Camera Input Handler\"",
@@ -329,6 +488,13 @@
             }
           ]
         },
+        "output_types": {
+          "description": "Optional type annotations for outputs.\n\nMaps output identifiers to type URNs (e.g. `std/media/v1/Image`).\nOnly annotated outputs are type-checked; unannotated outputs remain dynamic.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "outputs": {
           "description": "Output data identifiers produced by this node.\n\nList of output identifiers that the node sends.\nMust contain all `output_id` values that the node uses when sending output, e.g. through the\n[`send_output`](https://docs.rs/adora-node-api/latest/adora_node_api/struct.AdoraNode.html#method.send_output)\nfunction.\n\n## Example\n\n```yaml\nnodes:\n  - id: example-node\n    outputs:\n      - processed_image\n      - metadata\n```",
           "type": "array",
@@ -338,6 +504,13 @@
           },
           "uniqueItems": true
         },
+        "params": {
+          "description": "Parameters passed to a module for compile-time substitution.\n\nOnly meaningful when `module` is set. Values are substituted into\ninner node `args` fields (using `${_param.name}` syntax) and can be\ninjected into inner node `env` maps.\n\n## Example\n\n```yaml\nnodes:\n  - id: nav_stack\n    module: modules/navigation_module.yml\n    params:\n      speed: \"2.0\"\n      mode: turbo\n```",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "path": {
           "description": "Path to executable or script that should be run.\n\nSpecifies the path of the executable or script that Adora should run when starting the\ndataflow.\nThis can point to a normal executable (e.g. when using a compiled language such as Rust) or\na Python script.\n\nAdora will automatically append a `.exe` extension on Windows systems when the specified\nfile name has no extension.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-example\n    path: target/release/rust-node\n  - id: python-example\n    path: ./receive_data.py\n```\n\n## URL as Path\n\nThe `path` field can also point to a URL instead of a local path.\nIn this case, Adora will download the given file when starting the dataflow.\n\nNote that this is quite an old feature and using this functionality is **not recommended**\nanymore. Instead, we recommend using a [`git`][Self::git] and/or [`build`](Self::build)\nkey.",
           "type": [
@@ -345,13 +518,47 @@
             "null"
           ]
         },
+        "restart_delay": {
+          "description": "Initial delay in seconds before restarting. Doubles each attempt (exponential backoff).\n\nFor example, with `restart_delay: 1.0`, delays will be 1s, 2s, 4s, 8s, ...\nUse `max_restart_delay` to cap the backoff.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "restart_policy": {
           "description": "Whether this node should be restarted on exit or error.\n\nDefaults to `RestartPolicy::Never`.",
           "$ref": "#/$defs/RestartPolicy",
           "default": "never"
         },
+        "restart_window": {
+          "description": "Time window in seconds for counting restarts.\n\nWhen set, the restart counter resets after this period of time elapses since the\nfirst restart in the current window. This enables \"N restarts within M seconds\" semantics.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
         "rev": {
-          "description": "Git revision (e.g. commit hash) to checkout after cloning.\n\nThe `rev` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the git revision (e.g. a commit hash) that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/dora.git\n    rev: 64ab0d7c\n```",
+          "description": "Git revision (e.g. commit hash) to checkout after cloning.\n\nThe `rev` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the git revision (e.g. a commit hash) that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/adora.git\n    rev: 64ab0d7c\n```",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ros2": {
+          "description": "ROS2 bridge configuration (unstable).\n\nDeclares this node as a ROS2 bridge that automatically subscribes to or\npublishes on ROS2 topics. No custom code is needed -- the framework spawns\na bridge binary that converts between ROS2 DDS messages and Adora's Arrow\nformat.\n\n## Example\n\n```yaml\nnodes:\n  - id: camera_bridge\n    ros2:\n      topic: /camera/image_raw\n      message_type: sensor_msgs/Image\n      direction: subscribe\n    outputs:\n      - image\n```",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ros2BridgeConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "send_logs_as": {
+          "description": "Redirect structured log entries to a data output as JSON strings.\n\nUnlike `send_stdout_as` which sends raw stdout lines, this sends only\nparsed structured log entries (with level, timestamp, message, fields).\n\n## Example\n\n```yaml\nnodes:\n  - id: sensor\n    path: ./sensor\n    send_logs_as: logs\n    outputs:\n      - data\n      - logs\n```",
           "type": [
             "string",
             "null"
@@ -365,7 +572,7 @@
           ]
         },
         "tag": {
-          "description": "Git tag to checkout after cloning.\n\nThe `tag` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the git tag that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/dora.git\n    tag: v0.3.0\n```",
+          "description": "Git tag to checkout after cloning.\n\nThe `tag` field is only allowed in combination with the [`git`](#git) field.\nIt specifies the git tag that should be checked out after cloning.\nOnly one of `branch`, `tag`, or `rev` can be specified.\n\n## Example\n\n```yaml\nnodes:\n  - id: rust-node\n    git: https://github.com/adora-rs/adora.git\n    tag: v0.3.0\n```",
           "type": [
             "string",
             "null"
@@ -441,6 +648,13 @@
           "description": "Unique operator identifier within the runtime",
           "$ref": "#/$defs/OperatorId"
         },
+        "input_types": {
+          "description": "Optional type annotations for inputs",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "inputs": {
           "description": "Input data connections",
           "type": "object",
@@ -449,12 +663,42 @@
           },
           "default": {}
         },
+        "max_log_size": {
+          "description": "Maximum log file size before rotation (e.g. \"50MB\", \"1GB\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "max_rotated_files": {
+          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "min_log_level": {
+          "description": "Minimum log level for this operator",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "description": "Human-readable operator name",
           "type": [
             "string",
             "null"
           ]
+        },
+        "output_types": {
+          "description": "Optional type annotations for outputs",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "outputs": {
           "description": "Output data identifiers",
@@ -464,6 +708,13 @@
             "$ref": "#/$defs/DataId"
           },
           "uniqueItems": true
+        },
+        "send_logs_as": {
+          "description": "Redirect structured log entries to a data output as JSON strings",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "send_stdout_as": {
           "description": "Redirect stdout to data output",
@@ -542,10 +793,239 @@
           "const": "on-failure"
         },
         {
-          "description": "Always restart the node when it exits, regardless of exit code.\n\nThe node will not be restarted on the following conditions:\n\n- The node was stopped by the user (e.g., via `dora stop`).\n- All inputs to the node have been closed and the node finished with a non-zero exit code.",
+          "description": "Always restart the node when it exits, regardless of exit code.\n\nThe node will not be restarted on the following conditions:\n\n- The node was stopped by the user (e.g., via `adora stop`).\n- All inputs to the node have been closed and the node finished with a non-zero exit code.",
           "type": "string",
           "const": "always"
         }
+      ]
+    },
+    "Ros2BridgeConfig": {
+      "description": "ROS2 bridge configuration for declarative ROS2 bridging.\n\nThis allows nodes to interact with ROS2 topics, services, and actions\nwithout writing any custom code. The framework spawns a bridge binary that\nhandles the ROS2 DDS communication and Arrow data conversion.\n\nExactly one of `topic`, `topics`, `service`, or `action` must be set.",
+      "type": "object",
+      "properties": {
+        "action": {
+          "description": "ROS2 action name (e.g. \"/navigate\").\nMutually exclusive with `topic`, `topics`, `service`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "action_type": {
+          "description": "ROS2 action type (e.g. \"nav2_msgs/NavigateToPose\").\nRequired when `action` is set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "direction": {
+          "description": "Direction: subscribe (ROS2 -> Adora) or publish (Adora -> ROS2).\nDefaults to subscribe. Only used with `topic`/`topics`.",
+          "$ref": "#/$defs/Ros2Direction",
+          "default": "subscribe"
+        },
+        "message_type": {
+          "description": "ROS2 message type (e.g. \"sensor_msgs/Image\").\nRequired when `topic` is set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "namespace": {
+          "description": "ROS2 namespace (default: \"/\").",
+          "type": "string",
+          "default": "/"
+        },
+        "node_name": {
+          "description": "ROS2 node name. Defaults to the adora node id.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "qos": {
+          "description": "QoS policies applied to all topics (can be overridden per-topic).",
+          "$ref": "#/$defs/Ros2QosConfig",
+          "default": {
+            "keep_all": false,
+            "reliable": false
+          }
+        },
+        "role": {
+          "description": "Role: client or server. Required for `service` and `action`.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ros2Role"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "service": {
+          "description": "ROS2 service name (e.g. \"/add_two_ints\").\nMutually exclusive with `topic`, `topics`, `action`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "service_type": {
+          "description": "ROS2 service type (e.g. \"example_interfaces/AddTwoInts\").\nRequired when `service` is set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "topic": {
+          "description": "ROS2 topic name (e.g. \"/camera/image_raw\").\nMutually exclusive with `topics`, `service`, `action`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "topics": {
+          "description": "Multiple topics on a single ROS2 node context.\nMutually exclusive with `topic`, `service`, `action`.",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/Ros2TopicConfig"
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "Ros2Direction": {
+      "description": "Direction of ROS2 bridge communication.",
+      "oneOf": [
+        {
+          "description": "Subscribe: receive from ROS2, forward to adora outputs.",
+          "type": "string",
+          "const": "subscribe"
+        },
+        {
+          "description": "Publish: receive from adora inputs, publish to ROS2.",
+          "type": "string",
+          "const": "publish"
+        }
+      ]
+    },
+    "Ros2QosConfig": {
+      "description": "ROS2 Quality of Service configuration.",
+      "type": "object",
+      "properties": {
+        "durability": {
+          "description": "Durability: \"volatile\" (default), \"transient_local\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "keep_all": {
+          "description": "Use KeepAll history policy instead of KeepLast.",
+          "type": "boolean",
+          "default": false
+        },
+        "keep_last": {
+          "description": "History depth for KeepLast policy (default: 1).",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int32"
+        },
+        "lease_duration": {
+          "description": "Lease duration in seconds (default: infinity).",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "liveliness": {
+          "description": "Liveliness: \"automatic\" (default), \"manual_by_participant\", \"manual_by_topic\".",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "max_blocking_time": {
+          "description": "Max blocking time in seconds for reliable transport.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "format": "double"
+        },
+        "reliable": {
+          "description": "Use reliable transport (default: false = best effort).",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": true
+    },
+    "Ros2Role": {
+      "description": "Role of a ROS2 service or action bridge node.",
+      "oneOf": [
+        {
+          "description": "Client: sends requests/goals, receives responses/results.",
+          "type": "string",
+          "const": "client"
+        },
+        {
+          "description": "Server: receives requests, sends responses.",
+          "type": "string",
+          "const": "server"
+        }
+      ]
+    },
+    "Ros2TopicConfig": {
+      "description": "Configuration for a single ROS2 topic in multi-topic mode.",
+      "type": "object",
+      "properties": {
+        "direction": {
+          "description": "Direction: subscribe or publish.",
+          "$ref": "#/$defs/Ros2Direction",
+          "default": "subscribe"
+        },
+        "input": {
+          "description": "Maps to an adora input id (for publish direction).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message_type": {
+          "description": "ROS2 message type (e.g. \"geometry_msgs/Twist\").",
+          "type": "string"
+        },
+        "output": {
+          "description": "Maps to an adora output id (for subscribe direction).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "qos": {
+          "description": "Per-topic QoS override.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Ros2QosConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "topic": {
+          "description": "ROS2 topic name.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "required": [
+        "topic",
+        "message_type"
       ]
     },
     "RuntimeNode": {
@@ -583,6 +1063,13 @@
             }
           ]
         },
+        "input_types": {
+          "description": "Optional type annotations for inputs",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "inputs": {
           "description": "Input data connections",
           "type": "object",
@@ -591,12 +1078,42 @@
           },
           "default": {}
         },
+        "max_log_size": {
+          "description": "Maximum log file size before rotation (e.g. \"50MB\", \"1GB\")",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "max_rotated_files": {
+          "description": "Maximum number of rotated log files to keep (default: 5)",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0
+        },
+        "min_log_level": {
+          "description": "Minimum log level for this operator",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "name": {
           "description": "Human-readable operator name",
           "type": [
             "string",
             "null"
           ]
+        },
+        "output_types": {
+          "description": "Optional type annotations for outputs",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "outputs": {
           "description": "Output data identifiers",
@@ -606,6 +1123,13 @@
             "$ref": "#/$defs/DataId"
           },
           "uniqueItems": true
+        },
+        "send_logs_as": {
+          "description": "Redirect structured log entries to a data output as JSON strings",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "send_stdout_as": {
           "description": "Redirect stdout to data output",

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -22,7 +22,7 @@ pub use validate::ResolvedNodeExt;
 pub use visualize::collect_adora_timers;
 
 mod expand;
-mod validate;
+pub mod validate;
 mod visualize;
 
 pub use expand::{
@@ -128,6 +128,8 @@ impl DescriptorExt for Descriptor {
                     run_config: NodeRunConfig {
                         inputs: node.inputs,
                         outputs: node.outputs,
+                        output_types: node.output_types,
+                        input_types: node.input_types,
                     },
                     envs: None,
                     restart_policy: node.restart_policy,
@@ -168,6 +170,8 @@ impl DescriptorExt for Descriptor {
                         run_config: NodeRunConfig {
                             inputs: node.inputs,
                             outputs: node.outputs,
+                            output_types: node.output_types,
+                            input_types: node.input_types,
                         },
                         envs: Some(envs),
                         restart_policy: node.restart_policy,

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -653,6 +653,226 @@ fn validate_ros2_name(node_id: &NodeId, field: &str, name: &str) -> eyre::Result
     Ok(())
 }
 
+/// A non-fatal warning about type annotations in the dataflow.
+#[derive(Debug)]
+pub struct TypeWarning {
+    /// Node that produced the warning.
+    pub node_id: String,
+    /// Human-readable warning message.
+    pub message: String,
+}
+
+impl std::fmt::Display for TypeWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "node \"{}\": {}", self.node_id, self.message)
+    }
+}
+
+/// Check type annotations in a dataflow. Returns warnings (never errors).
+///
+/// Checks:
+/// 1. `output_types` keys exist in `outputs`
+/// 2. `input_types` keys exist in `inputs`
+/// 3. All type URNs resolve in the registry
+/// 4. Connected edges have matching types (when both sides are annotated)
+pub fn check_type_annotations(
+    dataflow: &super::Descriptor,
+    registry: &crate::types::TypeRegistry,
+) -> Vec<TypeWarning> {
+    let mut warnings = Vec::new();
+
+    // Map of (source_node_id, output_ref) -> type_urn for cross-edge checking.
+    // For custom nodes: ("node_id", "output_id")
+    // For operators: ("node_id", "op_id/output_id") — matches InputMapping::User format
+    let mut output_type_map: BTreeMap<(String, String), String> = BTreeMap::new();
+
+    for node in &dataflow.nodes {
+        let nid = node.id.to_string();
+
+        // Check node-level output_types
+        check_port_types(
+            &nid,
+            &node.output_types,
+            |id| node.outputs.contains(id),
+            "output",
+            registry,
+            &mut warnings,
+        );
+        // Register node outputs for cross-edge checking (only known URNs)
+        for (output_id, urn) in &node.output_types {
+            if registry.resolve(urn).is_some() {
+                output_type_map.insert((nid.clone(), output_id.to_string()), urn.clone());
+            }
+        }
+
+        // Check node-level input_types
+        check_port_types(
+            &nid,
+            &node.input_types,
+            |id| node.inputs.contains_key(id),
+            "input",
+            registry,
+            &mut warnings,
+        );
+
+        // Check operator output/input types
+        if let Some(op) = &node.operator {
+            let op_id = op
+                .id
+                .as_ref()
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| super::SINGLE_OPERATOR_DEFAULT_ID.to_string());
+            check_port_types(
+                &nid,
+                &op.config.output_types,
+                |id| op.config.outputs.contains(id),
+                "output",
+                registry,
+                &mut warnings,
+            );
+            // Operator outputs are referenced as "op_id/output_id" from the node
+            for (output_id, urn) in &op.config.output_types {
+                if registry.resolve(urn).is_some() {
+                    output_type_map
+                        .insert((nid.clone(), format!("{op_id}/{output_id}")), urn.clone());
+                }
+            }
+            check_port_types(
+                &nid,
+                &op.config.input_types,
+                |id| op.config.inputs.contains_key(id),
+                "input",
+                registry,
+                &mut warnings,
+            );
+        }
+        if let Some(runtime) = &node.operators {
+            for op in &runtime.operators {
+                let label = format!("{nid}/{}", op.id);
+                check_port_types(
+                    &label,
+                    &op.config.output_types,
+                    |id| op.config.outputs.contains(id),
+                    "output",
+                    registry,
+                    &mut warnings,
+                );
+                for (output_id, urn) in &op.config.output_types {
+                    if registry.resolve(urn).is_some() {
+                        output_type_map
+                            .insert((nid.clone(), format!("{}/{output_id}", op.id)), urn.clone());
+                    }
+                }
+                check_port_types(
+                    &label,
+                    &op.config.input_types,
+                    |id| op.config.inputs.contains_key(id),
+                    "input",
+                    registry,
+                    &mut warnings,
+                );
+            }
+        }
+    }
+
+    // Cross-edge type mismatch check (nodes + operators)
+    for node in &dataflow.nodes {
+        let nid = node.id.to_string();
+        check_edge_mismatches(
+            &nid,
+            &node.input_types,
+            &node.inputs,
+            &output_type_map,
+            &mut warnings,
+        );
+
+        if let Some(op) = &node.operator {
+            check_edge_mismatches(
+                &nid,
+                &op.config.input_types,
+                &op.config.inputs,
+                &output_type_map,
+                &mut warnings,
+            );
+        }
+        if let Some(runtime) = &node.operators {
+            for op in &runtime.operators {
+                let label = format!("{nid}/{}", op.id);
+                check_edge_mismatches(
+                    &label,
+                    &op.config.input_types,
+                    &op.config.inputs,
+                    &output_type_map,
+                    &mut warnings,
+                );
+            }
+        }
+    }
+
+    warnings
+}
+
+/// Validate that port type keys exist in the port list and URNs resolve.
+fn check_port_types(
+    node_id: &str,
+    type_map: &BTreeMap<DataId, String>,
+    contains: impl Fn(&DataId) -> bool,
+    port_kind: &str,
+    registry: &crate::types::TypeRegistry,
+    warnings: &mut Vec<TypeWarning>,
+) {
+    for (port_id, urn) in type_map {
+        if !contains(port_id) {
+            warnings.push(TypeWarning {
+                node_id: node_id.to_string(),
+                message: format!(
+                    "{port_kind}_types key \"{port_id}\" not found in {port_kind}s list"
+                ),
+            });
+        }
+        if registry.resolve(urn).is_none() {
+            let hint = registry
+                .suggest(urn)
+                .map(|s| format!(" (did you mean \"{s}\"?)"))
+                .unwrap_or_default();
+            warnings.push(TypeWarning {
+                node_id: node_id.to_string(),
+                message: format!("unknown type \"{urn}\" on {port_kind} \"{port_id}\"{hint}"),
+            });
+        }
+    }
+}
+
+/// Check cross-edge type mismatches for a set of inputs.
+fn check_edge_mismatches(
+    node_id: &str,
+    input_types: &BTreeMap<DataId, String>,
+    inputs: &BTreeMap<DataId, Input>,
+    output_type_map: &BTreeMap<(String, String), String>,
+    warnings: &mut Vec<TypeWarning>,
+) {
+    for (input_id, input_urn) in input_types {
+        if let Some(input) = inputs.get(input_id) {
+            if let InputMapping::User(ref mapping) = input.mapping {
+                let key = (mapping.source.to_string(), mapping.output.to_string());
+                if let Some(output_urn) = output_type_map.get(&key) {
+                    if output_urn != input_urn {
+                        warnings.push(TypeWarning {
+                            node_id: node_id.to_string(),
+                            message: format!(
+                                "type mismatch on input \"{input_id}\": \
+                                 upstream {}/{} declares \"{output_urn}\", \
+                                 but expected \"{input_urn}\"",
+                                mapping.source, mapping.output,
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn validate_ros2_type_format(node_id: &NodeId, name: &str, type_str: &str) -> eyre::Result<()> {
     // type must be "package/TypeName" format with alphanumeric+underscore parts
     let parts: Vec<&str> = type_str.split('/').collect();
@@ -676,8 +896,9 @@ fn validate_ros2_type_format(node_id: &NodeId, name: &str, type_str: &str) -> ey
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::TypeRegistry;
     use adora_message::config::{Input, InputMapping};
-    use adora_message::descriptor::{Ros2BridgeConfig, Ros2Role};
+    use adora_message::descriptor::{Descriptor, Ros2BridgeConfig, Ros2Role};
     use std::time::Duration;
 
     fn dummy_input() -> Input {
@@ -1024,6 +1245,100 @@ mod tests {
         let err = validate_ros2_config(&NodeId::from("n".to_owned()), &config, &inputs, &outputs)
             .unwrap_err();
         assert!(err.to_string().contains("keep_last"));
+    }
+
+    // --- Type annotation tests ---
+
+    fn parse_dataflow(yaml: &str) -> Descriptor {
+        serde_yaml::from_str(yaml).expect("test YAML should parse")
+    }
+
+    #[test]
+    fn type_check_no_annotations_no_warnings() {
+        let dataflow = parse_dataflow("nodes:\n  - id: a\n");
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn type_check_valid_output_type() {
+        let dataflow = parse_dataflow(
+            "nodes:\n  - id: camera\n    outputs:\n      - image\n    output_types:\n      image: std/media/v1/Image\n",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn type_check_output_types_key_not_in_outputs() {
+        let dataflow = parse_dataflow(
+            "nodes:\n  - id: camera\n    output_types:\n      image: std/media/v1/Image\n",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("not found in outputs"));
+    }
+
+    #[test]
+    fn type_check_unknown_urn_with_suggestion() {
+        let dataflow = parse_dataflow(
+            "nodes:\n  - id: camera\n    outputs:\n      - image\n    output_types:\n      image: std/media/v1/Imag\n",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("unknown type"));
+        assert!(warnings[0].message.contains("did you mean"));
+    }
+
+    #[test]
+    fn type_check_matching_edge_types() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+    output_types:
+      data: std/core/v1/Float32
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/Float32
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn type_check_mismatched_edge_types() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+    output_types:
+      data: std/core/v1/Bytes
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/media/v1/Image
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("type mismatch"));
+        assert!(warnings[0].message.contains("Bytes"));
+        assert!(warnings[0].message.contains("Image"));
     }
 
     #[test]

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -230,10 +230,16 @@ fn visualize_user_mapping(
         match &source_node.kind {
             CoreNodeKind::Custom(custom_node) => {
                 if custom_node.run_config.outputs.contains(output) {
+                    let type_label = custom_node
+                        .run_config
+                        .output_types
+                        .get(output)
+                        .map(|t| format_type_label(t))
+                        .unwrap_or_default();
                     let data = if output == input_id {
-                        format!("{output}")
+                        format!("{output}{type_label}")
                     } else {
-                        format!("{output} as {input_id}")
+                        format!("{output} as {input_id}{type_label}")
                     };
                     writeln!(flowchart, "  {source} -- {data} --> {target}").unwrap();
                     source_found = true;
@@ -243,10 +249,16 @@ fn visualize_user_mapping(
                 let (operator_id, output) = output.split_once('/').unwrap_or(("", output));
                 if let Some(operator) = operators.iter().find(|o| o.id.as_ref() == operator_id) {
                     if operator.config.outputs.contains(output) {
+                        let type_label = operator
+                            .config
+                            .output_types
+                            .get(&DataId::from(output.to_owned()))
+                            .map(|t| format_type_label(t))
+                            .unwrap_or_default();
                         let data = if output == input_id.as_str() {
-                            output.to_string()
+                            format!("{output}{type_label}")
                         } else {
-                            format!("{output} as {input_id}")
+                            format!("{output} as {input_id}{type_label}")
                         };
                         writeln!(flowchart, "  {source}/{operator_id} -- {data} --> {target}")
                             .unwrap();
@@ -259,4 +271,11 @@ fn visualize_user_mapping(
     if !source_found {
         writeln!(flowchart, "  missing>missing] -- {input_id} --> {target}").unwrap();
     }
+}
+
+/// Format a type URN as a short label for graph edges.
+/// Extracts the type name from the URN (e.g. `std/media/v1/Image` -> ` [Image]`).
+fn format_type_label(urn: &str) -> String {
+    let short = crate::types::urn_short_name(urn);
+    format!(" [{short}]")
 }

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod build;
 pub mod descriptor;
 pub mod metadata;
 pub mod topics;
+pub mod types;
 
 pub fn adjust_shared_library_path(path: &Path) -> Result<std::path::PathBuf, eyre::ErrReport> {
     let file_name = path

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -1,0 +1,245 @@
+use arrow_schema::DataType;
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+/// A single type definition from the standard type library.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TypeDef {
+    /// Arrow data type name (e.g. "Float32", "Struct", "LargeBinary")
+    pub arrow: String,
+    /// Human-readable description
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl TypeDef {
+    /// Convert the arrow type name to an `arrow_schema::DataType`.
+    ///
+    /// Returns `None` for complex types (Struct, etc.) that cannot be validated
+    /// from the type name alone.
+    pub fn arrow_data_type(&self) -> Option<DataType> {
+        match self.arrow.as_str() {
+            "Float32" => Some(DataType::Float32),
+            "Float64" => Some(DataType::Float64),
+            "Int32" => Some(DataType::Int32),
+            "Int64" => Some(DataType::Int64),
+            "UInt8" => Some(DataType::UInt8),
+            "UInt32" => Some(DataType::UInt32),
+            "UInt64" => Some(DataType::UInt64),
+            "Utf8" => Some(DataType::Utf8),
+            "LargeBinary" => Some(DataType::LargeBinary),
+            "Boolean" => Some(DataType::Boolean),
+            _ => None, // Struct, FixedSizeBinary, etc. — skip runtime validation
+        }
+    }
+}
+
+/// YAML file format for a type package.
+#[derive(Debug, Deserialize)]
+struct TypePackage {
+    types: BTreeMap<String, TypeDef>,
+}
+
+/// Extract the short type name from a URN (e.g. `std/media/v1/Image` -> `Image`).
+pub fn urn_short_name(urn: &str) -> &str {
+    urn.rsplit('/').next().unwrap_or(urn)
+}
+
+/// Registry of known type URNs, loaded from embedded YAML files.
+///
+/// URN format: `std/<category>/v<version>/<TypeName>`
+pub struct TypeRegistry {
+    types: BTreeMap<String, TypeDef>,
+}
+
+const PACKAGES: &[(&str, &str)] = &[
+    (
+        "std/core/v1",
+        include_str!("../../../types/std/core/v1.yml"),
+    ),
+    (
+        "std/math/v1",
+        include_str!("../../../types/std/math/v1.yml"),
+    ),
+    (
+        "std/control/v1",
+        include_str!("../../../types/std/control/v1.yml"),
+    ),
+    (
+        "std/media/v1",
+        include_str!("../../../types/std/media/v1.yml"),
+    ),
+    (
+        "std/vision/v1",
+        include_str!("../../../types/std/vision/v1.yml"),
+    ),
+];
+
+impl TypeRegistry {
+    /// Create a new registry with all built-in standard types loaded.
+    pub fn new() -> Self {
+        let mut types = BTreeMap::new();
+        for (prefix, yaml) in PACKAGES {
+            let pkg: TypePackage =
+                serde_yaml::from_str(yaml).expect("built-in type YAML should be valid");
+            for (name, def) in pkg.types {
+                let urn = format!("{prefix}/{name}");
+                types.insert(urn, def);
+            }
+        }
+        Self { types }
+    }
+
+    /// Resolve a type URN to its definition. Returns `None` if unknown.
+    pub fn resolve(&self, urn: &str) -> Option<&TypeDef> {
+        self.types.get(urn)
+    }
+
+    /// Resolve a type URN to its Arrow DataType. Returns `None` if unknown or complex.
+    pub fn resolve_arrow_type(&self, urn: &str) -> Option<DataType> {
+        self.resolve(urn).and_then(|def| def.arrow_data_type())
+    }
+
+    /// Return all known URNs (sorted).
+    pub fn all_urns(&self) -> impl Iterator<Item = &str> {
+        self.types.keys().map(String::as_str)
+    }
+
+    /// Suggest the closest URN for a typo. Returns `None` if no close match.
+    /// Prefers matches in the same package prefix (e.g. `std/media/v1`).
+    pub fn suggest(&self, urn: &str) -> Option<&str> {
+        let target_name = urn_short_name(urn).to_lowercase();
+        let target_prefix = urn.rsplit_once('/').map(|(p, _)| p);
+        self.types
+            .keys()
+            .filter_map(|k| {
+                let name = urn_short_name(k).to_lowercase();
+                let dist = edit_distance(&target_name, &name);
+                (dist <= 2).then(|| {
+                    // Penalize cross-package matches so same-package wins on ties
+                    let prefix_penalty = if target_prefix == k.rsplit_once('/').map(|(p, _)| p) {
+                        0
+                    } else {
+                        100
+                    };
+                    (k.as_str(), dist + prefix_penalty)
+                })
+            })
+            .min_by_key(|&(_, score)| score)
+            .map(|(k, _)| k)
+    }
+}
+
+impl Default for TypeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Simple edit distance (Levenshtein) for typo suggestions.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut dp = vec![vec![0usize; b.len() + 1]; a.len() + 1];
+    for (i, row) in dp.iter_mut().enumerate() {
+        row[0] = i;
+    }
+    for (j, val) in dp[0].iter_mut().enumerate() {
+        *val = j;
+    }
+    for i in 1..=a.len() {
+        for j in 1..=b.len() {
+            let cost = if a[i - 1] == b[j - 1] { 0 } else { 1 };
+            dp[i][j] = (dp[i - 1][j] + 1)
+                .min(dp[i][j - 1] + 1)
+                .min(dp[i - 1][j - 1] + cost);
+        }
+    }
+    dp[a.len()][b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_resolves_known_urns() {
+        let reg = TypeRegistry::new();
+        assert!(reg.resolve("std/core/v1/Float32").is_some());
+        assert!(reg.resolve("std/media/v1/Image").is_some());
+        assert!(reg.resolve("std/vision/v1/BoundingBox").is_some());
+    }
+
+    #[test]
+    fn registry_returns_none_for_unknown() {
+        let reg = TypeRegistry::new();
+        assert!(reg.resolve("std/core/v1/NonExistent").is_none());
+        assert!(reg.resolve("custom/MyType").is_none());
+    }
+
+    #[test]
+    fn all_embedded_yaml_loads() {
+        // TypeRegistry::new() panics if any YAML is invalid
+        let reg = TypeRegistry::new();
+        assert!(reg.types.len() > 10);
+    }
+
+    #[test]
+    fn suggest_finds_typo() {
+        let reg = TypeRegistry::new();
+        let suggestion = reg.suggest("std/media/v1/Imag");
+        assert_eq!(suggestion, Some("std/media/v1/Image"));
+    }
+
+    #[test]
+    fn suggest_returns_none_for_unrelated() {
+        let reg = TypeRegistry::new();
+        assert!(reg.suggest("std/core/v1/Xyzzy").is_none());
+    }
+
+    #[test]
+    fn type_def_has_arrow_field() {
+        let reg = TypeRegistry::new();
+        let def = reg.resolve("std/core/v1/Float32").unwrap();
+        assert_eq!(def.arrow, "Float32");
+    }
+
+    #[test]
+    fn arrow_data_type_primitives() {
+        let reg = TypeRegistry::new();
+        assert_eq!(
+            reg.resolve_arrow_type("std/core/v1/Float32"),
+            Some(DataType::Float32)
+        );
+        assert_eq!(
+            reg.resolve_arrow_type("std/core/v1/UInt64"),
+            Some(DataType::UInt64)
+        );
+        assert_eq!(
+            reg.resolve_arrow_type("std/core/v1/String"),
+            Some(DataType::Utf8)
+        );
+        assert_eq!(
+            reg.resolve_arrow_type("std/core/v1/Bool"),
+            Some(DataType::Boolean)
+        );
+        assert_eq!(
+            reg.resolve_arrow_type("std/core/v1/Bytes"),
+            Some(DataType::LargeBinary)
+        );
+    }
+
+    #[test]
+    fn arrow_data_type_complex_returns_none() {
+        let reg = TypeRegistry::new();
+        // Struct types cannot be validated from name alone
+        assert_eq!(reg.resolve_arrow_type("std/media/v1/Image"), None);
+        assert_eq!(reg.resolve_arrow_type("std/math/v1/Vector3"), None);
+    }
+
+    #[test]
+    fn arrow_data_type_unknown_urn_returns_none() {
+        let reg = TypeRegistry::new();
+        assert_eq!(reg.resolve_arrow_type("std/core/v1/NonExistent"), None);
+    }
+}

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -35,6 +35,12 @@ pub struct NodeRunConfig {
     ///  - output_2
     #[serde(default)]
     pub outputs: BTreeSet<DataId>,
+    /// Optional type annotations for outputs
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub output_types: BTreeMap<DataId, String>,
+    /// Optional type annotations for inputs
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub input_types: BTreeMap<DataId, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -360,6 +360,13 @@ pub struct Node {
     #[serde(default)]
     pub outputs: BTreeSet<DataId>,
 
+    /// Optional type annotations for outputs.
+    ///
+    /// Maps output identifiers to type URNs (e.g. `std/media/v1/Image`).
+    /// Only annotated outputs are type-checked; unannotated outputs remain dynamic.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub output_types: BTreeMap<DataId, String>,
+
     /// Input data connections from other nodes.
     ///
     /// Defines the inputs that this node is subscribing to.
@@ -394,6 +401,13 @@ pub struct Node {
     /// ```
     #[serde(default)]
     pub inputs: BTreeMap<DataId, Input>,
+
+    /// Optional type annotations for inputs.
+    ///
+    /// Maps input identifiers to expected type URNs. Used by `adora validate`
+    /// to check that upstream output types match expectations.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub input_types: BTreeMap<DataId, String>,
 
     /// Redirect stdout/stderr to a data output.
     ///
@@ -763,6 +777,13 @@ pub struct OperatorConfig {
     /// Output data identifiers
     #[serde(default)]
     pub outputs: BTreeSet<DataId>,
+    /// Optional type annotations for outputs
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub output_types: BTreeMap<DataId, String>,
+
+    /// Optional type annotations for inputs
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub input_types: BTreeMap<DataId, String>,
 
     /// Operator source configuration (Python, shared library, etc.)
     #[serde(flatten)]

--- a/types/std/control/v1.yml
+++ b/types/std/control/v1.yml
@@ -1,0 +1,10 @@
+types:
+  Twist:
+    arrow: Struct
+    description: "Linear and angular velocity (2x Vector3)"
+  JointState:
+    arrow: Struct
+    description: "Joint positions, velocities, efforts as Float64 lists"
+  Odometry:
+    arrow: Struct
+    description: "Pose + Twist in a reference frame"

--- a/types/std/core/v1.yml
+++ b/types/std/core/v1.yml
@@ -1,0 +1,21 @@
+types:
+  Float32:
+    arrow: Float32
+  Float64:
+    arrow: Float64
+  Int32:
+    arrow: Int32
+  Int64:
+    arrow: Int64
+  UInt8:
+    arrow: UInt8
+  UInt32:
+    arrow: UInt32
+  UInt64:
+    arrow: UInt64
+  String:
+    arrow: Utf8
+  Bytes:
+    arrow: LargeBinary
+  Bool:
+    arrow: Boolean

--- a/types/std/math/v1.yml
+++ b/types/std/math/v1.yml
@@ -1,0 +1,13 @@
+types:
+  Vector3:
+    arrow: Struct
+    description: "3D vector with x, y, z Float64 fields"
+  Quaternion:
+    arrow: Struct
+    description: "Quaternion with x, y, z, w Float64 fields"
+  Pose:
+    arrow: Struct
+    description: "6-DOF pose (position Vector3 + orientation Quaternion)"
+  Transform:
+    arrow: Struct
+    description: "Coordinate transform (translation Vector3 + rotation Quaternion)"

--- a/types/std/media/v1.yml
+++ b/types/std/media/v1.yml
@@ -1,0 +1,13 @@
+types:
+  Image:
+    arrow: Struct
+    description: "Raw image with width, height, encoding, data fields"
+  CompressedImage:
+    arrow: LargeBinary
+    description: "JPEG/PNG compressed image bytes"
+  PointCloud:
+    arrow: Struct
+    description: "3D point cloud with XYZ coordinates and optional fields"
+  AudioFrame:
+    arrow: Struct
+    description: "Audio samples with sample_rate, channels, data fields"

--- a/types/std/vision/v1.yml
+++ b/types/std/vision/v1.yml
@@ -1,0 +1,10 @@
+types:
+  BoundingBox:
+    arrow: Struct
+    description: "2D bounding box with x, y, width, height, confidence, label"
+  Detection:
+    arrow: Struct
+    description: "Object detection result (list of BoundingBox)"
+  Segmentation:
+    arrow: Struct
+    description: "Pixel-level segmentation mask with class labels"


### PR DESCRIPTION
## Summary

- Add `output_types` / `input_types` optional BTreeMap fields to Node, OperatorConfig, and NodeRunConfig for type annotations using URNs (e.g. `std/core/v1/Float32`)
- **Static validation** via `adora validate` command: key existence checks, URN resolution, cross-edge mismatch detection, typo suggestions with `--strict` flag for CI
- **Runtime validation** via `ADORA_RUNTIME_TYPE_CHECK` env var: `warn` (log and continue) or `error` (fail on mismatch), zero overhead when disabled
- Standard type library with 5 packages (core, math, control, media, vision) embedded via `include_str!()`
- Type labels on `adora graph` edges (e.g. `reading [Float64]`)
- New `examples/typed-dataflow/` Python example and type annotations on existing `examples/rust-dataflow/`
- Documentation: `docs/types.md`, updates to `docs/cli.md`, `docs/yaml-spec.md`, `README.md`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all` passes (excluding Python packages)
- [x] All 228 tests pass across adora-core, adora-cli, adora-node-api, adora-message, adora-daemon
- [x] `adora validate examples/typed-dataflow/dataflow.yml` returns "All type annotations OK"
- [x] `adora validate --strict examples/rust-dataflow/dataflow.yml` returns "All type annotations OK"
- [x] `adora graph examples/typed-dataflow/dataflow.yml --mermaid` shows type labels on edges
- [ ] Smoke test: `ADORA_RUNTIME_TYPE_CHECK=warn adora run examples/typed-dataflow/dataflow.yml --uv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)