### PR TITLE
fix(coordinator): propagate spawn errors instead of generic "request failed"

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -291,7 +291,10 @@ impl Executable for Run {
                 serde_json::from_slice(&reply_raw).context("failed to parse reply")?;
             match result {
                 ControlRequestReply::DataflowSpawned { uuid: _ } => {}
-                ControlRequestReply::Error(err) => bail!("{err}"),
+                ControlRequestReply::Error(err) => bail!(
+                    "dataflow failed to start: {err}\n\n  \
+                     hint: if nodes require building, run `adora build <dataflow.yml>` first"
+                ),
                 other => bail!("unexpected WaitForSpawn reply: {other:?}"),
             }
         }

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -212,7 +212,10 @@ fn wait_until_dataflow_started(
         ControlRequestReply::DataflowSpawned { uuid } => {
             println!("dataflow started: {uuid}");
         }
-        ControlRequestReply::Error(err) => bail!("{err}"),
+        ControlRequestReply::Error(err) => bail!(
+            "dataflow failed to start: {err}\n\n  \
+             hint: if nodes require building, run `adora build <dataflow.yml>` first"
+        ),
         other => bail!("unexpected start dataflow reply: {other:?}"),
     }
     Ok(())

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -510,11 +510,31 @@ async fn start_inner(
                                 for sender in finished_dataflow.stop_reply_senders {
                                     let _ = sender.send(Ok(reply.clone()));
                                 }
+                                // If WaitForSpawn waiters are still pending, notify them
+                                // that the dataflow finished before spawn completed (e.g.,
+                                // a node crashed at startup or the build failed).
                                 if !matches!(
                                     finished_dataflow.spawn_result,
                                     CachedResult::Cached { .. }
                                 ) {
-                                    tracing::error!("pending spawn result on dataflow finish");
+                                    let node_errors: Vec<String> = dataflow_results
+                                        .get(&uuid)
+                                        .into_iter()
+                                        .flat_map(|r| r.values())
+                                        .flat_map(|dr| dr.node_results.iter())
+                                        .filter_map(|(node_id, r)| {
+                                            r.as_ref().err().map(|e| format!("{node_id}: {e}"))
+                                        })
+                                        .collect();
+                                    let msg = if node_errors.is_empty() {
+                                        "dataflow exited before spawn completed".to_string()
+                                    } else {
+                                        format!(
+                                            "dataflow failed to start:\n  {}",
+                                            node_errors.join("\n  ")
+                                        )
+                                    };
+                                    finished_dataflow.spawn_result.set_result(Err(eyre!(msg)));
                                 }
                             }
                         }

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -375,7 +375,11 @@ pub(crate) async fn handle_control_ws(
                         let root = err.root_cause().to_string();
                         ControlRequestReply::Error(root)
                     }
-                    Err(_) => ControlRequestReply::Error("request failed".to_string()),
+                    Err(_) => ControlRequestReply::Error(
+                        "coordinator dropped the request without a reply \
+                         (it may have shut down or the dataflow exited unexpectedly)"
+                            .to_string(),
+                    ),
                 };
 
                 let stop = matches!(reply, ControlRequestReply::CoordinatorStopped);


### PR DESCRIPTION
## Summary
- **Root cause**: When a dataflow exited before `WaitForSpawn` completed (e.g., node binary not found, build failure), the coordinator dropped the pending reply senders without sending a response, causing the CLI to show the generic "request failed" error
- **Fix**: The coordinator now collects node errors from the finished dataflow and forwards them to pending `WaitForSpawn` waiters via `CachedResult::set_result(Err(...))`
- Improved the fallback message in `ws_control.rs` when a reply oneshot is dropped unexpectedly
- Added build hints to `adora run` and `adora start` error messages

Ref #30

## Test plan
- [x] `cargo test -p adora-cli --lib` — 123 tests pass
- [x] `cargo test -p adora-coordinator --lib` — 9 tests pass
- [x] `cargo clippy -p adora-cli -p adora-coordinator -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)