### PR TITLE
docs: clarify that PyPI package is `adora-rs`, not `adora`

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ cargo install adora-cli --features redb-backend
 
 ### 1. Run a Python dataflow
 
+> **Important:** The PyPI package is **`adora-rs`**, not `adora`. The import name
+> is `adora` (`from adora import Node`), but `pip install adora` installs an
+> unrelated package.
+
 ```bash
 pip install adora-rs-cli adora-rs
 git clone https://github.com/adora-rs/adora.git && cd adora

--- a/examples/python-dataflow/README.md
+++ b/examples/python-dataflow/README.md
@@ -32,10 +32,28 @@ The receiver has two inputs: raw `message` from sender and `transformed` from tr
 | `dataflow.yml` | Standard sender/transformer/receiver pipeline |
 | `dataflow_dynamic.yml` | Separate example: camera + opencv-plot vision pipeline with dynamic node loading |
 
+## Prerequisites
+
+Install the Python node API (the PyPI package is `adora-rs`, **not** `adora`):
+
+```bash
+pip install adora-rs
+```
+
+> **Note:** The Python import name is `adora` (`from adora import Node`), but the
+> PyPI package name is **`adora-rs`**. Running `pip install adora` installs an
+> unrelated package and will cause `ImportError: cannot import name 'Node'`.
+
 ## Run
 
 ```bash
 adora run dataflow.yml
+```
+
+Or use `uv` to manage the Python environment automatically:
+
+```bash
+adora run dataflow.yml --uv
 ```
 
 Expected output (receiver logs):


### PR DESCRIPTION
## Summary
- Added prominent note in main README quick-start that the PyPI package is **`adora-rs`**, not `adora` (which is an unrelated package)
- Added Prerequisites section to python-dataflow example README with correct install command and explanation
- Mentioned `--uv` flag as an alternative for automatic Python env management

The root cause of the ImportError is users running `pip install adora` instead of `pip install adora-rs`. The import name (`from adora import Node`) matches the module name, not the PyPI package name, which is confusing.

Ref #29

## Test plan
- [x] Documentation-only change, no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)