### PR TITLE
feat: add build-time type checking (8 phases)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "splitty",
+ "syn 2.0.114",
  "tempfile",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -323,7 +323,8 @@ nodes:
 
 ```bash
 adora validate dataflow.yml                        # static check (warnings)
-adora validate --strict dataflow.yml               # fail on warnings (CI)
+adora validate --strict-types dataflow.yml         # fail on warnings (CI)
+adora build dataflow.yml --strict-types            # type check during build
 ADORA_RUNTIME_TYPE_CHECK=warn adora run dataflow.yml  # runtime check
 ```
 

--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -36,6 +36,7 @@ pub fn build(
         coordinator_port,
         uv.unwrap_or_default(),
         force_local,
+        false,
     )
 }
 

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -50,6 +50,7 @@
 use adora_core::{
     descriptor::{CoreNodeKind, CustomNode, Descriptor, DescriptorExt},
     topics::{ADORA_COORDINATOR_PORT_WS_DEFAULT, LOCALHOST},
+    types::TypeRegistry,
 };
 use adora_message::{BuildId, descriptor::NodeSource};
 use eyre::Context;
@@ -88,6 +89,9 @@ pub struct Build {
     // Run build on local machine
     #[clap(long, action)]
     local: bool,
+    /// Treat type warnings as errors
+    #[clap(long, action)]
+    strict_types: bool,
 }
 
 impl Executable for Build {
@@ -99,6 +103,7 @@ impl Executable for Build {
             self.coordinator_port,
             self.uv,
             self.local,
+            self.strict_types,
         )
     }
 }
@@ -109,6 +114,7 @@ pub fn build(
     coordinator_port: Option<u16>,
     uv: bool,
     force_local: bool,
+    strict_types: bool,
 ) -> eyre::Result<()> {
     let dataflow_path = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
     let working_dir = dataflow_path
@@ -124,6 +130,45 @@ pub fn build(
         })?
         .expand(working_dir)
         .wrap_err("failed to expand modules in dataflow descriptor")?;
+
+    // --- Type checking (Phase 1) ---
+    let strict = strict_types || dataflow_descriptor.strict_types.unwrap_or(false);
+    let mut registry = TypeRegistry::new();
+    let types_dir = working_dir.join("types");
+    if types_dir.is_dir() {
+        match registry.load_from_dir(&types_dir) {
+            Ok(count) if count > 0 => {
+                log::info!("Loaded {count} user-defined type(s) from types/");
+            }
+            Err(e) => {
+                eyre::bail!("failed to load user types: {e}");
+            }
+            _ => {}
+        }
+    }
+    let type_result = adora_core::descriptor::validate::check_type_annotations_full(
+        &dataflow_descriptor,
+        &registry,
+        strict,
+    );
+    for inf in &type_result.inferences {
+        println!("  {inf}");
+    }
+    if !type_result.warnings.is_empty() {
+        for w in &type_result.warnings {
+            eprintln!("  warning: {w}");
+        }
+        let count = type_result.warnings.len();
+        if strict {
+            eyre::bail!("{count} type error(s) found (strict mode)");
+        } else {
+            eprintln!(
+                "{count} type warning(s) found.\n  \
+                 hint: use --strict-types to fail on type warnings"
+            );
+        }
+    }
+
     let mut dataflow_session =
         DataflowSession::read_session(&dataflow_path).context("failed to read DataflowSession")?;
 

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn parse_validate_strict() {
-        parse_ok(&["adora", "validate", "--strict", "dataflow.yml"]);
+        parse_ok(&["adora", "validate", "--strict-types", "dataflow.yml"]);
     }
 
     #[test]

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -1,6 +1,6 @@
 use super::Executable;
 use adora_core::{
-    descriptor::{Descriptor, DescriptorExt, validate::check_type_annotations},
+    descriptor::{Descriptor, DescriptorExt, validate::check_type_annotations_full},
     types::TypeRegistry,
 };
 use eyre::{Context, bail};
@@ -12,9 +12,9 @@ pub struct Validate {
     /// Path to the dataflow descriptor file
     #[clap(value_name = "PATH", value_hint = clap::ValueHint::FilePath)]
     dataflow: PathBuf,
-    /// Treat warnings as errors (non-zero exit code)
+    /// Treat type warnings as errors (non-zero exit code)
     #[clap(long, action)]
-    strict: bool,
+    strict_types: bool,
 }
 
 impl Executable for Validate {
@@ -38,20 +38,41 @@ impl Executable for Validate {
             .expand(working_dir)
             .context("failed to expand modules in dataflow descriptor")?;
 
-        // Run type annotation checks
-        let registry = TypeRegistry::new();
-        let warnings = check_type_annotations(&descriptor, &registry);
+        let strict = self.strict_types || descriptor.strict_types.unwrap_or(false);
 
-        if warnings.is_empty() {
+        // Load user types if a types/ directory exists
+        let mut registry = TypeRegistry::new();
+        let types_dir = working_dir.join("types");
+        if types_dir.is_dir() {
+            match registry.load_from_dir(&types_dir) {
+                Ok(count) if count > 0 => {
+                    println!("Loaded {count} user-defined type(s) from types/");
+                }
+                Err(e) => {
+                    bail!("failed to load user types: {e}");
+                }
+                _ => {}
+            }
+        }
+
+        // Run type annotation checks
+        let result = check_type_annotations_full(&descriptor, &registry, strict);
+
+        // Print inferences
+        for inf in &result.inferences {
+            println!("  {inf}");
+        }
+
+        if result.warnings.is_empty() {
             println!("All type annotations OK.");
         } else {
             println!("Type warnings:");
-            for w in &warnings {
+            for w in &result.warnings {
                 println!("  - {w}");
             }
-            let count = warnings.len();
+            let count = result.warnings.len();
             println!("{count} type warning(s) found.");
-            if self.strict {
+            if strict {
                 bail!("{count} type warning(s) found (--strict mode)");
             }
         }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -91,6 +91,8 @@ pub mod bench_support {
             deploy: None,
             debug: adora_message::descriptor::Debug::default(),
             health_check_interval: None,
+            strict_types: None,
+            type_rules: vec![],
         };
         let mut df = RunningDataflow::new(Uuid::nil(), DaemonId::new(None), descriptor);
 
@@ -3467,6 +3469,8 @@ mod fault_tolerance_tests {
             deploy: None,
             debug: DescriptorDebug::default(),
             health_check_interval: None,
+            strict_types: None,
+            type_rules: vec![],
         };
         RunningDataflow::new(Uuid::nil(), DaemonId::new(None), descriptor)
     }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -337,6 +337,9 @@ adora build <PATH> [OPTIONS]
 | `<PATH>` | required | Dataflow descriptor path |
 | `--uv` | false | Use `uv` for Python builds |
 | `--local` | false | Force local build (skip coordinator) |
+| `--strict-types` | false | Treat type warnings as errors (non-zero exit code) |
+
+**Type checking:** After expanding modules, `build` runs the same type checks as `validate`. Warnings are printed by default; use `--strict-types` (or set `strict_types: true` in the YAML) to fail the build on type mismatches. User-defined types in a `types/` directory next to the dataflow are loaded automatically.
 
 **Build strategy:** If nodes have `_unstable_deploy` sections and a coordinator is reachable, builds are distributed to target machines. Otherwise, builds run locally.
 
@@ -957,19 +960,26 @@ adora validate <PATH> [OPTIONS]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `<PATH>` | required | Dataflow descriptor path |
-| `--strict` | false | Treat warnings as errors (non-zero exit code for CI) |
+| `--strict-types` | false | Treat warnings as errors (non-zero exit code for CI) |
 
 Checks:
-1. `output_types`/`input_types` keys exist in the corresponding `outputs`/`inputs` lists
-2. All type URNs resolve in the standard type library
-3. Connected edges have matching types when both sides are annotated
+1. **Key existence**: `output_types`/`input_types` keys exist in the corresponding `outputs`/`inputs` lists
+2. **URN resolution**: All type URNs resolve in the standard or user-defined type library
+3. **Edge compatibility**: Connected edges have compatible types (exact match, widening, or user-defined rules)
+4. **Parameterized types**: Parameter mismatches (e.g. `AudioFrame[sample_type=f32]` vs `AudioFrame[sample_type=i16]`)
+5. **Timer auto-typing**: Timer inputs are automatically typed as `std/core/v1/UInt64`
+6. **Type inference**: When only upstream annotates a type, it is inferred on the downstream input
+7. **Metadata patterns**: `output_metadata` keys and `pattern` shorthands are validated
+8. **Schema compatibility**: Struct types are checked at the field level (missing/wrong fields)
+
+User-defined types in a `types/` directory next to the dataflow are loaded automatically.
 
 ```bash
 # Validate with warnings
 adora validate dataflow.yml
 
 # Strict mode for CI (exit 1 on warnings)
-adora validate --strict dataflow.yml
+adora validate --strict-types dataflow.yml
 ```
 
 See the [Type Annotations Guide](types.md) for the full type library and usage details.

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,6 +1,6 @@
 # Type Annotations
 
-Optional type annotations on dataflow inputs and outputs. Types are never required -- unannotated ports remain fully dynamic. Type checking is static only (no runtime overhead).
+Optional type annotations on dataflow inputs and outputs. Types are never required -- unannotated ports remain fully dynamic. Type checking runs at build time and validate time (no runtime overhead by default).
 
 ## Quick Start
 
@@ -31,7 +31,18 @@ Validate with:
 adora validate dataflow.yml
 
 # Fail with non-zero exit code on warnings (for CI)
-adora validate --strict dataflow.yml
+adora validate --strict-types dataflow.yml
+
+# Type checks also run during build
+adora build dataflow.yml --strict-types
+```
+
+You can also set `strict_types: true` at the top level of the YAML to enable strict mode without the CLI flag:
+
+```yaml
+strict_types: true
+nodes:
+  # ...
 ```
 
 ## Type URN Format
@@ -42,6 +53,34 @@ Type URNs follow the pattern `std/<category>/v<version>/<TypeName>`:
 std/core/v1/Float32
 std/media/v1/Image
 std/vision/v1/BoundingBox
+```
+
+### Parameterized Types
+
+Some struct types accept parameters to distinguish variants:
+
+```
+std/media/v1/AudioFrame[sample_type=f32]
+std/media/v1/AudioFrame[sample_type=f32,channels=2]
+```
+
+Matching rules:
+- Same base + same params -> compatible
+- Same base + one side unparameterized -> compatible (wildcard)
+- Same base + different param values -> **mismatch**
+
+```yaml
+# These are compatible (wildcard):
+output_types:
+  audio: std/media/v1/AudioFrame[sample_type=f32]
+input_types:
+  audio: std/media/v1/AudioFrame
+
+# These are a mismatch:
+output_types:
+  audio: std/media/v1/AudioFrame[sample_type=f32]
+input_types:
+  audio: std/media/v1/AudioFrame[sample_type=i16]
 ```
 
 ## Standard Type Library
@@ -58,17 +97,17 @@ std/vision/v1/BoundingBox
 | `UInt32` | UInt32 | 32-bit unsigned integer |
 | `UInt64` | UInt64 | 64-bit unsigned integer |
 | `String` | Utf8 | UTF-8 string |
-| `Bytes` | LargeBinary | Raw bytes |
+| `Bytes` | LargeBinary | Raw bytes (universal sink -- any type is compatible) |
 | `Bool` | Boolean | Boolean |
 
 ### `std/math/v1`
 
-| Type | Arrow Type | Description |
-|------|-----------|-------------|
-| `Vector3` | Struct | 3D vector (x, y, z Float64) |
-| `Quaternion` | Struct | Quaternion (x, y, z, w Float64) |
-| `Pose` | Struct | 6-DOF pose (position + orientation) |
-| `Transform` | Struct | Coordinate transform (translation + rotation) |
+| Type | Arrow Type | Fields | Description |
+|------|-----------|--------|-------------|
+| `Vector3` | Struct | x, y, z (Float64) | 3D vector |
+| `Quaternion` | Struct | x, y, z, w (Float64) | Quaternion |
+| `Pose` | Struct | position, orientation | 6-DOF pose |
+| `Transform` | Struct | translation, rotation | Coordinate transform |
 
 ### `std/control/v1`
 
@@ -80,12 +119,12 @@ std/vision/v1/BoundingBox
 
 ### `std/media/v1`
 
-| Type | Arrow Type | Description |
-|------|-----------|-------------|
-| `Image` | Struct | Raw image (width, height, encoding, data) |
-| `CompressedImage` | LargeBinary | JPEG/PNG compressed image |
-| `PointCloud` | Struct | 3D point cloud |
-| `AudioFrame` | Struct | Audio samples |
+| Type | Arrow Type | Parameters | Description |
+|------|-----------|------------|-------------|
+| `Image` | Struct | `encoding` | Raw image (width, height, encoding, data) |
+| `CompressedImage` | LargeBinary | `format` | JPEG/PNG compressed image |
+| `PointCloud` | Struct | `point_type` | 3D point cloud |
+| `AudioFrame` | Struct | `sample_type` (default: f32) | Audio samples |
 
 ### `std/vision/v1`
 
@@ -97,13 +136,18 @@ std/vision/v1/BoundingBox
 
 ## Validation Rules
 
-`adora validate` checks:
+`adora validate` and `adora build` check:
 
 1. **Key existence**: `output_types` keys must appear in `outputs`, `input_types` keys must appear in `inputs`
-2. **URN resolution**: All type URNs must exist in the standard library
-3. **Edge compatibility**: When a connected output and input both have types, they must match
+2. **URN resolution**: All type URNs must exist in the standard or user-defined type library. Typos get "did you mean?" suggestions.
+3. **Edge compatibility**: Connected edges must have compatible types (exact match, implicit widening, or user-defined rules)
+4. **Timer auto-typing**: Timer inputs (`adora/timer/*`) are automatically typed as `std/core/v1/UInt64`
+5. **Type inference**: When only the upstream side annotates a type, it is inferred on the downstream input and reported
+6. **Parameterized types**: Parameter mismatches are detected (see above)
+7. **Metadata patterns**: `output_metadata` keys and `pattern` shorthands are validated (see below)
+8. **Schema compatibility**: Struct types are checked at the field level -- missing fields or wrong field types are flagged
 
-All checks produce warnings (non-fatal by default). Use `--strict` to treat warnings as errors for CI pipelines. Typos get suggestions:
+All checks produce warnings (non-fatal by default). Use `--strict-types` to treat warnings as errors for CI pipelines.
 
 ```
 Type warnings:
@@ -112,7 +156,104 @@ Type warnings:
     (did you mean "std/vision/v1/BoundingBox"?)
   - node "detector": type mismatch on input "image": upstream camera/image
     declares "std/core/v1/Bytes", but expected "std/media/v1/Image"
+
+Inferred types:
+  inferred std/core/v1/Float64 on processor/reading (from sensor/reading)
 ```
+
+## Type Compatibility Rules
+
+Beyond exact matching, the type checker supports implicit widening conversions:
+
+| From | To |
+|------|-----|
+| `UInt8` | `UInt32` |
+| `UInt32` | `UInt64` |
+| `Int32` | `Int64` |
+| `Float32` | `Float64` |
+| Any type | `Bytes` (universal sink) |
+
+Widening is transitive up to depth 3 (e.g. `UInt8` -> `UInt32` -> `UInt64` works, but chains of 4+ do not).
+
+### User-Defined Compatibility Rules
+
+Add custom rules in the dataflow YAML:
+
+```yaml
+type_rules:
+  - from: myproject/SensorV1
+    to: myproject/SensorV2
+
+nodes:
+  # ...
+```
+
+## Metadata Patterns
+
+Nodes that implement communication patterns (services, actions) can declare required metadata keys on their outputs.
+
+### Explicit metadata
+
+```yaml
+- id: server
+  path: server.py
+  outputs:
+    - response
+  output_metadata:
+    response: [request_id]
+```
+
+### Pattern shorthand
+
+Use the `pattern` field to auto-imply required metadata keys:
+
+```yaml
+- id: server
+  path: server.py
+  pattern: service-server
+  outputs:
+    - response
+```
+
+| Pattern | Required metadata keys |
+|---------|----------------------|
+| `service-server` | `request_id` |
+| `service-client` | `request_id` |
+| `action-server` | `goal_id`, `goal_status` |
+| `action-client` | `goal_id` |
+
+## User-Defined Types
+
+Projects can define custom types in a `types/` directory next to the dataflow. The directory structure determines the URN prefix:
+
+```
+project/
+  dataflow.yml
+  types/
+    myproject/
+      sensors/
+        v1.yml    # URN prefix: myproject/sensors/v1
+```
+
+Type YAML files use the same format as the standard library:
+
+```yaml
+types:
+  MySensor:
+    arrow: Struct
+    description: Custom sensor reading
+    fields:
+      - name: temperature
+        type: Float32
+      - name: humidity
+        type: Float32
+```
+
+This creates the URN `myproject/sensors/v1/MySensor`.
+
+The `std/` prefix is reserved and cannot be used for user types.
+
+User types are loaded automatically by `adora validate` and `adora build` when a `types/` directory exists.
 
 ## Runtime Type Checking
 
@@ -134,7 +275,7 @@ Valid values: `1`, `warn`, `true` (warn mode), `error` (error mode). Unset or an
 - Validates `output_types` on the sender side (`send_output()` calls). `input_types` are checked statically by `adora validate` but not enforced at runtime
 - Covers all languages that send Arrow arrays (Rust, Python, C++ Arrow path)
 - Raw byte sends (`send_output_bytes`, C nodes) are untyped and skip checking
-- Complex types (Struct-based: Image, Vector3, etc.) are skipped — only primitive types, String, Bytes, and Bool are validated at runtime
+- Complex types (Struct-based: Image, Vector3, etc.) are skipped -- only primitive types, String, Bytes, and Bool are validated at runtime
 
 ## Graph Visualization
 
@@ -148,7 +289,7 @@ Edges display as `output_name [TypeName]` (e.g. `image [Image]`).
 
 ## Operators
 
-Operators support the same `output_types` and `input_types` fields:
+Operators support the same `output_types`, `input_types`, `output_metadata`, and `pattern` fields:
 
 ```yaml
 - id: runtime-node

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -37,6 +37,8 @@ nodes:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `nodes` | list | **required** | List of node configurations |
+| `strict_types` | bool | `false` | Treat type warnings as errors in `validate` and `build` |
+| `type_rules` | list | `[]` | User-defined type compatibility rules (see [Type Annotations](types.md#user-defined-compatibility-rules)) |
 | `health_check_interval` | float | `5.0` | Seconds between daemon health check sweeps. For each node with `health_check_timeout` set, the daemon checks whether the node has communicated within its timeout; if not, the node is killed and its `restart_policy` is evaluated |
 | `_unstable_deploy` | object | -- | Root-level deployment config (see [Deployment](#deployment)) |
 | `_unstable_debug` | object | -- | Debug options (see [Debug](#debug)) |
@@ -154,8 +156,10 @@ Optional type annotations for inputs and outputs. Types are never required -- un
 |-------|------|---------|-------------|
 | `output_types` | object | `{}` | Maps output IDs to type URNs. Keys must match entries in `outputs` |
 | `input_types` | object | `{}` | Maps input IDs to expected type URNs. Keys must match entries in `inputs` |
+| `output_metadata` | object | `{}` | Maps output IDs to lists of required metadata keys |
+| `pattern` | string | -- | Communication pattern shorthand: `service-server`, `service-client`, `action-server`, `action-client` |
 
-Type URNs use the format `std/<category>/v<version>/<TypeName>`. See the [Type Annotations Guide](types.md) for the full standard type library.
+Type URNs use the format `std/<category>/v<version>/<TypeName>` and support parameters (e.g. `std/media/v1/AudioFrame[sample_type=f32]`). See the [Type Annotations Guide](types.md) for the full standard type library, parameterized types, compatibility rules, and user-defined types.
 
 Run `adora validate <file>` to check type annotations statically. For runtime checking, set `ADORA_RUNTIME_TYPE_CHECK=warn` or `error`:
 

--- a/examples/benchmark/run.rs
+++ b/examples/benchmark/run.rs
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/examples/python-dataflow/run.rs
+++ b/examples/python-dataflow/run.rs
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true)?;
+    build("dataflow.yml".to_string(), None, None, true, true, false)?;
 
     adora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/python-operator-dataflow/run.rs
+++ b/examples/python-operator-dataflow/run.rs
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true)?;
+    build("dataflow.yml".to_string(), None, None, true, true, false)?;
 
     adora_run("dataflow.yml".to_string(), true)?;
 

--- a/examples/ros2-bridge/python/turtle/run.rs
+++ b/examples/ros2-bridge/python/turtle/run.rs
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, true, true)?;
+    build("dataflow.yml".to_string(), None, None, true, true, false)?;
 
     let dataflow_task = std::thread::spawn(|| {
         adora_run("dataflow.yml".to_string(), true).unwrap();

--- a/examples/ros2-bridge/rust/service-client/run.rs
+++ b/examples/ros2-bridge/rust/service-client/run.rs
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/service-server/run.rs
+++ b/examples/ros2-bridge/rust/service-server/run.rs
@@ -10,7 +10,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     let (finish_tx, finish_rx) = mpsc::channel();
     let dataflow_task = std::thread::spawn(move || {

--- a/examples/ros2-bridge/rust/topic-pub/run.rs
+++ b/examples/ros2-bridge/rust/topic-pub/run.rs
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/topic-sub/run.rs
+++ b/examples/ros2-bridge/rust/topic-sub/run.rs
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/ros2-bridge/rust/turtle/run.rs
+++ b/examples/ros2-bridge/rust/turtle/run.rs
@@ -9,7 +9,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join("../../../").join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     let dataflow_task = std::thread::spawn(|| {
         run("dataflow.yml".to_string(), false).unwrap();

--- a/examples/rust-dataflow-url/run.rs
+++ b/examples/rust-dataflow-url/run.rs
@@ -7,7 +7,7 @@ fn main() -> eyre::Result<()> {
     std::env::set_current_dir(root.join(file!()).parent().unwrap())
         .wrap_err("failed to set working dir")?;
 
-    build("dataflow.yml".to_string(), None, None, false, true)?;
+    build("dataflow.yml".to_string(), None, None, false, true, false)?;
 
     run("dataflow.yml".to_string(), false)?;
 

--- a/libraries/core/Cargo.toml
+++ b/libraries/core/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 [features]
 build = ["dep:git2", "dep:url"]
 zenoh = ["dep:zenoh"]
+type-inference = ["dep:syn"]
 
 [dependencies]
 adora-message = { workspace = true }
@@ -37,6 +38,7 @@ git2 = { workspace = true, optional = true }
 fs_extra = "1.3.0"
 splitty = "1.0.2"
 zenoh = { workspace = true, optional = true }
+syn = { version = "2", features = ["full", "visit"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.26.0"

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -134,6 +134,8 @@ pub fn expand_modules_with_boundaries(
             deploy: descriptor.deploy.clone(),
             debug: descriptor.debug.clone(),
             health_check_interval: descriptor.health_check_interval,
+            strict_types: descriptor.strict_types,
+            type_rules: descriptor.type_rules.clone(),
         },
         boundaries,
     })

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -668,22 +668,83 @@ impl std::fmt::Display for TypeWarning {
     }
 }
 
-/// Check type annotations in a dataflow. Returns warnings (never errors).
+/// A type inferred from an upstream annotated output (Phase 3).
+#[derive(Debug)]
+pub struct TypeInference {
+    /// Node that received the inferred type.
+    pub node_id: String,
+    /// Port that received the inferred type.
+    pub port_id: String,
+    /// The inferred type URN.
+    pub inferred_urn: String,
+    /// Source of the inference (e.g. "sensor/reading").
+    pub source: String,
+}
+
+impl std::fmt::Display for TypeInference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "inferred {} on {}/{} (from {})",
+            self.inferred_urn, self.node_id, self.port_id, self.source
+        )
+    }
+}
+
+/// Result of type checking a dataflow.
+pub struct TypeCheckResult {
+    /// Type warnings found.
+    pub warnings: Vec<TypeWarning>,
+    /// Types inferred from upstream annotations (Phase 3).
+    pub inferences: Vec<TypeInference>,
+}
+
+/// Timer node URN prefix.
+const TIMER_PREFIX: &str = "adora/timer/";
+/// Timer nodes auto-inject this type.
+const TIMER_TYPE: &str = "std/core/v1/UInt64";
+
+/// Check type annotations in a dataflow.
 ///
 /// Checks:
 /// 1. `output_types` keys exist in `outputs`
 /// 2. `input_types` keys exist in `inputs`
 /// 3. All type URNs resolve in the registry
-/// 4. Connected edges have matching types (when both sides are annotated)
+/// 4. Connected edges have compatible types (using compatibility graph)
+/// 5. Type inference across edges (Phase 3)
+/// 6. Metadata annotation validation (Phase 5)
+/// 7. Arrow schema validation (Phase 6)
+/// 8. Strict mode: warn on unannotated ports connected to annotated ports
 pub fn check_type_annotations(
     dataflow: &super::Descriptor,
     registry: &crate::types::TypeRegistry,
 ) -> Vec<TypeWarning> {
+    check_type_annotations_full(dataflow, registry, false).warnings
+}
+
+/// Full type checking with strict mode support. Returns warnings + inferences.
+pub fn check_type_annotations_full(
+    dataflow: &super::Descriptor,
+    registry: &crate::types::TypeRegistry,
+    strict: bool,
+) -> TypeCheckResult {
+    use crate::types::{CompatibilityGraph, TypeRule};
+
     let mut warnings = Vec::new();
+    let mut inferences = Vec::new();
+
+    // Build compatibility graph from user rules
+    let user_rules: Vec<TypeRule> = dataflow
+        .type_rules
+        .iter()
+        .map(|r| TypeRule {
+            from: r.from.clone(),
+            to: r.to.clone(),
+        })
+        .collect();
+    let compat = CompatibilityGraph::new(&user_rules);
 
     // Map of (source_node_id, output_ref) -> type_urn for cross-edge checking.
-    // For custom nodes: ("node_id", "output_id")
-    // For operators: ("node_id", "op_id/output_id") — matches InputMapping::User format
     let mut output_type_map: BTreeMap<(String, String), String> = BTreeMap::new();
 
     for node in &dataflow.nodes {
@@ -698,7 +759,7 @@ pub fn check_type_annotations(
             registry,
             &mut warnings,
         );
-        // Register node outputs for cross-edge checking (only known URNs)
+        // Register node outputs for cross-edge checking
         for (output_id, urn) in &node.output_types {
             if registry.resolve(urn).is_some() {
                 output_type_map.insert((nid.clone(), output_id.to_string()), urn.clone());
@@ -712,6 +773,15 @@ pub fn check_type_annotations(
             |id| node.inputs.contains_key(id),
             "input",
             registry,
+            &mut warnings,
+        );
+
+        // Check metadata annotations (Phase 5)
+        check_metadata_annotations(
+            &nid,
+            &node.output_metadata,
+            &node.pattern,
+            &node.outputs,
             &mut warnings,
         );
 
@@ -730,7 +800,6 @@ pub fn check_type_annotations(
                 registry,
                 &mut warnings,
             );
-            // Operator outputs are referenced as "op_id/output_id" from the node
             for (output_id, urn) in &op.config.output_types {
                 if registry.resolve(urn).is_some() {
                     output_type_map
@@ -743,6 +812,13 @@ pub fn check_type_annotations(
                 |id| op.config.inputs.contains_key(id),
                 "input",
                 registry,
+                &mut warnings,
+            );
+            check_metadata_annotations(
+                &nid,
+                &op.config.output_metadata,
+                &op.config.pattern,
+                &op.config.outputs,
                 &mut warnings,
             );
         }
@@ -771,45 +847,92 @@ pub fn check_type_annotations(
                     registry,
                     &mut warnings,
                 );
-            }
-        }
-    }
-
-    // Cross-edge type mismatch check (nodes + operators)
-    for node in &dataflow.nodes {
-        let nid = node.id.to_string();
-        check_edge_mismatches(
-            &nid,
-            &node.input_types,
-            &node.inputs,
-            &output_type_map,
-            &mut warnings,
-        );
-
-        if let Some(op) = &node.operator {
-            check_edge_mismatches(
-                &nid,
-                &op.config.input_types,
-                &op.config.inputs,
-                &output_type_map,
-                &mut warnings,
-            );
-        }
-        if let Some(runtime) = &node.operators {
-            for op in &runtime.operators {
-                let label = format!("{nid}/{}", op.id);
-                check_edge_mismatches(
+                check_metadata_annotations(
                     &label,
-                    &op.config.input_types,
-                    &op.config.inputs,
-                    &output_type_map,
+                    &op.config.output_metadata,
+                    &op.config.pattern,
+                    &op.config.outputs,
                     &mut warnings,
                 );
             }
         }
     }
 
-    warnings
+    // Cross-edge type checking + inference (Phase 3 + 4)
+    // Also check timer inputs against input_types annotations.
+    for node in &dataflow.nodes {
+        let nid = node.id.to_string();
+        let timer_types = timer_input_types(&node.inputs);
+        check_edge_mismatches_with_compat(
+            &nid,
+            &node.input_types,
+            &node.inputs,
+            &output_type_map,
+            &timer_types,
+            &compat,
+            registry,
+            strict,
+            &mut warnings,
+            &mut inferences,
+        );
+
+        if let Some(op) = &node.operator {
+            let op_timer = timer_input_types(&op.config.inputs);
+            check_edge_mismatches_with_compat(
+                &nid,
+                &op.config.input_types,
+                &op.config.inputs,
+                &output_type_map,
+                &op_timer,
+                &compat,
+                registry,
+                strict,
+                &mut warnings,
+                &mut inferences,
+            );
+        }
+        if let Some(runtime) = &node.operators {
+            for op in &runtime.operators {
+                let label = format!("{nid}/{}", op.id);
+                let op_timer = timer_input_types(&op.config.inputs);
+                check_edge_mismatches_with_compat(
+                    &label,
+                    &op.config.input_types,
+                    &op.config.inputs,
+                    &output_type_map,
+                    &op_timer,
+                    &compat,
+                    registry,
+                    strict,
+                    &mut warnings,
+                    &mut inferences,
+                );
+            }
+        }
+    }
+
+    TypeCheckResult {
+        warnings,
+        inferences,
+    }
+}
+
+/// Build a map of (input_id -> timer_type) for Timer-mapped inputs.
+fn timer_input_types(inputs: &BTreeMap<DataId, Input>) -> BTreeMap<DataId, String> {
+    // Quick check: skip allocation if no timer inputs
+    if !inputs
+        .values()
+        .any(|i| matches!(i.mapping, InputMapping::Timer { .. }))
+    {
+        return BTreeMap::new();
+    }
+    let mut result = BTreeMap::new();
+    for (input_id, input) in inputs {
+        if matches!(input.mapping, InputMapping::Timer { .. }) {
+            result.insert(input_id.clone(), TIMER_TYPE.to_string());
+        }
+    }
+    result
 }
 
 /// Validate that port type keys exist in the port list and URNs resolve.
@@ -843,33 +966,137 @@ fn check_port_types(
     }
 }
 
-/// Check cross-edge type mismatches for a set of inputs.
-fn check_edge_mismatches(
+/// Check metadata annotations on outputs (Phase 5).
+fn check_metadata_annotations(
+    node_id: &str,
+    output_metadata: &BTreeMap<DataId, Vec<String>>,
+    pattern: &Option<String>,
+    outputs: &BTreeSet<DataId>,
+    warnings: &mut Vec<TypeWarning>,
+) {
+    // Check explicit output_metadata keys exist in outputs
+    for (output_id, _) in output_metadata {
+        if !outputs.contains(output_id) {
+            warnings.push(TypeWarning {
+                node_id: node_id.to_string(),
+                message: format!("output_metadata key \"{output_id}\" not found in outputs list"),
+            });
+        }
+    }
+
+    // Validate pattern shorthand
+    if let Some(pat) = pattern {
+        if crate::types::pattern_metadata_keys(pat).is_none() {
+            warnings.push(TypeWarning {
+                node_id: node_id.to_string(),
+                message: format!(
+                    "unknown pattern \"{pat}\", expected one of: \
+                     service-server, service-client, action-server, action-client"
+                ),
+            });
+        }
+    }
+}
+
+/// Check cross-edge type mismatches using compatibility graph.
+///
+/// Also performs type inference (Phase 3) and strict-mode unannotated checks.
+/// `timer_types` maps input IDs to auto-injected timer type URNs.
+fn check_edge_mismatches_with_compat(
     node_id: &str,
     input_types: &BTreeMap<DataId, String>,
     inputs: &BTreeMap<DataId, Input>,
     output_type_map: &BTreeMap<(String, String), String>,
+    timer_types: &BTreeMap<DataId, String>,
+    compat: &crate::types::CompatibilityGraph,
+    registry: &crate::types::TypeRegistry,
+    strict: bool,
     warnings: &mut Vec<TypeWarning>,
+    inferences: &mut Vec<TypeInference>,
 ) {
-    for (input_id, input_urn) in input_types {
-        if let Some(input) = inputs.get(input_id) {
-            if let InputMapping::User(ref mapping) = input.mapping {
+    for (input_id, input) in inputs {
+        match &input.mapping {
+            InputMapping::User(mapping) => {
                 let key = (mapping.source.to_string(), mapping.output.to_string());
-                if let Some(output_urn) = output_type_map.get(&key) {
-                    if output_urn != input_urn {
+                let upstream_urn = output_type_map.get(&key);
+                let downstream_urn = input_types.get(input_id);
+
+                match (upstream_urn, downstream_urn) {
+                    (Some(out_urn), Some(in_urn)) => {
+                        if !compat.is_compatible(out_urn, in_urn) {
+                            let schema_detail = check_schema_compat(out_urn, in_urn, registry);
+                            let detail =
+                                schema_detail.map(|d| format!(" ({d})")).unwrap_or_default();
+                            warnings.push(TypeWarning {
+                                node_id: node_id.to_string(),
+                                message: format!(
+                                    "type mismatch on input \"{input_id}\": \
+                                     upstream {}/{} declares \"{out_urn}\", \
+                                     but expected \"{in_urn}\"{detail}",
+                                    mapping.source, mapping.output,
+                                ),
+                            });
+                        }
+                    }
+                    (Some(out_urn), None) => {
+                        inferences.push(TypeInference {
+                            node_id: node_id.to_string(),
+                            port_id: input_id.to_string(),
+                            inferred_urn: out_urn.clone(),
+                            source: format!("{}/{}", mapping.source, mapping.output),
+                        });
+                    }
+                    (None, Some(in_urn)) if strict => {
+                        warnings.push(TypeWarning {
+                            node_id: node_id.to_string(),
+                            message: format!(
+                                "input \"{input_id}\" expects type \"{in_urn}\" but upstream \
+                                 {}/{} has no type annotation",
+                                mapping.source, mapping.output,
+                            ),
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            InputMapping::Timer { .. } => {
+                // Timer inputs auto-inject std/core/v1/UInt64
+                if let Some(expected_urn) = input_types.get(input_id) {
+                    let timer_urn = timer_types
+                        .get(input_id)
+                        .map(|s| s.as_str())
+                        .unwrap_or(TIMER_TYPE);
+                    if !compat.is_compatible(timer_urn, expected_urn) {
                         warnings.push(TypeWarning {
                             node_id: node_id.to_string(),
                             message: format!(
                                 "type mismatch on input \"{input_id}\": \
-                                 upstream {}/{} declares \"{output_urn}\", \
-                                 but expected \"{input_urn}\"",
-                                mapping.source, mapping.output,
+                                 timer provides \"{timer_urn}\", \
+                                 but expected \"{expected_urn}\"",
                             ),
                         });
                     }
                 }
             }
         }
+    }
+}
+
+/// Check schema-level compatibility for struct types (Phase 6).
+/// Returns an optional detail string for the error message.
+fn check_schema_compat(
+    out_urn: &str,
+    in_urn: &str,
+    registry: &crate::types::TypeRegistry,
+) -> Option<String> {
+    let out_def = registry.resolve(out_urn)?;
+    let in_def = registry.resolve(in_urn)?;
+    let out_schema = out_def.to_arrow_schema()?;
+    let in_schema = in_def.to_arrow_schema()?;
+    // in_schema = expected (consumer), out_schema = actual (producer)
+    match crate::types::schema_compatible(&in_schema, &out_schema) {
+        Ok(()) => None,
+        Err(e) => Some(e.to_string()),
     }
 }
 
@@ -1325,7 +1552,7 @@ nodes:
     outputs:
       - data
     output_types:
-      data: std/core/v1/Bytes
+      data: std/core/v1/Float32
   - id: receiver
     inputs:
       data: sender/data
@@ -1337,8 +1564,272 @@ nodes:
         let warnings = check_type_annotations(&dataflow, &reg);
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].message.contains("type mismatch"));
-        assert!(warnings[0].message.contains("Bytes"));
+        assert!(warnings[0].message.contains("Float32"));
         assert!(warnings[0].message.contains("Image"));
+    }
+
+    // --- Phase 1: strict mode tests ---
+
+    #[test]
+    fn strict_types_parses_in_yaml() {
+        let dataflow = parse_dataflow("nodes:\n  - id: a\nstrict_types: true\n");
+        assert_eq!(dataflow.strict_types, Some(true));
+    }
+
+    #[test]
+    fn strict_mode_warns_on_unannotated_upstream() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/Float32
+",
+        );
+        let reg = TypeRegistry::new();
+        let result = check_type_annotations_full(&dataflow, &reg, true);
+        assert!(!result.warnings.is_empty());
+        assert!(result.warnings[0].message.contains("no type annotation"));
+    }
+
+    #[test]
+    fn non_strict_no_warning_on_unannotated_upstream() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/Float32
+",
+        );
+        let reg = TypeRegistry::new();
+        let result = check_type_annotations_full(&dataflow, &reg, false);
+        assert!(result.warnings.is_empty());
+    }
+
+    // --- Phase 3: type inference tests ---
+
+    #[test]
+    fn inference_from_annotated_upstream() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sensor
+    outputs:
+      - reading
+    output_types:
+      reading: std/core/v1/Float64
+  - id: processor
+    inputs:
+      reading: sensor/reading
+",
+        );
+        let reg = TypeRegistry::new();
+        let result = check_type_annotations_full(&dataflow, &reg, false);
+        assert!(result.warnings.is_empty());
+        assert_eq!(result.inferences.len(), 1);
+        assert_eq!(result.inferences[0].inferred_urn, "std/core/v1/Float64");
+        assert_eq!(result.inferences[0].port_id, "reading");
+    }
+
+    #[test]
+    fn no_inference_when_both_annotated() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+    output_types:
+      data: std/core/v1/Float32
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/Float32
+",
+        );
+        let reg = TypeRegistry::new();
+        let result = check_type_annotations_full(&dataflow, &reg, false);
+        assert!(result.inferences.is_empty());
+    }
+
+    #[test]
+    fn no_inference_when_neither_annotated() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+  - id: receiver
+    inputs:
+      data: sender/data
+",
+        );
+        let reg = TypeRegistry::new();
+        let result = check_type_annotations_full(&dataflow, &reg, false);
+        assert!(result.inferences.is_empty());
+    }
+
+    // --- Phase 4: compatibility tests ---
+
+    #[test]
+    fn compat_uint8_to_uint32_edge() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+    output_types:
+      data: std/core/v1/UInt8
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/UInt32
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(warnings.is_empty(), "UInt8 -> UInt32 should be compatible");
+    }
+
+    #[test]
+    fn compat_any_to_bytes_edge() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: sender
+    outputs:
+      - data
+    output_types:
+      data: std/media/v1/Image
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/Bytes
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(
+            warnings.is_empty(),
+            "anything -> Bytes should be compatible"
+        );
+    }
+
+    #[test]
+    fn compat_user_defined_rule_in_yaml() {
+        let dataflow = parse_dataflow(
+            "\
+type_rules:
+  - from: std/core/v1/UInt8
+    to: std/core/v1/String
+nodes:
+  - id: sender
+    outputs:
+      - data
+    output_types:
+      data: std/core/v1/UInt8
+  - id: receiver
+    inputs:
+      data: sender/data
+    input_types:
+      data: std/core/v1/String
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(
+            warnings.is_empty(),
+            "user-defined rule should make this compatible"
+        );
+    }
+
+    // --- Phase 5: metadata tests ---
+
+    #[test]
+    fn metadata_pattern_resolves() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: srv
+    pattern: service-server
+    outputs:
+      - response
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn metadata_unknown_pattern() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: srv
+    pattern: unknown-pattern
+    outputs:
+      - response
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("unknown pattern"));
+    }
+
+    #[test]
+    fn metadata_output_key_not_in_outputs() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: srv
+    output_metadata:
+      missing_port: [request_id]
+    outputs:
+      - response
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("output_metadata key"));
+    }
+
+    // --- Timer auto-inject test ---
+
+    #[test]
+    fn timer_input_type_mismatch() {
+        let dataflow = parse_dataflow(
+            "\
+nodes:
+  - id: node
+    inputs:
+      tick: adora/timer/millis/100
+    input_types:
+      tick: std/media/v1/Image
+",
+        );
+        let reg = TypeRegistry::new();
+        let warnings = check_type_annotations(&dataflow, &reg);
+        assert!(!warnings.is_empty());
+        assert!(warnings[0].message.contains("type mismatch"));
     }
 
     #[test]

--- a/libraries/core/src/inference.rs
+++ b/libraries/core/src/inference.rs
@@ -1,0 +1,221 @@
+//! Type inference from Rust source code (Phase 8).
+//!
+//! Scans Rust source files for `send_output` calls and maps Arrow constructor
+//! patterns to type URNs. Best-effort: unrecognizable patterns produce no
+//! suggestion (not an error).
+//!
+//! Feature-gated behind `type-inference`.
+
+use std::path::Path;
+use syn::{Expr, ExprMethodCall, visit::Visit};
+
+/// A suggested type annotation inferred from source code.
+#[derive(Debug)]
+pub struct TypeSuggestion {
+    /// Node ID (derived from context, not from source)
+    pub node_id: String,
+    /// Output ID found in `send_output` calls
+    pub output_id: String,
+    /// Suggested type URN
+    pub suggested_urn: String,
+    /// Source file path
+    pub file: String,
+    /// Line number in source (None if unavailable)
+    pub line: Option<usize>,
+}
+
+impl std::fmt::Display for TypeSuggestion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(line) = self.line {
+            write!(
+                f,
+                "suggest: node \"{}\" output \"{}\" -> {} (from {}:{})",
+                self.node_id, self.output_id, self.suggested_urn, self.file, line,
+            )
+        } else {
+            write!(
+                f,
+                "suggest: node \"{}\" output \"{}\" -> {} (from {})",
+                self.node_id, self.output_id, self.suggested_urn, self.file,
+            )
+        }
+    }
+}
+
+/// Scan a Rust source file for type hints. Returns suggestions.
+pub fn infer_types_from_file(
+    source_path: &Path,
+    node_id: &str,
+) -> Result<Vec<TypeSuggestion>, String> {
+    let content = std::fs::read_to_string(source_path)
+        .map_err(|e| format!("{}: {e}", source_path.display()))?;
+    infer_types_from_source(&content, source_path.to_string_lossy().as_ref(), node_id)
+}
+
+/// Scan Rust source text for type hints.
+pub fn infer_types_from_source(
+    source: &str,
+    file_name: &str,
+    node_id: &str,
+) -> Result<Vec<TypeSuggestion>, String> {
+    let syntax =
+        syn::parse_file(source).map_err(|e| format!("failed to parse {file_name}: {e}"))?;
+
+    let mut visitor = TypeInferenceVisitor {
+        suggestions: Vec::new(),
+        node_id: node_id.to_string(),
+        file_name: file_name.to_string(),
+    };
+    visitor.visit_file(&syntax);
+    Ok(visitor.suggestions)
+}
+
+struct TypeInferenceVisitor {
+    suggestions: Vec<TypeSuggestion>,
+    node_id: String,
+    file_name: String,
+}
+
+impl<'ast> Visit<'ast> for TypeInferenceVisitor {
+    fn visit_expr_method_call(&mut self, node: &'ast ExprMethodCall) {
+        let method_name = node.method.to_string();
+        if method_name == "send_output" && node.args.len() >= 2 {
+            // Try to extract output_id from first argument (string literal)
+            if let Some(output_id) = extract_string_lit(&node.args[0]) {
+                // Try to infer type from second argument
+                if let Some(urn) = infer_type_from_expr(&node.args[1]) {
+                    self.suggestions.push(TypeSuggestion {
+                        node_id: self.node_id.clone(),
+                        output_id,
+                        suggested_urn: urn,
+                        file: self.file_name.clone(),
+                        line: None,
+                    });
+                }
+            }
+        }
+        // Continue visiting nested expressions
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+/// Try to extract a string literal from an expression.
+fn extract_string_lit(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Str(s) => Some(s.value()),
+            _ => None,
+        },
+        Expr::Reference(r) => extract_string_lit(&r.expr),
+        _ => None,
+    }
+}
+
+/// Try to infer a type URN from an expression (e.g. `Float64Array::from(...)`).
+fn infer_type_from_expr(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Call(call) => {
+            // Look for Type::from(...) patterns
+            if let Expr::Path(path) = &*call.func {
+                let segments: Vec<String> = path
+                    .path
+                    .segments
+                    .iter()
+                    .map(|s| s.ident.to_string())
+                    .collect();
+                let full = segments.join("::");
+                return map_constructor_to_urn(&full);
+            }
+            None
+        }
+        Expr::MethodCall(mc) => {
+            // Look for .into() on typed values, or ArrowArray constructors
+            let method = mc.method.to_string();
+            if method == "into" || method == "from" {
+                // Try to get type from receiver
+                return infer_type_from_expr(&mc.receiver);
+            }
+            None
+        }
+        Expr::Path(path) => {
+            let segments: Vec<String> = path
+                .path
+                .segments
+                .iter()
+                .map(|s| s.ident.to_string())
+                .collect();
+            let full = segments.join("::");
+            map_constructor_to_urn(&full)
+        }
+        _ => None,
+    }
+}
+
+/// Map known Arrow constructor names to type URNs.
+fn map_constructor_to_urn(name: &str) -> Option<String> {
+    match name {
+        "Float32Array" | "Float32Array::from" => Some("std/core/v1/Float32".into()),
+        "Float64Array" | "Float64Array::from" => Some("std/core/v1/Float64".into()),
+        "Int32Array" | "Int32Array::from" => Some("std/core/v1/Int32".into()),
+        "Int64Array" | "Int64Array::from" => Some("std/core/v1/Int64".into()),
+        "UInt8Array" | "UInt8Array::from" => Some("std/core/v1/UInt8".into()),
+        "UInt32Array" | "UInt32Array::from" => Some("std/core/v1/UInt32".into()),
+        "UInt64Array" | "UInt64Array::from" => Some("std/core/v1/UInt64".into()),
+        "StringArray" | "StringArray::from" => Some("std/core/v1/String".into()),
+        "BooleanArray" | "BooleanArray::from" => Some("std/core/v1/Bool".into()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infer_float64_from_send_output() {
+        let source = r#"
+            fn main() {
+                node.send_output("reading", Float64Array::from(vec![42.0]));
+            }
+        "#;
+        let suggestions = infer_types_from_source(source, "test.rs", "sensor").unwrap();
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].output_id, "reading");
+        assert_eq!(suggestions[0].suggested_urn, "std/core/v1/Float64");
+        assert_eq!(suggestions[0].node_id, "sensor");
+    }
+
+    #[test]
+    fn infer_unrecognizable_no_suggestion() {
+        let source = r#"
+            fn main() {
+                node.send_output("data", some_complex_expression());
+            }
+        "#;
+        let suggestions = infer_types_from_source(source, "test.rs", "node").unwrap();
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn infer_no_send_output() {
+        let source = r#"
+            fn main() {
+                let x = 42;
+            }
+        "#;
+        let suggestions = infer_types_from_source(source, "test.rs", "node").unwrap();
+        assert!(suggestions.is_empty());
+    }
+
+    #[test]
+    fn infer_string_array() {
+        let source = r#"
+            fn main() {
+                node.send_output("text", StringArray::from(vec!["hello"]));
+            }
+        "#;
+        let suggestions = infer_types_from_source(source, "test.rs", "node").unwrap();
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].suggested_urn, "std/core/v1/String");
+    }
+}

--- a/libraries/core/src/lib.rs
+++ b/libraries/core/src/lib.rs
@@ -10,6 +10,8 @@ pub use adora_message::{config, uhlc};
 #[cfg(feature = "build")]
 pub mod build;
 pub mod descriptor;
+#[cfg(feature = "type-inference")]
+pub mod inference;
 pub mod metadata;
 pub mod topics;
 pub mod types;

--- a/libraries/core/src/types.rs
+++ b/libraries/core/src/types.rs
@@ -1,6 +1,43 @@
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Field, Schema};
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::path::Path;
+
+/// A field definition within a struct type.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FieldDef {
+    /// Field name
+    pub name: String,
+    /// Arrow type name or URN reference
+    pub r#type: String,
+    /// Whether the field is nullable (default: true)
+    #[serde(default = "default_true")]
+    pub nullable: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// A type parameter declaration (e.g. `sample_type` on AudioFrame).
+#[derive(Debug, Clone, Deserialize)]
+pub struct TypeParam {
+    /// Parameter name
+    pub name: String,
+    /// Default value (used when parameter is not specified)
+    #[serde(default)]
+    pub default: Option<String>,
+}
+
+/// Metadata key required on outputs of a given type.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MetadataDef {
+    /// Key name that must be present in message metadata
+    pub key: String,
+    /// Description of the metadata key
+    #[serde(default)]
+    pub description: Option<String>,
+}
 
 /// A single type definition from the standard type library.
 #[derive(Debug, Clone, Deserialize)]
@@ -10,6 +47,15 @@ pub struct TypeDef {
     /// Human-readable description
     #[serde(default)]
     pub description: Option<String>,
+    /// Type parameters (e.g. sample_type for AudioFrame)
+    #[serde(default)]
+    pub params: Vec<TypeParam>,
+    /// Struct field definitions (only for Struct arrow types)
+    #[serde(default)]
+    pub fields: Vec<FieldDef>,
+    /// Required metadata keys
+    #[serde(default)]
+    pub metadata: Vec<MetadataDef>,
 }
 
 impl TypeDef {
@@ -18,20 +64,128 @@ impl TypeDef {
     /// Returns `None` for complex types (Struct, etc.) that cannot be validated
     /// from the type name alone.
     pub fn arrow_data_type(&self) -> Option<DataType> {
-        match self.arrow.as_str() {
-            "Float32" => Some(DataType::Float32),
-            "Float64" => Some(DataType::Float64),
-            "Int32" => Some(DataType::Int32),
-            "Int64" => Some(DataType::Int64),
-            "UInt8" => Some(DataType::UInt8),
-            "UInt32" => Some(DataType::UInt32),
-            "UInt64" => Some(DataType::UInt64),
-            "Utf8" => Some(DataType::Utf8),
-            "LargeBinary" => Some(DataType::LargeBinary),
-            "Boolean" => Some(DataType::Boolean),
-            _ => None, // Struct, FixedSizeBinary, etc. — skip runtime validation
+        arrow_type_from_name(&self.arrow)
+    }
+
+    /// Build an Arrow `Schema` from the field definitions.
+    ///
+    /// Returns `None` if the type has no field definitions.
+    pub fn to_arrow_schema(&self) -> Option<Schema> {
+        if self.fields.is_empty() {
+            return None;
+        }
+        let fields: Vec<Field> = self
+            .fields
+            .iter()
+            .filter_map(|f| {
+                let dt = arrow_type_from_name(&f.r#type)?;
+                Some(Field::new(&f.name, dt, f.nullable))
+            })
+            .collect();
+        if fields.is_empty() {
+            return None;
+        }
+        Some(Schema::new(fields))
+    }
+}
+
+/// Convert an arrow type name string to a `DataType`.
+fn arrow_type_from_name(name: &str) -> Option<DataType> {
+    match name {
+        "Float32" => Some(DataType::Float32),
+        "Float64" => Some(DataType::Float64),
+        "Int32" => Some(DataType::Int32),
+        "Int64" => Some(DataType::Int64),
+        "UInt8" => Some(DataType::UInt8),
+        "UInt32" => Some(DataType::UInt32),
+        "UInt64" => Some(DataType::UInt64),
+        "Utf8" => Some(DataType::Utf8),
+        "LargeBinary" => Some(DataType::LargeBinary),
+        "Boolean" => Some(DataType::Boolean),
+        _ => None, // Struct, FixedSizeBinary, etc. — skip runtime validation
+    }
+}
+
+/// Parsed URN with optional type parameters.
+///
+/// Example: `std/media/v1/AudioFrame[sample_type=f32,channels=2]`
+/// -> base = `std/media/v1/AudioFrame`, params = `{sample_type: f32, channels: 2}`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedUrn {
+    /// Base URN without parameters
+    pub base: String,
+    /// Parameter key-value pairs
+    pub params: BTreeMap<String, String>,
+}
+
+/// Parse a URN string into base + optional parameters.
+///
+/// Accepted formats:
+/// - `std/core/v1/Float32` (no params)
+/// - `std/media/v1/AudioFrame[sample_type=f32]` (with params)
+/// - `std/media/v1/AudioFrame[sample_type=f32,channels=2]` (multiple params)
+pub fn parse_urn(urn: &str) -> Option<ParsedUrn> {
+    if urn.is_empty() {
+        return None;
+    }
+    let Some(bracket_start) = urn.find('[') else {
+        return Some(ParsedUrn {
+            base: urn.to_string(),
+            params: BTreeMap::new(),
+        });
+    };
+    if !urn.ends_with(']') {
+        return None; // malformed: has `[` but no closing `]`
+    }
+    let base = urn[..bracket_start].to_string();
+    let params_str = &urn[bracket_start + 1..urn.len() - 1];
+    if params_str.is_empty() {
+        return None; // malformed: empty brackets
+    }
+    let mut params = BTreeMap::new();
+    for part in params_str.split(',') {
+        let part = part.trim();
+        let (k, v) = part.split_once('=')?;
+        let k = k.trim();
+        let v = v.trim();
+        if k.is_empty() || v.is_empty() {
+            return None;
+        }
+        params.insert(k.to_string(), v.to_string());
+    }
+    Some(ParsedUrn { base, params })
+}
+
+/// Check if two type URNs are compatible (considering parameters).
+///
+/// Rules:
+/// - Same base + same params -> compatible
+/// - Same base + one side unparameterized -> compatible (wildcard)
+/// - Same base + different param values -> mismatch
+/// - Different base -> mismatch
+pub fn types_match(a: &str, b: &str) -> bool {
+    let Some(pa) = parse_urn(a) else {
+        return a == b;
+    };
+    let Some(pb) = parse_urn(b) else {
+        return a == b;
+    };
+    if pa.base != pb.base {
+        return false;
+    }
+    // If either side has no params, treat as wildcard
+    if pa.params.is_empty() || pb.params.is_empty() {
+        return true;
+    }
+    // Both have params — all shared keys must agree
+    for (k, va) in &pa.params {
+        if let Some(vb) = pb.params.get(k) {
+            if va != vb {
+                return false;
+            }
         }
     }
+    true
 }
 
 /// YAML file format for a type package.
@@ -42,7 +196,194 @@ struct TypePackage {
 
 /// Extract the short type name from a URN (e.g. `std/media/v1/Image` -> `Image`).
 pub fn urn_short_name(urn: &str) -> &str {
-    urn.rsplit('/').next().unwrap_or(urn)
+    // Strip params first
+    let base = urn.split('[').next().unwrap_or(urn);
+    base.rsplit('/').next().unwrap_or(base)
+}
+
+// --- Compatibility graph (Phase 4) ---
+
+/// A user-defined type compatibility rule.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TypeRule {
+    /// Source type URN
+    pub from: String,
+    /// Target type URN
+    pub to: String,
+}
+
+/// Graph of type compatibility rules for checking implicit conversions.
+pub struct CompatibilityGraph {
+    /// Adjacency list: from-URN -> set of to-URNs
+    edges: BTreeMap<String, Vec<String>>,
+}
+
+impl CompatibilityGraph {
+    /// Create a new compatibility graph with hardcoded rules + optional user rules.
+    pub fn new(user_rules: &[TypeRule]) -> Self {
+        let mut edges: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+        // Hardcoded widening rules
+        let builtins = [
+            ("std/core/v1/UInt8", "std/core/v1/UInt32"),
+            ("std/core/v1/UInt32", "std/core/v1/UInt64"),
+            ("std/core/v1/Int32", "std/core/v1/Int64"),
+            ("std/core/v1/Float32", "std/core/v1/Float64"),
+        ];
+        for (from, to) in builtins {
+            edges
+                .entry(from.to_string())
+                .or_default()
+                .push(to.to_string());
+        }
+
+        // User-defined rules
+        for rule in user_rules {
+            edges
+                .entry(rule.from.clone())
+                .or_default()
+                .push(rule.to.clone());
+        }
+
+        Self { edges }
+    }
+
+    /// Check if `from` can be implicitly converted to `to`.
+    ///
+    /// Uses BFS with a depth limit of 3 to prevent surprise transitive chains.
+    /// Also handles the universal `* -> Bytes` sink.
+    pub fn is_compatible(&self, from: &str, to: &str) -> bool {
+        // Universal sink: anything -> Bytes
+        if to == "std/core/v1/Bytes" {
+            return true;
+        }
+
+        // Parse URNs once and reuse for both matching and BFS
+        let from_parsed = parse_urn(from);
+        let to_parsed = parse_urn(to);
+        let from_base = from_parsed
+            .as_ref()
+            .map(|p| p.base.as_str())
+            .unwrap_or(from);
+        let to_base = to_parsed.as_ref().map(|p| p.base.as_str()).unwrap_or(to);
+
+        // Check parameterized match using already-parsed URNs
+        if from_base == to_base {
+            // Same base — check params. If either has no params, wildcard match.
+            let from_params = from_parsed.as_ref().map(|p| &p.params);
+            let to_params = to_parsed.as_ref().map(|p| &p.params);
+            match (from_params, to_params) {
+                (Some(fp), Some(tp)) if !fp.is_empty() && !tp.is_empty() => {
+                    // Both have params — all shared keys must agree
+                    for (k, va) in fp {
+                        if let Some(vb) = tp.get(k) {
+                            if va != vb {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+            return true;
+        }
+
+        // BFS with depth limit 3
+        let mut queue = std::collections::VecDeque::new();
+        let mut visited = std::collections::BTreeSet::new();
+        queue.push_back((from_base.to_string(), 0u32));
+        visited.insert(from_base.to_string());
+
+        while let Some((current, depth)) = queue.pop_front() {
+            if depth >= 3 {
+                continue;
+            }
+            if let Some(neighbors) = self.edges.get(&current) {
+                for next in neighbors {
+                    if next == to_base {
+                        return true;
+                    }
+                    if visited.insert(next.clone()) {
+                        queue.push_back((next.clone(), depth + 1));
+                    }
+                }
+            }
+        }
+
+        false
+    }
+}
+
+// --- Arrow schema compatibility (Phase 6) ---
+
+/// Check if `actual` schema is compatible with `expected` schema.
+///
+/// Rules:
+/// - Actual superset of expected -> OK (additive fields fine)
+/// - Missing expected field -> incompatible
+/// - Wrong field type -> incompatible
+/// - Field order is irrelevant (lookup by name)
+pub fn schema_compatible(expected: &Schema, actual: &Schema) -> Result<(), SchemaError> {
+    for expected_field in expected.fields() {
+        match actual.field_with_name(expected_field.name()) {
+            Ok(actual_field) => {
+                if actual_field.data_type() != expected_field.data_type() {
+                    return Err(SchemaError::TypeMismatch {
+                        field: expected_field.name().to_string(),
+                        expected: format!("{:?}", expected_field.data_type()),
+                        actual: format!("{:?}", actual_field.data_type()),
+                    });
+                }
+            }
+            Err(_) => {
+                return Err(SchemaError::MissingField {
+                    field: expected_field.name().to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Schema compatibility error.
+#[derive(Debug)]
+pub enum SchemaError {
+    /// A required field is missing
+    MissingField { field: String },
+    /// A field has the wrong type
+    TypeMismatch {
+        field: String,
+        expected: String,
+        actual: String,
+    },
+}
+
+impl std::fmt::Display for SchemaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaError::MissingField { field } => write!(f, "missing field \"{field}\""),
+            SchemaError::TypeMismatch {
+                field,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "field \"{field}\" type mismatch: expected {expected}, got {actual}"
+            ),
+        }
+    }
+}
+
+// --- Metadata pattern resolution (Phase 5) ---
+
+/// Resolve a pattern shorthand to required metadata keys.
+pub fn pattern_metadata_keys(pattern: &str) -> Option<&'static [&'static str]> {
+    match pattern {
+        "service-server" | "service-client" => Some(&["request_id"]),
+        "action-server" => Some(&["goal_id", "goal_status"]),
+        "action-client" => Some(&["goal_id"]),
+        _ => None,
+    }
 }
 
 /// Registry of known type URNs, loaded from embedded YAML files.
@@ -90,9 +431,21 @@ impl TypeRegistry {
         Self { types }
     }
 
-    /// Resolve a type URN to its definition. Returns `None` if unknown.
+    /// Resolve a type URN to its definition.
+    ///
+    /// Handles parameterized URNs by stripping parameters before lookup.
     pub fn resolve(&self, urn: &str) -> Option<&TypeDef> {
-        self.types.get(urn)
+        // Try exact match first
+        if let Some(def) = self.types.get(urn) {
+            return Some(def);
+        }
+        // Try stripping parameters
+        if let Some(parsed) = parse_urn(urn) {
+            if parsed.base != urn {
+                return self.types.get(&parsed.base);
+            }
+        }
+        None
     }
 
     /// Resolve a type URN to its Arrow DataType. Returns `None` if unknown or complex.
@@ -105,18 +458,65 @@ impl TypeRegistry {
         self.types.keys().map(String::as_str)
     }
 
+    /// Load user-defined types from a directory tree.
+    ///
+    /// Convention: `types/<prefix>/<category>/v<N>.yml`
+    /// URN prefix derived from directory structure.
+    /// The `std/` prefix is rejected.
+    pub fn load_from_dir(&mut self, dir: &Path) -> Result<usize, String> {
+        if !dir.is_dir() {
+            return Ok(0);
+        }
+        let mut count = 0;
+        for path in walkdir_iter(dir) {
+            if path.extension().and_then(|e| e.to_str()) != Some("yml") {
+                continue;
+            }
+            let rel = path.strip_prefix(dir).map_err(|e| e.to_string())?;
+            let prefix = rel
+                .parent()
+                .map(|p| p.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_default();
+            if prefix.starts_with("std/") || prefix == "std" {
+                return Err(format!(
+                    "user types cannot use the \"std/\" prefix: {}",
+                    path.display()
+                ));
+            }
+            let stem = rel
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| format!("invalid file name: {}", path.display()))?;
+            let urn_prefix = if prefix.is_empty() {
+                stem.to_string()
+            } else {
+                format!("{prefix}/{stem}")
+            };
+            let content =
+                std::fs::read_to_string(&path).map_err(|e| format!("{}: {e}", path.display()))?;
+            let pkg: TypePackage =
+                serde_yaml::from_str(&content).map_err(|e| format!("{}: {e}", path.display()))?;
+            for (name, def) in pkg.types {
+                let urn = format!("{urn_prefix}/{name}");
+                self.types.insert(urn, def);
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
     /// Suggest the closest URN for a typo. Returns `None` if no close match.
     /// Prefers matches in the same package prefix (e.g. `std/media/v1`).
     pub fn suggest(&self, urn: &str) -> Option<&str> {
         let target_name = urn_short_name(urn).to_lowercase();
-        let target_prefix = urn.rsplit_once('/').map(|(p, _)| p);
+        let target_prefix = urn.split('[').next().unwrap_or(urn);
+        let target_prefix = target_prefix.rsplit_once('/').map(|(p, _)| p);
         self.types
             .keys()
             .filter_map(|k| {
                 let name = urn_short_name(k).to_lowercase();
                 let dist = edit_distance(&target_name, &name);
                 (dist <= 2).then(|| {
-                    // Penalize cross-package matches so same-package wins on ties
                     let prefix_penalty = if target_prefix == k.rsplit_once('/').map(|(p, _)| p) {
                         0
                     } else {
@@ -130,6 +530,32 @@ impl TypeRegistry {
     }
 }
 
+/// Walk a directory tree yielding file paths lazily.
+///
+/// Depth-limited to 8 levels. Uses `file_type()` to avoid following symlinks.
+fn walkdir_iter(dir: &Path) -> Vec<std::path::PathBuf> {
+    const MAX_DEPTH: u32 = 8;
+    let mut result = Vec::new();
+    let mut stack: Vec<(std::path::PathBuf, u32)> = vec![(dir.to_path_buf(), 0)];
+    while let Some((path, depth)) = stack.pop() {
+        if depth >= MAX_DEPTH {
+            continue;
+        }
+        let Ok(entries) = std::fs::read_dir(&path) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+            if is_dir {
+                stack.push((entry.path(), depth + 1));
+            } else {
+                result.push(entry.path());
+            }
+        }
+    }
+    result
+}
+
 impl Default for TypeRegistry {
     fn default() -> Self {
         Self::new()
@@ -137,7 +563,11 @@ impl Default for TypeRegistry {
 }
 
 /// Simple edit distance (Levenshtein) for typo suggestions.
+/// Returns `usize::MAX` for inputs longer than 256 characters to prevent DoS.
 fn edit_distance(a: &str, b: &str) -> usize {
+    if a.len() > 256 || b.len() > 256 {
+        return usize::MAX;
+    }
     let a: Vec<char> = a.chars().collect();
     let b: Vec<char> = b.chars().collect();
     let mut dp = vec![vec![0usize; b.len() + 1]; a.len() + 1];
@@ -232,7 +662,6 @@ mod tests {
     #[test]
     fn arrow_data_type_complex_returns_none() {
         let reg = TypeRegistry::new();
-        // Struct types cannot be validated from name alone
         assert_eq!(reg.resolve_arrow_type("std/media/v1/Image"), None);
         assert_eq!(reg.resolve_arrow_type("std/math/v1/Vector3"), None);
     }
@@ -241,5 +670,230 @@ mod tests {
     fn arrow_data_type_unknown_urn_returns_none() {
         let reg = TypeRegistry::new();
         assert_eq!(reg.resolve_arrow_type("std/core/v1/NonExistent"), None);
+    }
+
+    // --- Phase 2: parse_urn tests ---
+
+    #[test]
+    fn parse_urn_no_params() {
+        let parsed = parse_urn("std/media/v1/Image").unwrap();
+        assert_eq!(parsed.base, "std/media/v1/Image");
+        assert!(parsed.params.is_empty());
+    }
+
+    #[test]
+    fn parse_urn_single_param() {
+        let parsed = parse_urn("std/media/v1/AudioFrame[sample_type=f32]").unwrap();
+        assert_eq!(parsed.base, "std/media/v1/AudioFrame");
+        assert_eq!(parsed.params.len(), 1);
+        assert_eq!(parsed.params["sample_type"], "f32");
+    }
+
+    #[test]
+    fn parse_urn_multiple_params() {
+        let parsed = parse_urn("std/media/v1/AudioFrame[sample_type=f32,channels=2]").unwrap();
+        assert_eq!(parsed.base, "std/media/v1/AudioFrame");
+        assert_eq!(parsed.params.len(), 2);
+        assert_eq!(parsed.params["sample_type"], "f32");
+        assert_eq!(parsed.params["channels"], "2");
+    }
+
+    #[test]
+    fn parse_urn_malformed() {
+        assert!(parse_urn("").is_none());
+        assert!(parse_urn("foo[").is_none()); // no closing bracket
+        assert!(parse_urn("foo[]").is_none()); // empty brackets
+        assert!(parse_urn("foo[=val]").is_none()); // empty key
+        assert!(parse_urn("foo[key=]").is_none()); // empty value
+    }
+
+    #[test]
+    fn types_match_exact() {
+        assert!(types_match("std/core/v1/Float32", "std/core/v1/Float32"));
+    }
+
+    #[test]
+    fn types_match_wildcard() {
+        assert!(types_match(
+            "std/media/v1/AudioFrame",
+            "std/media/v1/AudioFrame[sample_type=f32]"
+        ));
+        assert!(types_match(
+            "std/media/v1/AudioFrame[sample_type=f32]",
+            "std/media/v1/AudioFrame"
+        ));
+    }
+
+    #[test]
+    fn types_match_param_mismatch() {
+        assert!(!types_match(
+            "std/media/v1/AudioFrame[sample_type=f32]",
+            "std/media/v1/AudioFrame[sample_type=i16]"
+        ));
+    }
+
+    #[test]
+    fn types_match_different_base() {
+        assert!(!types_match("std/core/v1/Float32", "std/core/v1/Float64"));
+    }
+
+    // --- Phase 4: compatibility graph tests ---
+
+    #[test]
+    fn compat_uint8_to_uint32() {
+        let g = CompatibilityGraph::new(&[]);
+        assert!(g.is_compatible("std/core/v1/UInt8", "std/core/v1/UInt32"));
+    }
+
+    #[test]
+    fn compat_uint8_to_uint64_transitive() {
+        let g = CompatibilityGraph::new(&[]);
+        assert!(g.is_compatible("std/core/v1/UInt8", "std/core/v1/UInt64"));
+    }
+
+    #[test]
+    fn compat_uint8_to_int32_mismatch() {
+        let g = CompatibilityGraph::new(&[]);
+        assert!(!g.is_compatible("std/core/v1/UInt8", "std/core/v1/Int32"));
+    }
+
+    #[test]
+    fn compat_any_to_bytes() {
+        let g = CompatibilityGraph::new(&[]);
+        assert!(g.is_compatible("std/media/v1/Image", "std/core/v1/Bytes"));
+        assert!(g.is_compatible("std/core/v1/Float32", "std/core/v1/Bytes"));
+    }
+
+    #[test]
+    fn compat_depth_limit() {
+        // Create a chain of 4: A->B->C->D->E
+        let rules = vec![
+            TypeRule {
+                from: "a/A".into(),
+                to: "a/B".into(),
+            },
+            TypeRule {
+                from: "a/B".into(),
+                to: "a/C".into(),
+            },
+            TypeRule {
+                from: "a/C".into(),
+                to: "a/D".into(),
+            },
+            TypeRule {
+                from: "a/D".into(),
+                to: "a/E".into(),
+            },
+        ];
+        let g = CompatibilityGraph::new(&rules);
+        assert!(g.is_compatible("a/A", "a/C")); // depth 2
+        assert!(g.is_compatible("a/A", "a/D")); // depth 3
+        assert!(!g.is_compatible("a/A", "a/E")); // depth 4 — exceeds limit
+    }
+
+    #[test]
+    fn compat_user_defined_rule() {
+        let rules = vec![TypeRule {
+            from: "myproject/SensorV1".into(),
+            to: "myproject/SensorV2".into(),
+        }];
+        let g = CompatibilityGraph::new(&rules);
+        assert!(g.is_compatible("myproject/SensorV1", "myproject/SensorV2"));
+    }
+
+    // --- Phase 5: metadata pattern tests ---
+
+    #[test]
+    fn pattern_service_server() {
+        let keys = pattern_metadata_keys("service-server").unwrap();
+        assert!(keys.contains(&"request_id"));
+    }
+
+    #[test]
+    fn pattern_action_server() {
+        let keys = pattern_metadata_keys("action-server").unwrap();
+        assert!(keys.contains(&"goal_id"));
+        assert!(keys.contains(&"goal_status"));
+    }
+
+    #[test]
+    fn pattern_unknown() {
+        assert!(pattern_metadata_keys("unknown").is_none());
+    }
+
+    // --- Phase 6: schema compatibility tests ---
+
+    #[test]
+    fn schema_superset_compatible() {
+        let expected = Schema::new(vec![Field::new("x", DataType::Float64, true)]);
+        let actual = Schema::new(vec![
+            Field::new("x", DataType::Float64, true),
+            Field::new("y", DataType::Float64, true),
+        ]);
+        assert!(schema_compatible(&expected, &actual).is_ok());
+    }
+
+    #[test]
+    fn schema_missing_field() {
+        let expected = Schema::new(vec![
+            Field::new("x", DataType::Float64, true),
+            Field::new("y", DataType::Float64, true),
+        ]);
+        let actual = Schema::new(vec![Field::new("x", DataType::Float64, true)]);
+        let err = schema_compatible(&expected, &actual).unwrap_err();
+        assert!(matches!(err, SchemaError::MissingField { .. }));
+    }
+
+    #[test]
+    fn schema_wrong_type() {
+        let expected = Schema::new(vec![Field::new("x", DataType::Float64, true)]);
+        let actual = Schema::new(vec![Field::new("x", DataType::Int32, true)]);
+        let err = schema_compatible(&expected, &actual).unwrap_err();
+        assert!(matches!(err, SchemaError::TypeMismatch { .. }));
+    }
+
+    // --- Phase 7: user-defined types tests ---
+
+    #[test]
+    fn load_user_types_from_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg_dir = dir.path().join("myproject").join("sensors");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("v1.yml"),
+            "types:\n  MySensor:\n    arrow: Struct\n    description: test\n",
+        )
+        .unwrap();
+        let mut reg = TypeRegistry::new();
+        let count = reg.load_from_dir(dir.path()).unwrap();
+        assert_eq!(count, 1);
+        assert!(reg.resolve("myproject/sensors/v1/MySensor").is_some());
+    }
+
+    #[test]
+    fn load_user_types_std_prefix_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let pkg_dir = dir.path().join("std").join("foo");
+        std::fs::create_dir_all(&pkg_dir).unwrap();
+        std::fs::write(
+            pkg_dir.join("v1.yml"),
+            "types:\n  Foo:\n    arrow: Struct\n",
+        )
+        .unwrap();
+        let mut reg = TypeRegistry::new();
+        let err = reg.load_from_dir(dir.path());
+        assert!(err.is_err());
+        assert!(err.unwrap_err().contains("std/"));
+    }
+
+    // --- Phase 2: resolve parameterized URN ---
+
+    #[test]
+    fn resolve_parameterized_urn() {
+        let reg = TypeRegistry::new();
+        // AudioFrame exists as std/media/v1/AudioFrame
+        let def = reg.resolve("std/media/v1/AudioFrame[sample_type=f32]");
+        assert!(def.is_some());
+        assert_eq!(def.unwrap().arrow, "Struct");
     }
 }

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -96,6 +96,37 @@ pub struct Descriptor {
     /// faster but add more overhead.
     #[serde(default)]
     pub health_check_interval: Option<f64>,
+
+    /// Enable strict type checking: type warnings become errors during build.
+    ///
+    /// Can also be enabled via `--strict-types` CLI flag on `adora build`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strict_types: Option<bool>,
+
+    /// Custom type compatibility rules.
+    ///
+    /// Each rule declares that a source type can be implicitly converted to
+    /// a target type. These supplement the built-in widening rules.
+    ///
+    /// ## Example
+    ///
+    /// ```yaml
+    /// type_rules:
+    ///   - from: myproject/SensorV1
+    ///     to: myproject/SensorV2
+    /// ```
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub type_rules: Vec<TypeRuleDef>,
+}
+
+/// A type compatibility rule declared in the dataflow YAML.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct TypeRuleDef {
+    /// Source type URN
+    pub from: String,
+    /// Target type URN
+    pub to: String,
 }
 
 /// Specifies when a node should be restarted.
@@ -408,6 +439,27 @@ pub struct Node {
     /// to check that upstream output types match expectations.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub input_types: BTreeMap<DataId, String>,
+
+    /// Required metadata keys per output.
+    ///
+    /// Maps output identifiers to lists of required metadata key names.
+    /// These are checked at build/validate time.
+    ///
+    /// ## Example
+    ///
+    /// ```yaml
+    /// output_metadata:
+    ///   response: [request_id]
+    /// ```
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub output_metadata: BTreeMap<DataId, Vec<String>>,
+
+    /// Communication pattern shorthand (e.g. `service-server`).
+    ///
+    /// Automatically implies required metadata keys on all outputs.
+    /// See `pattern_metadata_keys()` for supported patterns.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
 
     /// Redirect stdout/stderr to a data output.
     ///
@@ -784,6 +836,14 @@ pub struct OperatorConfig {
     /// Optional type annotations for inputs
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub input_types: BTreeMap<DataId, String>,
+
+    /// Required metadata keys per output
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub output_metadata: BTreeMap<DataId, Vec<String>>,
+
+    /// Communication pattern shorthand (e.g. `service-server`)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pattern: Option<String>,
 
     /// Operator source configuration (Python, shared library, etc.)
     #[serde(flatten)]

--- a/types/std/math/v1.yml
+++ b/types/std/math/v1.yml
@@ -2,9 +2,25 @@ types:
   Vector3:
     arrow: Struct
     description: "3D vector with x, y, z Float64 fields"
+    fields:
+      - name: x
+        type: Float64
+      - name: "y"
+        type: Float64
+      - name: z
+        type: Float64
   Quaternion:
     arrow: Struct
     description: "Quaternion with x, y, z, w Float64 fields"
+    fields:
+      - name: x
+        type: Float64
+      - name: "y"
+        type: Float64
+      - name: z
+        type: Float64
+      - name: w
+        type: Float64
   Pose:
     arrow: Struct
     description: "6-DOF pose (position Vector3 + orientation Quaternion)"

--- a/types/std/media/v1.yml
+++ b/types/std/media/v1.yml
@@ -2,12 +2,38 @@ types:
   Image:
     arrow: Struct
     description: "Raw image with width, height, encoding, data fields"
+    fields:
+      - name: width
+        type: UInt32
+      - name: height
+        type: UInt32
+      - name: encoding
+        type: Utf8
+      - name: data
+        type: LargeBinary
   CompressedImage:
     arrow: LargeBinary
     description: "JPEG/PNG compressed image bytes"
   PointCloud:
     arrow: Struct
     description: "3D point cloud with XYZ coordinates and optional fields"
+    fields:
+      - name: points
+        type: LargeBinary
+      - name: width
+        type: UInt32
+      - name: height
+        type: UInt32
   AudioFrame:
     arrow: Struct
     description: "Audio samples with sample_rate, channels, data fields"
+    params:
+      - name: sample_type
+        default: f32
+    fields:
+      - name: sample_rate
+        type: UInt32
+      - name: channels
+        type: UInt32
+      - name: data
+        type: LargeBinary

--- a/types/std/vision/v1.yml
+++ b/types/std/vision/v1.yml
@@ -2,6 +2,19 @@ types:
   BoundingBox:
     arrow: Struct
     description: "2D bounding box with x, y, width, height, confidence, label"
+    fields:
+      - name: x
+        type: Float32
+      - name: "y"
+        type: Float32
+      - name: width
+        type: Float32
+      - name: height
+        type: Float32
+      - name: confidence
+        type: Float32
+      - name: label
+        type: Utf8
   Detection:
     arrow: Struct
     description: "Object detection result (list of BoundingBox)"


### PR DESCRIPTION
## Summary

- Wire comprehensive type checking into `adora build` and `adora validate` across 8 phases:
  - **Phase 1**: `--strict-types` flag on build/validate, `strict_types` YAML field, timer auto-typing
  - **Phase 2**: Parameterized types (`AudioFrame[sample_type=f32]`) with struct field schemas
  - **Phase 3**: Type inference across edges (upstream annotation propagates downstream)
  - **Phase 4**: Compatibility graph with widening rules (UInt8->UInt32->UInt64, etc.) + user-defined `type_rules`
  - **Phase 5**: Metadata pattern validation (`service-server`, `action-client`, etc.) via `output_metadata` and `pattern` fields
  - **Phase 6**: Arrow schema field-level compatibility (missing fields, wrong types)
  - **Phase 7**: User-defined type packages from `types/` directory with URN derivation
  - **Phase 8**: Feature-gated Rust source inference via `syn` AST scanning (`type-inference` feature)
- All checks backward compatible -- unannotated ports remain fully dynamic
- Updated docs: `types.md` (major rewrite), `cli.md`, `yaml-spec.md`, `README.md`

## Test plan

- [x] 98 core tests pass (`cargo test -p adora-core`)
- [x] 4 inference tests pass (`cargo test -p adora-core --features type-inference`)
- [x] CLI tests pass (`cargo test -p adora-cli`)
- [x] Clippy clean (`cargo clippy -p adora-core -p adora-cli`)
- [x] Format clean (`cargo fmt --all -- --check`)
- [ ] CI passes
- [ ] Smoke test with example dataflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)