### PR TITLE
fix(cli): fall back to cargo install for record/replay node binaries

### DIFF
--- a/binaries/cli/src/command/node_binary.rs
+++ b/binaries/cli/src/command/node_binary.rs
@@ -3,28 +3,47 @@ use std::path::PathBuf;
 use eyre::bail;
 
 /// Search for a node binary by name, auto-building from the given crate if not found.
+///
+/// Tries `cargo build -p` first (works in the workspace during development),
+/// then falls back to `cargo install` (works for standalone installations).
 pub fn find(binary_name: &str, crate_name: &str) -> eyre::Result<PathBuf> {
     if let Some(path) = search(binary_name) {
         return Ok(path);
     }
 
     eprintln!("{binary_name} not found, building...");
-    let status = std::process::Command::new("cargo")
+
+    // Try workspace build first (fast, works during development)
+    let build_ok = std::process::Command::new("cargo")
         .args(["build", "-p", crate_name])
+        .status()
+        .is_ok_and(|s| s.success());
+
+    if build_ok {
+        if let Some(path) = search(binary_name) {
+            return Ok(path);
+        }
+    }
+
+    // Fall back to cargo install (works for standalone installations)
+    eprintln!("{binary_name} not found in workspace, installing via cargo install...");
+    let version = env!("CARGO_PKG_VERSION");
+    let status = std::process::Command::new("cargo")
+        .args(["install", crate_name, "--version", version])
         .status();
     match status {
         Ok(s) if s.success() => {}
-        Ok(s) => bail!("failed to build {crate_name} (exit code: {s})"),
+        Ok(s) => bail!("failed to install {crate_name} (exit code: {s})"),
         Err(e) => bail!(
-            "could not find `{binary_name}` binary and `cargo build` failed: {e}\n\
-             Build it manually with: cargo build -p {crate_name}"
+            "could not find `{binary_name}` and installation failed: {e}\n\
+             Install it manually with: cargo install {crate_name}"
         ),
     }
 
     search(binary_name).ok_or_else(|| {
         eyre::eyre!(
-            "built {crate_name} but could not find the binary.\n\
-             Try: cargo build -p {crate_name}"
+            "installed {crate_name} but could not find the binary.\n\
+             Try: cargo install {crate_name}"
         )
     })
 }


### PR DESCRIPTION
## Summary
- When `adora record` or `adora replay` can't find the node binary, it tries `cargo build -p` (workspace build) first
- If that fails (e.g., running outside the workspace after standalone install), falls back to `cargo install` with version pinned to match the CLI
- Fixes the `package ID specification did not match any packages` error on fresh installations

## Root cause
`cargo build -p adora-record-node` only works inside the adora workspace. When `adora-cli` is installed standalone (via `cargo install` or release binary) and run from a user's project directory, the package isn't found.

## Changes
- `binaries/cli/src/command/node_binary.rs` — try workspace build first, fall back to `cargo install --version <cli_version>`
- Version pinned via `env!("CARGO_PKG_VERSION")` to ensure compatible versions

## Test plan
- [x] `cargo clippy -p adora-cli -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: install `adora-cli` standalone, run `adora record` from outside workspace, verify it installs the record node

Ref #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)