### PR TITLE
feat(cli): add structured JSON output to status command

### DIFF
--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -316,6 +316,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_status_json() {
+        parse_ok(&["adora", "status", "--format", "json"]);
+    }
+
+    #[test]
+    fn parse_status_json_short() {
+        parse_ok(&["adora", "status", "-f", "json"]);
+    }
+
+    #[test]
     fn parse_inspect_top() {
         parse_ok(&["adora", "inspect", "top"]);
     }

--- a/binaries/cli/src/command/system/status.rs
+++ b/binaries/cli/src/command/system/status.rs
@@ -1,6 +1,7 @@
 use crate::command::{Executable, default_tracing};
 use crate::common::CoordinatorOptions;
 use crate::common::connect_to_coordinator;
+use crate::formatting::OutputFormat;
 use crate::ws_client::WsSession;
 use adora_core::descriptor::Descriptor;
 use adora_core::descriptor::DescriptorExt;
@@ -9,6 +10,7 @@ use adora_message::{
     coordinator_to_cli::{ControlRequestReply, DataflowStatus},
 };
 use eyre::{Context, bail};
+use serde::Serialize;
 use std::path::PathBuf;
 use std::{
     io::{IsTerminal, Write},
@@ -16,9 +18,83 @@ use std::{
 };
 use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
-pub fn check_environment(coordinator_addr: SocketAddr) -> eyre::Result<()> {
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusOutput {
+    pub coordinator: ComponentStatus,
+    pub daemon: ComponentStatus,
+    pub active_dataflows: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ComponentStatus {
+    pub status: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
+}
+
+fn collect_status(coordinator_addr: SocketAddr) -> (StatusOutput, bool) {
     let mut error_occurred = false;
 
+    let (coordinator, session) = match connect_to_coordinator(coordinator_addr) {
+        Ok(session) => (
+            ComponentStatus {
+                status: "running",
+                address: Some(coordinator_addr.to_string()),
+            },
+            Some(session),
+        ),
+        Err(_) => {
+            error_occurred = true;
+            (
+                ComponentStatus {
+                    status: "not running",
+                    address: None,
+                },
+                None,
+            )
+        }
+    };
+
+    let daemon_running = session
+        .as_ref()
+        .map(daemon_running)
+        .transpose()
+        .ok()
+        .flatten();
+
+    let daemon = if daemon_running == Some(true) {
+        ComponentStatus {
+            status: "running",
+            address: None,
+        }
+    } else if session.is_some() {
+        error_occurred = true;
+        ComponentStatus {
+            status: "not running",
+            address: None,
+        }
+    } else {
+        error_occurred = true;
+        ComponentStatus {
+            status: "unknown",
+            address: None,
+        }
+    };
+
+    let active_dataflows = session
+        .as_ref()
+        .and_then(|s| query_running_dataflow_count(s).ok());
+
+    let output = StatusOutput {
+        coordinator,
+        daemon,
+        active_dataflows,
+    };
+
+    (output, error_occurred)
+}
+
+fn print_status_table(output: &StatusOutput) -> eyre::Result<()> {
     let color_choice = if std::io::stdout().is_terminal() {
         ColorChoice::Auto
     } else {
@@ -26,57 +102,59 @@ pub fn check_environment(coordinator_addr: SocketAddr) -> eyre::Result<()> {
     };
     let mut stdout = termcolor::StandardStream::stdout(color_choice);
 
-    // Coordinator status
-    let session = match connect_to_coordinator(coordinator_addr) {
-        Ok(session) => {
-            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
-            write!(stdout, "✓ ")?;
-            let _ = stdout.reset();
-            writeln!(stdout, "Coordinator: Running")?;
-            writeln!(
-                stdout,
-                "  Address: {}:{}",
-                coordinator_addr.ip(),
-                coordinator_addr.port()
-            )?;
-            Some(session)
-        }
-        Err(_) => {
-            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
-            write!(stdout, "✗ ")?;
-            let _ = stdout.reset();
-            writeln!(stdout, "Coordinator: Not running")?;
-            error_occurred = true;
-            None
-        }
-    };
-
-    // Daemon status
-    let daemon_running = session.as_ref().map(daemon_running).transpose()?;
-
-    if daemon_running == Some(true) {
+    // Coordinator
+    if output.coordinator.status == "running" {
         let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
         write!(stdout, "✓ ")?;
         let _ = stdout.reset();
-        writeln!(stdout, "Daemon: Running")?;
-    } else if session.is_some() {
-        let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
-        write!(stdout, "✗ ")?;
-        let _ = stdout.reset();
-        writeln!(stdout, "Daemon: Not running")?;
-        error_occurred = true;
+        writeln!(stdout, "Coordinator: Running")?;
+        if let Some(addr) = &output.coordinator.address {
+            writeln!(stdout, "  Address: {addr}")?;
+        }
     } else {
         let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
         write!(stdout, "✗ ")?;
         let _ = stdout.reset();
-        writeln!(stdout, "Daemon: Unknown (coordinator not available)")?;
-        error_occurred = true;
+        writeln!(stdout, "Coordinator: Not running")?;
+    }
+
+    // Daemon
+    match output.daemon.status {
+        "running" => {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)));
+            write!(stdout, "✓ ")?;
+            let _ = stdout.reset();
+            writeln!(stdout, "Daemon: Running")?;
+        }
+        "not running" => {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
+            write!(stdout, "✗ ")?;
+            let _ = stdout.reset();
+            writeln!(stdout, "Daemon: Not running")?;
+        }
+        _ => {
+            let _ = stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
+            write!(stdout, "✗ ")?;
+            let _ = stdout.reset();
+            writeln!(stdout, "Daemon: Unknown (coordinator not available)")?;
+        }
     }
 
     // Dataflow count
-    if let Some(ref sess) = session {
-        if let Ok(count) = query_running_dataflow_count(sess) {
-            writeln!(stdout, "Active dataflows: {}", count)?;
+    if let Some(count) = output.active_dataflows {
+        writeln!(stdout, "Active dataflows: {count}")?;
+    }
+
+    Ok(())
+}
+
+pub fn check_environment(coordinator_addr: SocketAddr, format: OutputFormat) -> eyre::Result<()> {
+    let (output, error_occurred) = collect_status(coordinator_addr);
+
+    match format {
+        OutputFormat::Table => print_status_table(&output)?,
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(&output)?);
         }
     }
 
@@ -125,6 +203,9 @@ pub struct Status {
     /// Path to the dataflow descriptor file (enables additional checks)
     #[clap(long, value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
     dataflow: Option<PathBuf>,
+    /// Output format (table or json)
+    #[clap(long, short = 'f', value_name = "FORMAT", default_value_t = OutputFormat::Table)]
+    format: OutputFormat,
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
 }
@@ -134,20 +215,16 @@ impl Executable for Status {
         default_tracing()?;
 
         let addr = self.coordinator.socket_addr();
-        match self.dataflow {
-            Some(dataflow) => {
-                let working_dir = dataflow
-                    .canonicalize()
-                    .context("failed to canonicalize dataflow path")?
-                    .parent()
-                    .ok_or_else(|| eyre::eyre!("dataflow path has no parent dir"))?
-                    .to_owned();
-                Descriptor::blocking_read(&dataflow)?.check(&working_dir)?;
-                check_environment(addr)?
-            }
-            None => check_environment(addr)?,
+        if let Some(dataflow) = self.dataflow {
+            let working_dir = dataflow
+                .canonicalize()
+                .context("failed to canonicalize dataflow path")?
+                .parent()
+                .ok_or_else(|| eyre::eyre!("dataflow path has no parent dir"))?
+                .to_owned();
+            Descriptor::blocking_read(&dataflow)?.check(&working_dir)?;
         }
 
-        Ok(())
+        check_environment(addr, self.format)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `--format json` / `-f json` flag to `adora status` for script/dashboard integration
- Refactors status collection into a `StatusOutput` struct (with `Serialize`) so both table and JSON share the same data path
- Default remains `table` (colored terminal output), fully backward compatible

## Example output
```json
{
  "coordinator": {
    "status": "running",
    "address": "127.0.0.1:6012"
  },
  "daemon": {
    "status": "running"
  },
  "active_dataflows": 2
}
```

## Test plan
- [x] `cargo clippy -p adora-cli` — clean
- [x] `cargo test -p adora-cli` — 123 tests pass (2 new parse tests)
- [x] `cargo fmt --all` — clean
- [x] Manual: `adora status --format json` outputs valid JSON

Ref #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)