### PR TITLE
fix(cli): fix topic hz panic and improve topic error reporting

### DIFF
--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -174,11 +174,11 @@ fn run_hz(
     outputs: BTreeSet<TopicIdentifier>,
     data_rx: std::sync::mpsc::Receiver<eyre::Result<Vec<u8>>>,
 ) -> eyre::Result<()> {
-    // Add a synthetic aggregate entry ("<ALL>") that merges all outputs
+    // Add a synthetic aggregate entry ("_ALL_") that merges all outputs
     let mut topics_with_all = Vec::with_capacity(outputs.len() + 1);
     topics_with_all.push(TopicIdentifier {
-        node_id: "<ALL>".to_string().into(),
-        data_id: "*".to_string().into(),
+        node_id: "_ALL_".to_string().into(),
+        data_id: "_".to_string().into(),
     });
     topics_with_all.extend(outputs);
 

--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -163,7 +163,10 @@ fn info(
                 Ok(Ok(payload)) => {
                     let event = match Timestamped::deserialize_inter_daemon_event(&payload) {
                         Ok(e) => e,
-                        Err(_) => continue,
+                        Err(e) => {
+                            eprintln!("warning: failed to deserialize event: {e}");
+                            continue;
+                        }
                     };
                     match event.inner {
                         InterDaemonEvent::Output { metadata, data, .. } => {


### PR DESCRIPTION
## Summary
- **topic hz panic**: `NodeId::from("<ALL>")` panics because `<` and `>` are invalid characters in NodeId validation. Replaced with valid identifier `_ALL_`
- **topic info silent failures**: Deserialization errors were silently swallowed (`Err(_) => continue`), making it impossible to diagnose why zero messages were reported. Now logs warnings

## Note on echo/info "no messages" issue
The `topic echo` freeze and `topic info` showing 0 messages may be related to zenoh session discovery timing or the user's dataflow not having `publish_all_messages_to_zenoh: true` enabled. The code path for subscription and message forwarding looks correct. The improved error logging in `topic info` should help diagnose this in the field.

## Test plan
- [x] `cargo clippy -p adora-cli -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manual: run `adora topic hz` and verify no panic

Ref #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)