### PR TITLE
fix(daemon): correct node restart count tracking

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1317,7 +1317,8 @@ impl Daemon {
                                 .map(|(_, data_id)| data_id.to_string())
                                 .collect();
 
-                            let restart_count = running_node.node_config.restart_count;
+                            let restart_count =
+                                running_node.restart_count.load(atomic::Ordering::Acquire);
 
                             // Derive status from current state
                             let status = if !broken_inputs.is_empty() {
@@ -1357,7 +1358,7 @@ impl Daemon {
             // Second pass: report nodes without a running process
             for (node_id, running_node) in &dataflow.running_nodes {
                 if !metrics.contains_key(node_id) {
-                    let restart_count = running_node.node_config.restart_count;
+                    let restart_count = running_node.restart_count.load(atomic::Ordering::Acquire);
                     let status = if running_node.restarts_disabled() {
                         adora_message::daemon_to_coordinator::NodeStatus::Failed
                     } else if restart_count > 0 {
@@ -3450,6 +3451,8 @@ fn runtime_node_outputs(n: &RuntimeNode) -> BTreeSet<DataId> {
 #[cfg(test)]
 mod fault_tolerance_tests {
     use super::*;
+    use std::sync::atomic::AtomicU32;
+
     use adora_message::{
         config::CommunicationConfig,
         daemon_to_node::NodeEvent,
@@ -3487,6 +3490,7 @@ mod fault_tolerance_tests {
                 restart_count: 0,
             },
             pid: None,
+            restart_count: Arc::new(AtomicU32::new(0)),
             restart_policy: RestartPolicy::Never,
             disable_restart: Arc::new(AtomicBool::new(false)),
             last_activity: Arc::new(AtomicU64::new(0)),

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -54,6 +54,7 @@ pub struct RunningNode {
     pub(crate) process: Option<ProcessHandle>,
     pub(crate) node_config: NodeConfig,
     pub(crate) pid: Option<Arc<AtomicU32>>,
+    pub(crate) restart_count: Arc<AtomicU32>,
     pub(crate) restart_policy: RestartPolicy,
     pub(crate) disable_restart: Arc<AtomicBool>,
     pub(crate) last_activity: Arc<AtomicU64>,

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -92,6 +92,7 @@ impl PreparedNode {
 
         let disable_restart = Arc::new(AtomicBool::new(false));
         let pid = Arc::new(AtomicU32::new(0));
+        let restart_count = Arc::new(AtomicU32::new(0));
         let running_node = RunningNode {
             process: match &kind {
                 NodeKind::Dynamic => None,
@@ -100,6 +101,7 @@ impl PreparedNode {
             node_config: self.node_config.clone(),
             restart_policy: self.restart_policy(),
             disable_restart: disable_restart.clone(),
+            restart_count: restart_count.clone(),
             pid: match kind {
                 NodeKind::Dynamic => None,
                 NodeKind::Spawned { pid: new_pid } => {
@@ -111,7 +113,7 @@ impl PreparedNode {
             health_check_timeout: self.health_check_timeout(),
         };
 
-        tokio::spawn(self.restart_loop(logger, finished_rx, disable_restart, pid));
+        tokio::spawn(self.restart_loop(logger, finished_rx, disable_restart, pid, restart_count));
 
         Ok(running_node)
     }
@@ -150,6 +152,7 @@ impl PreparedNode {
         mut finished_rx: oneshot::Receiver<NodeProcessFinished>,
         disable_restart: Arc<AtomicBool>,
         pid: Arc<AtomicU32>,
+        shared_restart_count: Arc<AtomicU32>,
     ) {
         let config = self.restart_config();
         let mut restart_count: u32 = 0;
@@ -276,6 +279,7 @@ impl PreparedNode {
 
                 restart_count += 1;
                 self.node_config.restart_count = restart_count;
+                shared_restart_count.store(restart_count, atomic::Ordering::Release);
                 self.ft_stats
                     .restarts
                     .fetch_add(1, atomic::Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- `RunningNode` received a **cloned** `NodeConfig` at spawn time, so its `restart_count` field was frozen at 0
- The restart loop in `PreparedNode` incremented its own separate copy, which metrics never read
- Added a shared `Arc<AtomicU32>` for `restart_count` between `RunningNode` and the restart loop

## Root cause
At `prepared.rs:100`, `RunningNode` gets `node_config: self.node_config.clone()`. Then `self` (PreparedNode) moves into the restart loop. When the loop increments `self.node_config.restart_count`, it updates PreparedNode's copy — but metrics reads from RunningNode's copy, which is never updated.

## Files changed
- `binaries/daemon/src/running_dataflow.rs` — added `restart_count: Arc<AtomicU32>` field to `RunningNode`
- `binaries/daemon/src/spawn/prepared.rs` — create shared atomic, pass to restart loop, update it on restart
- `binaries/daemon/src/lib.rs` — read restart count from shared atomic in metrics collection

## Test plan
- [x] `cargo test -p adora-daemon` — 18/18 pass
- [x] `cargo clippy -p adora-daemon -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: restart a node via `adora node restart`, verify count increments in `adora node list`

Ref #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)