### PR TITLE
fix(coordinator): use unique temp dir per ArtifactStore to prevent test races

### DIFF
--- a/binaries/coordinator/src/artifacts.rs
+++ b/binaries/coordinator/src/artifacts.rs
@@ -10,9 +10,9 @@ pub(crate) struct ArtifactStore {
 }
 
 impl ArtifactStore {
-    /// Create a new artifact store in a temp directory.
+    /// Create a new artifact store in a unique temp directory.
     pub fn new() -> eyre::Result<Self> {
-        let base_dir = std::env::temp_dir().join("adora-artifacts");
+        let base_dir = std::env::temp_dir().join(format!("adora-artifacts-{}", Uuid::new_v4()));
         std::fs::create_dir_all(&base_dir)
             .with_context(|| format!("failed to create artifact dir {}", base_dir.display()))?;
         Ok(Self { base_dir })


### PR DESCRIPTION
## Summary

- Each `ArtifactStore` now gets a UUID-suffixed temp directory instead of the shared `adora-artifacts` path
- Prevents parallel test coordinators from racing on directory create/cleanup
- Fixes flaky `param_set_list_delete` failure on macOS CI (same root cause as #11 on Windows)

## Test plan

- [x] `cargo test -p adora-coordinator` -- all 18 tests pass
- [x] `cargo clippy -p adora-coordinator` -- clean
- [x] `cargo fmt --all -- --check` -- clean

Generated with [Claude Code](https://claude.com/claude-code)
