### PR TITLE
fix(cli): prevent double tracing subscriber in record/replay

### DIFF
--- a/binaries/cli/src/command/record.rs
+++ b/binaries/cli/src/command/record.rs
@@ -58,10 +58,13 @@ pub struct Record {
 
 impl Executable for Record {
     fn execute(self) -> eyre::Result<()> {
-        default_tracing()?;
         if self.proxy {
+            // Proxy mode handles recording directly without delegating to Run,
+            // so it needs its own tracing subscriber.
+            default_tracing()?;
             run_record_proxy(self)
         } else {
+            // Run::execute() sets up its own tracing subscriber.
             run_record(self)
         }
     }

--- a/binaries/cli/src/command/replay.rs
+++ b/binaries/cli/src/command/replay.rs
@@ -9,7 +9,7 @@ use adora_recording::RecordingReader;
 use clap::Args;
 use eyre::{Context, bail};
 
-use crate::command::{Executable, Run, default_tracing};
+use crate::command::{Executable, Run};
 
 /// Replay a recorded dataflow from an `.adorec` file.
 ///
@@ -59,7 +59,7 @@ pub struct Replay {
 
 impl Executable for Replay {
     fn execute(self) -> eyre::Result<()> {
-        default_tracing()?;
+        // Run::execute() sets up its own tracing subscriber.
         run_replay(self)
     }
 }


### PR DESCRIPTION
## Summary
- `adora record` and `adora replay` called `default_tracing()` then delegated to `Run::execute()`, which sets up its own tracing subscriber
- The second `set_global_default` call failed: "a global default trace dispatcher has already been set"
- Now only the proxy code path (which doesn't delegate to `Run`) initializes tracing

## Files changed
- `binaries/cli/src/command/record.rs` — move `default_tracing()` into proxy-only branch
- `binaries/cli/src/command/replay.rs` — remove `default_tracing()` call (always delegates to `Run`)

## Test plan
- [x] `cargo clippy -p adora-cli -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: run `adora record dataflow.yml`, verify no tracing error

Ref #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)