### PR TITLE
feat: add streaming pattern for voice/real-time apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 
 ### Ecosystem
 
-- **Communication patterns** -- built-in [service (request/reply)](docs/patterns.md#2-service-requestreply) and [action (goal/feedback/result)](docs/patterns.md#3-action-goalfeedbackresult) patterns via well-known metadata keys; no daemon or YAML changes required
+- **Communication patterns** -- built-in [service (request/reply)](docs/patterns.md#2-service-requestreply), [action (goal/feedback/result)](docs/patterns.md#3-action-goalfeedbackresult), and [streaming (session/segment/chunk)](docs/patterns.md#4-streaming-sessionsegmentchunk) patterns via well-known metadata keys; no daemon or YAML changes required
 - **ROS2 bridge** -- bidirectional interop with ROS2 topics, services, and actions; QoS mapping; Arrow-native type conversion
 - **Pre-packaged nodes** -- [node hub](https://github.com/dora-rs/dora-hub/) with ready-made nodes for cameras, YOLO, LLMs, TTS, and more
 - **In-process operators** -- lightweight functions that run inside a shared runtime, avoiding per-node process overhead for simple transformations

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -99,18 +99,32 @@ impl Scheduler {
     }
 
     pub(crate) fn add_event(&mut self, event: EventItem) {
-        let event_id = match &event {
+        let (event_id, should_flush) = match &event {
             EventItem::NodeEvent {
-                event:
-                    NodeEvent::Input {
-                        id,
-                        metadata: _,
-                        data: _,
-                    },
-                ack_channel: _,
-            } => id,
-            _ => &DataId::from(NON_INPUT_EVENT.to_string()),
+                event: NodeEvent::Input { id, metadata, .. },
+                ..
+            } => {
+                let flush = adora_message::metadata::get_bool_param(
+                    &metadata.parameters,
+                    adora_message::metadata::FLUSH,
+                ) == Some(true);
+                (id, flush)
+            }
+            _ => (&DataId::from(NON_INPUT_EVENT.to_string()), false),
         };
+
+        // Flush older queued messages when flush=true is present
+        if should_flush {
+            if let Some((_size, queue)) = self.event_queues.get_mut(event_id) {
+                let drained = queue.len();
+                queue.clear();
+                if drained > 0 {
+                    tracing::debug!(
+                        "Flushed {drained} queued event(s) for input `{event_id}` (flush signal)"
+                    );
+                }
+            }
+        }
 
         // Enforce queue size limit
         let (size, queue) = self
@@ -159,5 +173,107 @@ impl Scheduler {
         self.event_queues
             .iter()
             .all(|(_id, (_size, queue))| queue.is_empty())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::uhlc;
+    use adora_message::{
+        daemon_to_node::NodeEvent,
+        metadata::{ArrowTypeInfo, FLUSH, Metadata, MetadataParameters, Parameter},
+    };
+    use arrow_schema::DataType;
+
+    fn make_input(id: &str, params: MetadataParameters) -> EventItem {
+        let type_info = ArrowTypeInfo {
+            data_type: DataType::Null,
+            len: 0,
+            null_count: 0,
+            validity: None,
+            offset: 0,
+            buffer_offsets: vec![],
+            child_data: vec![],
+        };
+        let ts = uhlc::HLC::default().new_timestamp();
+        let metadata = Metadata::from_parameters(ts, type_info, params);
+        let (tx, _rx) = flume::bounded(1);
+        EventItem::NodeEvent {
+            event: NodeEvent::Input {
+                id: DataId::from(id.to_string()),
+                metadata,
+                data: None,
+            },
+            ack_channel: tx,
+        }
+    }
+
+    fn make_scheduler(audio_capacity: usize) -> (Scheduler, DataId) {
+        let id = DataId::from("audio".to_string());
+        let mut queues = HashMap::new();
+        queues.insert(id.clone(), (audio_capacity, VecDeque::new()));
+        queues.insert(
+            DataId::from(NON_INPUT_EVENT.to_string()),
+            (10, VecDeque::new()),
+        );
+        (Scheduler::new(queues), id)
+    }
+
+    #[test]
+    fn flush_clears_older_queued_events() {
+        let (mut sched, id) = make_scheduler(10);
+
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        assert_eq!(sched.event_queues[&id].1.len(), 3);
+
+        // Flush should clear the 3 older events, then insert itself
+        let mut flush_params = MetadataParameters::new();
+        flush_params.insert(FLUSH.into(), Parameter::Bool(true));
+        sched.add_event(make_input("audio", flush_params));
+
+        assert_eq!(sched.event_queues[&id].1.len(), 1);
+    }
+
+    #[test]
+    fn non_flush_does_not_clear_queue() {
+        let (mut sched, id) = make_scheduler(10);
+
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        assert_eq!(sched.event_queues[&id].1.len(), 3);
+    }
+
+    #[test]
+    fn flush_false_does_not_clear_queue() {
+        let (mut sched, id) = make_scheduler(10);
+
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+
+        let mut params = MetadataParameters::new();
+        params.insert(FLUSH.into(), Parameter::Bool(false));
+        sched.add_event(make_input("audio", params));
+
+        assert_eq!(sched.event_queues[&id].1.len(), 3);
+    }
+
+    #[test]
+    fn flush_with_queue_size_one_retains_flush_message() {
+        let (mut sched, id) = make_scheduler(1);
+
+        sched.add_event(make_input("audio", MetadataParameters::new()));
+        assert_eq!(sched.event_queues[&id].1.len(), 1);
+
+        // Flush clears the queue, then the flush message itself is inserted
+        let mut flush_params = MetadataParameters::new();
+        flush_params.insert(FLUSH.into(), Parameter::Bool(true));
+        sched.add_event(make_input("audio", flush_params));
+
+        // The flush message should survive (queue was cleared to 0, then inserted)
+        assert_eq!(sched.event_queues[&id].1.len(), 1);
     }
 }

--- a/apis/rust/node/src/lib.rs
+++ b/apis/rust/node/src/lib.rs
@@ -91,9 +91,9 @@ pub use adora_core::{self, uhlc};
 pub use adora_message::{
     DataflowId,
     metadata::{
-        self, GOAL_ID, GOAL_STATUS, GOAL_STATUS_ABORTED, GOAL_STATUS_CANCELED,
-        GOAL_STATUS_SUCCEEDED, Metadata, MetadataParameters, Parameter, REQUEST_ID,
-        get_string_param,
+        self, FIN, FLUSH, GOAL_ID, GOAL_STATUS, GOAL_STATUS_ABORTED, GOAL_STATUS_CANCELED,
+        GOAL_STATUS_SUCCEEDED, Metadata, MetadataParameters, Parameter, REQUEST_ID, SEGMENT_ID,
+        SEQ, SESSION_ID, get_bool_param, get_integer_param, get_string_param,
     },
 };
 use adora_message::{
@@ -112,7 +112,7 @@ pub use flume::Receiver;
 pub use futures;
 #[cfg(feature = "tracing")]
 pub use node::init_tracing;
-pub use node::{AdoraNode, DataSample, ZERO_COPY_THRESHOLD, arrow_utils};
+pub use node::{AdoraNode, DataSample, StreamSegment, ZERO_COPY_THRESHOLD, arrow_utils};
 pub use uuid;
 
 pub use serde_json;

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -23,7 +23,10 @@ use adora_core::{
 use adora_message::{
     DataflowId,
     daemon_to_node::{DaemonCommunication, DaemonReply, NodeConfig},
-    metadata::{ArrowTypeInfo, Metadata, MetadataParameters},
+    metadata::{
+        ArrowTypeInfo, FIN, FLUSH, Metadata, MetadataParameters, Parameter, SEGMENT_ID, SEQ,
+        SESSION_ID,
+    },
     node_to_daemon::{DaemonRequest, DataMessage, DropToken, Timestamped},
 };
 use aligned_vec::{AVec, ConstAlign};
@@ -989,6 +992,23 @@ impl AdoraNode {
         self.send_output(output_id, parameters, data)
     }
 
+    // -----------------------------------------------------------------
+    // Streaming helpers
+    // -----------------------------------------------------------------
+
+    /// Send a streaming segment chunk. Convenience wrapper around
+    /// [`send_output`](Self::send_output) that builds metadata from the
+    /// [`StreamSegment`] builder.
+    pub fn send_stream_chunk(
+        &mut self,
+        output_id: DataId,
+        segment: &mut StreamSegment,
+        fin: bool,
+        data: impl Array,
+    ) -> NodeResult<()> {
+        self.send_output(output_id, segment.chunk(fin), data)
+    }
+
     /// Allocates a [`DataSample`] of the specified size.
     ///
     /// The data sample will use shared memory when suitable to enable efficient data transfer
@@ -1293,6 +1313,95 @@ pub fn init_tracing(
     Ok(guard)
 }
 
+/// Builder for streaming segment metadata.
+///
+/// Manages session/segment IDs and auto-incrementing sequence numbers
+/// for real-time streaming patterns (voice, video, sensor streams).
+pub struct StreamSegment {
+    session_id: String,
+    segment_id: i64,
+    seq: i64,
+}
+
+impl StreamSegment {
+    /// Start a new session with a generated session ID and segment 0.
+    pub fn new() -> Self {
+        Self {
+            session_id: AdoraNode::new_request_id(),
+            segment_id: 0,
+            seq: 0,
+        }
+    }
+
+    /// Start a new session with an explicit session ID.
+    pub fn with_session_id(session_id: String) -> Self {
+        Self {
+            session_id,
+            segment_id: 0,
+            seq: 0,
+        }
+    }
+
+    /// Advance to a new segment (resets seq to 0). Returns the new segment_id.
+    pub fn next_segment(&mut self) -> i64 {
+        self.segment_id += 1;
+        self.seq = 0;
+        self.segment_id
+    }
+
+    /// Build metadata parameters for a chunk. Auto-increments seq.
+    pub fn chunk(&mut self, fin: bool) -> MetadataParameters {
+        let mut params = MetadataParameters::new();
+        params.insert(
+            SESSION_ID.into(),
+            Parameter::String(self.session_id.clone()),
+        );
+        params.insert(SEGMENT_ID.into(), Parameter::Integer(self.segment_id));
+        params.insert(SEQ.into(), Parameter::Integer(self.seq));
+        params.insert(FIN.into(), Parameter::Bool(fin));
+        self.seq += 1;
+        params
+    }
+
+    /// Build metadata for a flush message (new segment, discards older queued data).
+    ///
+    /// Advances to a new segment, then emits a chunk with `flush=true` and
+    /// `fin=false`. The prior segment ends without a `fin=true` signal -- this
+    /// is intentional for interruption semantics (the old data is being
+    /// discarded, not completed).
+    ///
+    /// **Note**: flush discards *all* queued messages on the receiver's input
+    /// regardless of `session_id`. Do not multiplex independent sessions on a
+    /// single `DataId` when using flush.
+    pub fn flush(&mut self) -> MetadataParameters {
+        self.next_segment();
+        let mut params = self.chunk(false);
+        params.insert(FLUSH.into(), Parameter::Bool(true));
+        params
+    }
+
+    /// Returns the session ID.
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Returns the current segment ID.
+    pub fn segment_id(&self) -> i64 {
+        self.segment_id
+    }
+
+    /// Returns the sequence number that will be used by the next `chunk()` call.
+    pub fn seq(&self) -> i64 {
+        self.seq
+    }
+}
+
+impl Default for StreamSegment {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1398,5 +1507,89 @@ mod tests {
         let outputs: Vec<_> = rx.try_iter().collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "response");
+    }
+
+    #[test]
+    fn stream_segment_new_generates_valid_session_id() {
+        let seg = StreamSegment::new();
+        uuid::Uuid::parse_str(seg.session_id()).expect("session_id should be valid UUID");
+        assert_eq!(seg.segment_id(), 0);
+    }
+
+    #[test]
+    fn stream_segment_with_session_id() {
+        let seg = StreamSegment::with_session_id("my-session".into());
+        assert_eq!(seg.session_id(), "my-session");
+        assert_eq!(seg.segment_id(), 0);
+        assert_eq!(seg.seq(), 0);
+    }
+
+    #[test]
+    fn stream_segment_seq_accessor_tracks_next_seq() {
+        let mut seg = StreamSegment::with_session_id("s1".into());
+        assert_eq!(seg.seq(), 0);
+        seg.chunk(false);
+        assert_eq!(seg.seq(), 1);
+        seg.chunk(false);
+        assert_eq!(seg.seq(), 2);
+        seg.next_segment();
+        assert_eq!(seg.seq(), 0);
+    }
+
+    #[test]
+    fn stream_segment_chunk_auto_increments_seq() {
+        let mut seg = StreamSegment::with_session_id("s1".into());
+        let p0 = seg.chunk(false);
+        let p1 = seg.chunk(false);
+        let p2 = seg.chunk(true);
+
+        assert_eq!(p0.get(SEQ), Some(&Parameter::Integer(0)));
+        assert_eq!(p1.get(SEQ), Some(&Parameter::Integer(1)));
+        assert_eq!(p2.get(SEQ), Some(&Parameter::Integer(2)));
+        assert_eq!(p0.get(FIN), Some(&Parameter::Bool(false)));
+        assert_eq!(p2.get(FIN), Some(&Parameter::Bool(true)));
+        assert_eq!(p0.get(SESSION_ID), Some(&Parameter::String("s1".into())));
+        assert_eq!(p0.get(SEGMENT_ID), Some(&Parameter::Integer(0)));
+    }
+
+    #[test]
+    fn stream_segment_next_segment_resets_seq() {
+        let mut seg = StreamSegment::with_session_id("s1".into());
+        seg.chunk(false); // seq=0
+        seg.chunk(false); // seq=1
+        let new_id = seg.next_segment();
+        assert_eq!(new_id, 1);
+        assert_eq!(seg.segment_id(), 1);
+
+        let p = seg.chunk(false);
+        assert_eq!(p.get(SEQ), Some(&Parameter::Integer(0)));
+        assert_eq!(p.get(SEGMENT_ID), Some(&Parameter::Integer(1)));
+    }
+
+    #[test]
+    fn stream_segment_flush_advances_segment_and_sets_flush() {
+        let mut seg = StreamSegment::with_session_id("s1".into());
+        seg.chunk(false);
+        let p = seg.flush();
+        assert_eq!(seg.segment_id(), 1);
+        assert_eq!(p.get(FLUSH), Some(&Parameter::Bool(true)));
+        assert_eq!(p.get(SEGMENT_ID), Some(&Parameter::Integer(1)));
+        // flush resets seq, then chunk increments it to 1
+        assert_eq!(p.get(SEQ), Some(&Parameter::Integer(0)));
+    }
+
+    #[test]
+    fn send_stream_chunk_sends_output() {
+        let (mut node, events, rx) = test_node();
+        let mut seg = StreamSegment::with_session_id("s1".into());
+
+        node.send_stream_chunk("audio".into(), &mut seg, false, NullArray::new(0))
+            .unwrap();
+
+        drop(node);
+        drop(events);
+        let outputs: Vec<_> = rx.try_iter().collect();
+        assert_eq!(outputs.len(), 1);
+        assert_eq!(outputs[0]["id"], "audio");
     }
 }

--- a/docs/api-cxx.md
+++ b/docs/api-cxx.md
@@ -249,15 +249,20 @@ enum class MetadataValueType : uint8_t {
 };
 ```
 
-### Service and Action Patterns
+### Service, Action, and Streaming Patterns
 
-C++ nodes can implement [service and action patterns](patterns.md) using the metadata API. The well-known metadata keys are:
+C++ nodes can implement [communication patterns](patterns.md) using the metadata API. The well-known metadata keys are:
 
 | Key | Description |
 |-----|-------------|
 | `"request_id"` | Service request/response correlation (UUID v7) |
 | `"goal_id"` | Action goal identification (UUID v7) |
 | `"goal_status"` | Action result status: `"succeeded"`, `"aborted"`, or `"canceled"` |
+| `"session_id"` | Streaming session identifier |
+| `"segment_id"` | Streaming segment within a session (integer) |
+| `"seq"` | Streaming chunk sequence number (integer) |
+| `"fin"` | Last chunk of a streaming segment (bool) |
+| `"flush"` | Discard older queued messages on input (bool) |
 
 ```cpp
 // Service server: pass through request_id from input metadata

--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -156,9 +156,9 @@ node.send_output("image", pa.array(pixels), {"camera_id": "front"})
 
 **Raises:** `RuntimeError` if `data` is neither `bytes` nor a `pyarrow.Array`.
 
-##### Service and action patterns
+##### Service, action, and streaming patterns
 
-Python nodes use the same metadata key conventions as Rust for [service and action patterns](patterns.md). Parameters are plain dicts with string keys.
+Python nodes use the same metadata key conventions as Rust for [communication patterns](patterns.md). Parameters are plain dicts with string keys.
 
 **Well-known metadata keys:**
 
@@ -167,6 +167,11 @@ Python nodes use the same metadata key conventions as Rust for [service and acti
 | `"request_id"` | Service request/response correlation (UUID v7) |
 | `"goal_id"` | Action goal identification (UUID v7) |
 | `"goal_status"` | Action result status: `"succeeded"`, `"aborted"`, or `"canceled"` |
+| `"session_id"` | Streaming session identifier |
+| `"segment_id"` | Streaming segment within a session (integer) |
+| `"seq"` | Streaming chunk sequence number (integer) |
+| `"fin"` | Last chunk of a streaming segment (bool) |
+| `"flush"` | Discard older queued messages on input (bool) |
 
 **Service client example:**
 
@@ -190,6 +195,19 @@ node.send_output("response", result, event["metadata"])
 ```python
 goal_id = str(uuid.uuid7())
 node.send_output("goal", data, {"goal_id": goal_id})
+```
+
+**Streaming example** (flush downstream queues on user interruption):
+
+```python
+params = {
+    "session_id": session_id,
+    "segment_id": 1,
+    "seq": 0,
+    "fin": False,
+    "flush": True,
+}
+node.send_output("text", data, metadata={"parameters": params})
 ```
 
 See [patterns.md](patterns.md) for the full guide.

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -111,9 +111,9 @@ pub fn send_output_sample(
 pub fn close_outputs(&mut self, outputs_ids: Vec<DataId>) -> NodeResult<()>
 ```
 
-#### Service and Action Helpers
+#### Service, Action, and Streaming Helpers
 
-Higher-level methods for the [service and action communication patterns](patterns.md). These use well-known metadata keys to correlate requests, goals, and responses.
+Higher-level methods for the [communication patterns](patterns.md). These use well-known metadata keys to correlate requests, goals, responses, and streaming segments.
 
 ```rust
 // Generate a unique, time-ordered ID (UUID v7) for correlation.
@@ -158,6 +158,23 @@ node.send_output("goal".into(), params, data)?;
 
 // Server: extract goal_id, send feedback/result with goal_status
 let gid = get_string_param(&metadata.parameters, GOAL_ID);
+```
+
+**Streaming example** (real-time voice/video pipeline with interruption):
+```rust
+use adora_node_api::StreamSegment;
+
+// Create a streaming segment builder (auto-generates session_id)
+let mut seg = StreamSegment::new();
+
+// Send chunks with auto-incrementing seq
+node.send_stream_chunk("text".into(), &mut seg, false, chunk_data)?;
+// Mark final chunk of a segment
+node.send_stream_chunk("text".into(), &mut seg, true, last_chunk)?;
+
+// On user interruption: flush downstream queues and start a new segment
+let flush_params = seg.flush();
+node.send_output("text".into(), flush_params, empty_data)?;
 ```
 
 See [patterns.md](patterns.md) for the full guide and [examples/service-example](../examples/service-example) and [examples/action-example](../examples/action-example) for working code.
@@ -331,11 +348,13 @@ pub enum Parameter {
     Timestamp(DateTime<Utc>),
 }
 
-// Extract a string parameter, returning None if missing or non-String.
+// Extract typed parameters, returning None if missing or wrong type.
 pub fn get_string_param<'a>(params: &'a MetadataParameters, key: &str) -> Option<&'a str>
+pub fn get_integer_param(params: &MetadataParameters, key: &str) -> Option<i64>
+pub fn get_bool_param(params: &MetadataParameters, key: &str) -> Option<bool>
 ```
 
-**Well-known metadata keys** (for [service and action patterns](patterns.md)):
+**Well-known metadata keys** (for [communication patterns](patterns.md)):
 
 | Constant | Value | Used by |
 |----------|-------|---------|
@@ -345,6 +364,11 @@ pub fn get_string_param<'a>(params: &'a MetadataParameters, key: &str) -> Option
 | `GOAL_STATUS_SUCCEEDED` | `"succeeded"` | Goal completed successfully |
 | `GOAL_STATUS_ABORTED` | `"aborted"` | Goal aborted by server |
 | `GOAL_STATUS_CANCELED` | `"canceled"` | Goal canceled by client |
+| `SESSION_ID` | `"session_id"` | Streaming session identifier |
+| `SEGMENT_ID` | `"segment_id"` | Streaming segment within a session |
+| `SEQ` | `"seq"` | Streaming chunk sequence number |
+| `FIN` | `"fin"` | Last chunk of a streaming segment |
+| `FLUSH` | `"flush"` | Discard older queued messages on input |
 
 All constants are re-exported from `adora_node_api`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -401,6 +401,11 @@ pub enum Parameter {
 | `request_id` | Service request/reply correlation |
 | `goal_id` | Action goal identifier |
 | `goal_status` | Action completion: `succeeded`, `aborted`, `canceled` |
+| `session_id` | Streaming session identifier |
+| `segment_id` | Streaming segment within a session |
+| `seq` | Streaming chunk sequence number |
+| `fin` | Last chunk of a streaming segment |
+| `flush` | Discard older queued messages on input |
 
 ## Zero-Copy Shared Memory
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -1,10 +1,11 @@
 # Communication Patterns
 
 Adora is a dataflow framework based on pub/sub message passing. On top of
-basic topics, the framework supports **service** (request/reply) and **action**
-(goal/feedback/result) patterns using well-known metadata keys. No changes to
-the daemon, coordinator, or YAML syntax are required -- the patterns are
-implemented as conventions at the node API level.
+basic topics, the framework supports **service** (request/reply), **action**
+(goal/feedback/result), and **streaming** (session/segment/chunk) patterns
+using well-known metadata keys. No changes to the daemon, coordinator, or
+YAML syntax are required -- the patterns are implemented as conventions at
+the node API level.
 
 ## 1. Topic (pub/sub)
 
@@ -118,21 +119,105 @@ sends a result with `goal_status = "canceled"`.
 
 **Example**: `examples/action-example/`
 
-## 4. Choosing a pattern
+## 4. Streaming (session/segment/chunk)
 
-| Need a response? | Long-running? | Cancelable? | Pattern |
-|:-:|:-:|:-:|---------|
-| No | - | - | **Topic** |
-| Yes | No | No | **Service** |
-| Yes | Yes | Optional | **Action** |
+For real-time pipelines (voice, video, sensor streams) where a user can
+interrupt mid-stream and queued data must be discarded.
 
-## 5. Important details
+### Well-known metadata keys
+
+| Key | Type | Constant | Description |
+|-----|------|----------|-------------|
+| `session_id` | String | `SESSION_ID` | Identifies the conversation/session |
+| `segment_id` | Integer | `SEGMENT_ID` | Logical unit within a session (e.g. one utterance) |
+| `seq` | Integer | `SEQ` | Chunk sequence number within a segment |
+| `fin` | Bool | `FIN` | `true` on the last chunk of a segment |
+| `flush` | Bool | `FLUSH` | `true` to discard older queued messages on this input |
+
+### YAML
+
+```yaml
+nodes:
+  - id: asr
+    inputs:
+      mic: mic-source/audio
+    outputs:
+      - text
+
+  - id: llm
+    inputs:
+      text: asr/text
+    outputs:
+      - tokens
+
+  - id: tts
+    inputs:
+      tokens: llm/tokens
+    outputs:
+      - audio
+```
+
+### Node API
+
+```rust
+use adora_node_api::{StreamSegment, AdoraNode};
+
+let mut seg = StreamSegment::new();
+
+// Send chunks with auto-incrementing seq (e.g. inside an ASR node)
+node.send_stream_chunk("text".into(), &mut seg, false, chunk_data)?;
+// Mark final chunk of a segment
+node.send_stream_chunk("text".into(), &mut seg, true, last_chunk)?;
+
+// On user interruption: flush downstream queues and start a new segment.
+// The prior segment ends without a fin=true signal -- old data is discarded.
+let flush_params = seg.flush();
+node.send_output("text".into(), flush_params, empty_data)?;
+```
+
+### Queue flush behavior
+
+When a message arrives with `flush: true` in its metadata, the
+receiver's input queue is cleared of all older messages before the
+flush message is delivered. This enables instant interruption in
+voice pipelines -- when the user speaks over TTS output, the ASR node
+sends a new segment with `flush: true`, and the TTS node immediately
+discards any queued audio chunks from the previous response.
+
+**Note**: flush discards *all* queued messages on the input regardless of
+`session_id`. Do not multiplex independent sessions on a single input
+when using flush.
+
+### Python
+
+```python
+# Streaming metadata is a plain dict
+params = {
+    "session_id": session_id,
+    "segment_id": 1,
+    "seq": 0,
+    "fin": False,
+    "flush": True,  # flush older queued messages
+}
+node.send_output("text", data, metadata={"parameters": params})
+```
+
+## 5. Choosing a pattern
+
+| Need a response? | Long-running? | Cancelable? | Real-time stream? | Pattern |
+|:-:|:-:|:-:|:-:|---------|
+| No | - | - | No | **Topic** |
+| Yes | No | No | No | **Service** |
+| Yes | Yes | Optional | No | **Action** |
+| No | Yes | Via flush | Yes | **Streaming** |
+
+## 6. Important details
 
 - **`goal_status` matching is case-sensitive.** Always use the exact lowercase
   values: `"succeeded"`, `"aborted"`, `"canceled"`. The ROS2 bridge defaults
   to `Aborted` for unrecognised values.
 
-## 6. Python compatibility
+## 7. Python compatibility
 
 Python nodes use the same metadata conventions. Parameters are plain dicts
 with string keys:

--- a/docs/python-guide.md
+++ b/docs/python-guide.md
@@ -227,6 +227,6 @@ Also available: `adora/timer/hz/30` for 30 Hz.
 ## Next Steps
 
 - [Python API Reference](api-python.md) -- full API docs for Node, Operator, DataflowBuilder, CUDA
-- [Communication Patterns](patterns.md) -- service (request/reply) and action (goal/feedback/result) patterns
+- [Communication Patterns](patterns.md) -- service (request/reply), action (goal/feedback/result), and streaming (session/segment/chunk) patterns
 - [Examples](../examples/) -- python-dataflow, python-async, python-drain, python-concurrent-rw, python-multiple-arrays
 - [Distributed Deployment](distributed-deployment.md) -- running across multiple machines with `adora up`

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -439,11 +439,12 @@ Required for `adora topic echo`, `adora topic hz`, and `adora topic info` comman
 
 ## Communication Patterns
 
-Adora supports three communication patterns built on top of the dataflow:
+Adora supports four communication patterns built on top of the dataflow:
 
 - **Topic** (default): pub/sub dataflow
 - **Service**: request/reply via `request_id` metadata
 - **Action**: goal/feedback/result via `goal_id`/`goal_status` metadata, with cancellation support
+- **Streaming**: session/segment/chunk via `session_id`/`segment_id`/`seq`/`fin`/`flush` metadata, with queue flush for interruption
 
 See [Communication Patterns](../../../docs/patterns.md) for details and examples.
 

--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -38,11 +38,9 @@ impl Metadata {
     }
 
     pub fn open_telemetry_context(&self) -> String {
-        if let Some(Parameter::String(otel)) = self.parameters.get("open_telemetry_context") {
-            otel.to_string()
-        } else {
-            "".to_string()
-        }
+        get_string_param(&self.parameters, "open_telemetry_context")
+            .unwrap_or("")
+            .to_string()
     }
 }
 
@@ -82,6 +80,24 @@ pub fn get_string_param<'a>(params: &'a MetadataParameters, key: &str) -> Option
     })
 }
 
+/// Extract an integer parameter from metadata, returning `None` if missing or
+/// not a `Parameter::Integer`.
+pub fn get_integer_param(params: &MetadataParameters, key: &str) -> Option<i64> {
+    params.get(key).and_then(|p| match p {
+        Parameter::Integer(n) => Some(*n),
+        _ => None,
+    })
+}
+
+/// Extract a bool parameter from metadata, returning `None` if missing or
+/// not a `Parameter::Bool`.
+pub fn get_bool_param(params: &MetadataParameters, key: &str) -> Option<bool> {
+    params.get(key).and_then(|p| match p {
+        Parameter::Bool(b) => Some(*b),
+        _ => None,
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Well-known metadata parameter keys for service and action patterns
 // ---------------------------------------------------------------------------
@@ -104,6 +120,25 @@ pub const GOAL_STATUS_ABORTED: &str = "aborted";
 /// Goal was canceled by the client.
 pub const GOAL_STATUS_CANCELED: &str = "canceled";
 
+// ---------------------------------------------------------------------------
+// Well-known metadata parameter keys for the streaming pattern
+// ---------------------------------------------------------------------------
+
+/// Metadata key identifying the conversation/session.
+pub const SESSION_ID: &str = "session_id";
+
+/// Metadata key for the logical segment within a session (e.g. one utterance).
+pub const SEGMENT_ID: &str = "segment_id";
+
+/// Metadata key for chunk sequence number within a segment.
+pub const SEQ: &str = "seq";
+
+/// Metadata key marking the last chunk of a segment (`true` on final chunk).
+pub const FIN: &str = "fin";
+
+/// Metadata key to discard older queued messages on this input (`true` to flush).
+pub const FLUSH: &str = "flush";
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BufferOffset {
     pub offset: usize,
@@ -124,11 +159,25 @@ mod tests {
         assert_eq!(GOAL_STATUS_SUCCEEDED, "succeeded");
         assert_eq!(GOAL_STATUS_ABORTED, "aborted");
         assert_eq!(GOAL_STATUS_CANCELED, "canceled");
+        assert_eq!(SESSION_ID, "session_id");
+        assert_eq!(SEGMENT_ID, "segment_id");
+        assert_eq!(SEQ, "seq");
+        assert_eq!(FIN, "fin");
+        assert_eq!(FLUSH, "flush");
     }
 
     #[test]
     fn well_known_keys_are_distinct() {
-        let keys = [REQUEST_ID, GOAL_ID, GOAL_STATUS];
+        let keys = [
+            REQUEST_ID,
+            GOAL_ID,
+            GOAL_STATUS,
+            SESSION_ID,
+            SEGMENT_ID,
+            SEQ,
+            FIN,
+            FLUSH,
+        ];
         for (i, a) in keys.iter().enumerate() {
             for b in &keys[i + 1..] {
                 assert_ne!(a, b);
@@ -163,5 +212,35 @@ mod tests {
         let mut params = MetadataParameters::default();
         params.insert("num".to_string(), Parameter::Integer(42));
         assert_eq!(get_string_param(&params, "num"), None);
+    }
+
+    #[test]
+    fn get_integer_param_extracts_integer() {
+        let mut params = MetadataParameters::default();
+        params.insert("key".to_string(), Parameter::Integer(42));
+        assert_eq!(get_integer_param(&params, "key"), Some(42));
+        assert_eq!(get_integer_param(&params, "missing"), None);
+    }
+
+    #[test]
+    fn get_integer_param_returns_none_for_non_integer() {
+        let mut params = MetadataParameters::default();
+        params.insert("s".to_string(), Parameter::String("hello".to_string()));
+        assert_eq!(get_integer_param(&params, "s"), None);
+    }
+
+    #[test]
+    fn get_bool_param_extracts_bool() {
+        let mut params = MetadataParameters::default();
+        params.insert("key".to_string(), Parameter::Bool(true));
+        assert_eq!(get_bool_param(&params, "key"), Some(true));
+        assert_eq!(get_bool_param(&params, "missing"), None);
+    }
+
+    #[test]
+    fn get_bool_param_returns_none_for_non_bool() {
+        let mut params = MetadataParameters::default();
+        params.insert("n".to_string(), Parameter::Integer(1));
+        assert_eq!(get_bool_param(&params, "n"), None);
     }
 }


### PR DESCRIPTION
## Summary

- Add **streaming pattern** (session/segment/chunk) as a new communication pattern alongside Service and Action
- Well-known metadata keys: session_id, segment_id, seq, fin, flush
- StreamSegment builder with auto-incrementing seq, segment advancement, and flush support
- Scheduler flush: when flush=true arrives, discard all older queued messages on that input
- get_integer_param and get_bool_param helpers in metadata
- Documentation updates across 8 files

## Test plan

- [x] cargo test -p adora-message -- 42 tests pass
- [x] cargo test -p adora-node-api -- 26 tests pass
- [x] cargo clippy clean, cargo fmt clean