### PR TITLE
feat: unified logging with adora/logs virtual input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ name = "adora-metrics"
 version = "0.4.1"
 dependencies = [
  "eyre",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-system-metrics",
  "opentelemetry_sdk",
@@ -337,7 +337,7 @@ dependencies = [
  "futures-timer",
  "inquire",
  "is-terminal",
- "opentelemetry 0.23.0",
+ "opentelemetry",
  "serde_json",
  "serde_yaml",
  "shared-memory-server",
@@ -615,7 +615,7 @@ name = "adora-tracing"
 version = "0.4.1"
 dependencies = [
  "eyre",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "tracing",
@@ -4399,20 +4399,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -4434,7 +4420,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "reqwest",
 ]
 
@@ -4445,7 +4431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
@@ -4463,7 +4449,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prost",
  "tonic",
@@ -4477,7 +4463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1ec890c1a190441ba7242ce2b31e03347ed5f61ad1de905e27ed3f5849d6c48"
 dependencies = [
  "eyre",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "sysinfo 0.35.2",
  "tokio",
  "tracing",
@@ -4492,7 +4478,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -6988,7 +6974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",

--- a/adora-schema.json
+++ b/adora-schema.json
@@ -176,11 +176,11 @@
       "additionalProperties": false
     },
     "Input": {
-      "description": "An input subscription. Either a short-form string (`node-id/output-id` or `adora/timer/millis/N`) or an object with `source`, `queue_size`, `queue_policy`, and `input_timeout`.",
+      "description": "An input subscription. Either a short-form string (`node-id/output-id`, `adora/timer/millis/N`, or `adora/logs[/level[/node]]`) or an object with `source`, `queue_size`, `queue_policy`, and `input_timeout`.",
       "anyOf": [
         {
           "type": "string",
-          "description": "Short form: `<node-id>/<output-id>` or `adora/timer/millis/<N>` or `adora/timer/hz/<N>`."
+          "description": "Short form: `<node-id>/<output-id>`, `adora/timer/millis/<N>`, `adora/timer/hz/<N>`, or `adora/logs[/<level>[/<node-id>]]`."
         },
         {
           "type": "object",

--- a/apis/python/node/adora/__init__.pyi
+++ b/apis/python/node/adora/__init__.pyi
@@ -80,6 +80,11 @@ class Node:
         """The custom node API lets you integrate `dora` into your application.
         It allows you to retrieve input and send output in any fashion you want.
 
+        Creating a Node automatically bridges Python's ``logging`` module to the
+        adora daemon. After ``Node()`` is created, ``logging.info()`` etc. produce
+        structured log entries that work with ``min_log_level``, ``send_logs_as``,
+        and ``adora/logs`` subscribers. No extra configuration needed.
+
         Use with:
 
         ```python
@@ -87,6 +92,38 @@ class Node:
 
         node = Node()
         ```"""
+
+    def log(
+        self,
+        level: str,
+        message: str,
+        target: typing.Optional[str] = None,
+        fields: typing.Optional[typing.Dict[str, str]] = None,
+    ) -> None:
+        """Send a structured log message.
+
+        Outputs a JSONL line to stdout that the daemon parses automatically.
+        Works with ``min_log_level`` filtering and ``send_logs_as`` routing.
+
+        :param level: Log level string (error, warn, info, debug, trace)
+        :param message: The log message
+        :param target: Optional target/module path
+        :param fields: Optional key-value pairs for structured context"""
+
+    def log_error(self, message: str) -> None:
+        """Log an error message. Shorthand for ``node.log("error", message)``."""
+
+    def log_warn(self, message: str) -> None:
+        """Log a warning message. Shorthand for ``node.log("warn", message)``."""
+
+    def log_info(self, message: str) -> None:
+        """Log an info message. Shorthand for ``node.log("info", message)``."""
+
+    def log_debug(self, message: str) -> None:
+        """Log a debug message. Shorthand for ``node.log("debug", message)``."""
+
+    def log_trace(self, message: str) -> None:
+        """Log a trace message. Shorthand for ``node.log("trace", message)``."""
 
     def dataflow_descriptor(self) -> dict:
         """Returns the full dataflow descriptor that this node is part of.

--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -36,37 +36,34 @@ fn runtime() -> PyResult<&'static Runtime> {
 }
 
 /// Consume a Python `logging.LogRecord` and emit a Rust `tracing::Event` instead.
+///
+/// Emits synchronously on the calling thread (no async needed since there are
+/// no `.await` points) and uses `Span::in_scope()` instead of `span.enter()`
+/// to avoid holding an `Entered` guard across thread boundaries.
 #[pyfunction]
 fn host_log<'py>(record: Bound<'py, PyAny>) -> PyResult<()> {
     let level = record.getattr("levelno")?.extract::<u8>()?;
     let message = record.getattr("getMessage")?.call0()?.to_string();
     let pathname = record.getattr("pathname")?.to_string();
-    let lineno = record.getattr("lineno")?.to_string();
+    let lineno = record.getattr("lineno")?.extract::<u32>().unwrap_or(0);
     let target = record.getattr("name")?.to_string();
 
-    runtime()?.spawn(async move {
-    if level.ge(&40u8) {
-        let span = span!(Level::ERROR, "adora.python.log.error", file=pathname, line=lineno, %target, %message);
-        let _enter = span.enter();
-        tracing::event!(tracing::Level::ERROR, file=pathname, line=lineno, %target, %message);
-    } else if level.ge(&30u8) {
-        let span = span!(Level::WARN, "adora.python.log.warn", file=pathname, line=lineno, %target, %message);
-        let _enter = span.enter();
-        tracing::event!(tracing::Level::WARN, file=pathname, line=lineno, %target, %message);
-    } else if level.ge(&20u8){
-        let span = span!(Level::INFO, "adora.python.log.info", file=pathname, line=lineno, %target, %message);
-        let _enter = span.enter();
-        tracing::event!(tracing::Level::INFO, file=pathname, line=lineno, %target, %message);
-    } else if level.ge(&10u8) {
-        let span = span!(Level::DEBUG, "adora.python.log.debug", file=pathname, line=lineno, %target, %message);
-        let _enter = span.enter();
-        tracing::event!(tracing::Level::DEBUG, file=pathname, line=lineno, %target, %message);
+    if level >= 40 {
+        span!(Level::ERROR, "adora.python.log.error", file = pathname, line = lineno, %target, %message)
+            .in_scope(|| tracing::event!(tracing::Level::ERROR, file = pathname, line = lineno, %target, %message));
+    } else if level >= 30 {
+        span!(Level::WARN, "adora.python.log.warn", file = pathname, line = lineno, %target, %message)
+            .in_scope(|| tracing::event!(tracing::Level::WARN, file = pathname, line = lineno, %target, %message));
+    } else if level >= 20 {
+        span!(Level::INFO, "adora.python.log.info", file = pathname, line = lineno, %target, %message)
+            .in_scope(|| tracing::event!(tracing::Level::INFO, file = pathname, line = lineno, %target, %message));
+    } else if level >= 10 {
+        span!(Level::DEBUG, "adora.python.log.debug", file = pathname, line = lineno, %target, %message)
+            .in_scope(|| tracing::event!(tracing::Level::DEBUG, file = pathname, line = lineno, %target, %message));
     } else {
-        let span = span!(Level::TRACE, "adora.python.log.trace", file=pathname, line=lineno, %target, %message);
-        let _enter = span.enter();
-        tracing::event!(tracing::Level::TRACE, file=pathname, line=lineno, %target, %message);
+        span!(Level::TRACE, "adora.python.log.trace", file = pathname, line = lineno, %target, %message)
+            .in_scope(|| tracing::event!(tracing::Level::TRACE, file = pathname, line = lineno, %target, %message));
     }
-    });
     Ok(())
 }
 
@@ -411,6 +408,61 @@ impl Node {
         self.node
             .get_mut()
             .log_with_fields(level, message, target, ordered.as_ref());
+    }
+
+    /// Log an error message.
+    ///
+    /// Shorthand for ``node.log("error", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_error(&self, message: &str) {
+        self.node.get_mut().log_error(message);
+    }
+
+    /// Log a warning message.
+    ///
+    /// Shorthand for ``node.log("warn", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_warn(&self, message: &str) {
+        self.node.get_mut().log_warn(message);
+    }
+
+    /// Log an info message.
+    ///
+    /// Shorthand for ``node.log("info", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_info(&self, message: &str) {
+        self.node.get_mut().log_info(message);
+    }
+
+    /// Log a debug message.
+    ///
+    /// Shorthand for ``node.log("debug", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_debug(&self, message: &str) {
+        self.node.get_mut().log_debug(message);
+    }
+
+    /// Log a trace message.
+    ///
+    /// Shorthand for ``node.log("trace", message)``.
+    ///
+    /// :param message: The log message
+    /// :type message: str
+    /// :rtype: None
+    pub fn log_trace(&self, message: &str) {
+        self.node.get_mut().log_trace(message);
     }
 
     /// Returns the full dataflow descriptor that this node is part of.

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 
 [features]
 default = ["tracing", "metrics"]
-tracing = ["dep:adora-tracing"]
+tracing = ["dep:adora-tracing", "dep:opentelemetry"]
 metrics = ["dep:adora-metrics"]
 
 [dependencies]
@@ -26,7 +26,7 @@ bincode = "1.3.3"
 shared_memory_extended = "0.13.0"
 adora-tracing = { workspace = true, optional = true }
 adora-metrics = { workspace = true, optional = true }
-opentelemetry = { version = "0.23.0", optional = true }
+opentelemetry = { version = "0.31.0", optional = true }
 arrow = { workspace = true }
 futures = "0.3.28"
 futures-concurrency = "7.3.0"

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -778,11 +778,29 @@ impl AdoraNode {
         &mut self,
         output_id: DataId,
         type_info: ArrowTypeInfo,
-        parameters: MetadataParameters,
+        #[allow(unused_mut)] mut parameters: MetadataParameters,
         sample: Option<DataSample>,
     ) -> NodeResult<()> {
         if !self.interactive {
             self.handle_finished_drop_tokens()?;
+        }
+
+        // Auto-inject OpenTelemetry trace context when telemetry is enabled.
+        // Uses the ambient OTel context, which is populated when the tracing
+        // subscriber has an OpenTelemetry layer (e.g., via with_otlp_tracing).
+        // Only trace/span IDs are propagated (via W3C TraceContext propagator).
+        // OTel Baggage is NOT propagated to avoid leaking sensitive data across
+        // node boundaries. If a user explicitly provides this key, it wins.
+        #[cfg(feature = "tracing")]
+        if !parameters.contains_key("open_telemetry_context") {
+            let cx = opentelemetry::Context::current();
+            let serialized = adora_tracing::telemetry::serialize_context(&cx);
+            if !serialized.is_empty() {
+                parameters.insert(
+                    "open_telemetry_context".to_string(),
+                    crate::Parameter::String(serialized),
+                );
+            }
         }
 
         let metadata = Metadata::from_parameters(self.clock.new_timestamp(), type_info, parameters);
@@ -865,6 +883,10 @@ impl AdoraNode {
         self.log_with_fields(level, message, target, None);
     }
 
+    /// Maximum total size of log fields before they are dropped (60 KB).
+    /// Matches the downstream 64 KB parse limit with headroom for the message envelope.
+    const MAX_LOG_FIELDS_BYTES: usize = 60 * 1024;
+
     /// Send a structured log message with optional key-value fields.
     ///
     /// Like [`log`](Self::log), but accepts additional structured fields that
@@ -896,7 +918,7 @@ impl AdoraNode {
         }
         if let Some(fields) = fields {
             let total: usize = fields.iter().map(|(k, v)| k.len() + v.len()).sum();
-            if total <= 48 * 1024 {
+            if total <= Self::MAX_LOG_FIELDS_BYTES {
                 entry["fields"] = serde_json::json!(fields);
             } else {
                 eprintln!("adora log: fields too large ({total} bytes), dropping fields");

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -248,6 +248,7 @@ fn build_input_info(node_desc: &adora_message::descriptor::Node) -> Vec<InputInf
                 InputMapping::Timer { interval } => {
                     format!("adora/timer/millis/{}", interval.as_millis())
                 }
+                mapping @ InputMapping::Logs(_) => mapping.to_string(),
             };
             InputInfo {
                 id: input_id.to_string(),

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1695,6 +1695,15 @@ impl Daemon {
                                 .or_default()
                                 .insert((node.id.clone(), input_id));
                         }
+                        InputMapping::Logs(filter) => {
+                            dataflow
+                                .log_subscribers
+                                .push(crate::running_dataflow::LogSubscriber {
+                                    node_id: node.id.clone(),
+                                    input_id,
+                                    filter,
+                                });
+                        }
                     }
                 } else if let InputMapping::User(mapping) = input.mapping {
                     dataflow
@@ -2715,6 +2724,89 @@ impl Daemon {
                     dataflow.subscribe_channels.remove(id);
                 }
             }
+            AdoraEvent::LogBroadcast {
+                dataflow_id,
+                log_message,
+            } => {
+                let Some(dataflow) = self.running.get_mut(&dataflow_id) else {
+                    return Ok(());
+                };
+
+                if dataflow.log_subscribers.is_empty() {
+                    return Ok(());
+                }
+
+                // Serialize to JSON once (shared across all subscribers)
+                let json = match serde_json::to_string(&log_message) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        tracing::warn!("failed to serialize LogMessage: {e}");
+                        return Ok(());
+                    }
+                };
+
+                // Convert to Arrow once, share the sample across subscribers
+                use adora_arrow_convert::IntoArrow;
+                let array = json.as_str().into_arrow();
+                let array: adora_node_api::arrow::array::ArrayData = array.into();
+                let total_len = adora_node_api::arrow_utils::required_data_size(&array);
+                let mut sample: aligned_vec::AVec<u8, aligned_vec::ConstAlign<128>> =
+                    aligned_vec::AVec::__from_elem(128, 0, total_len);
+                let type_info =
+                    adora_node_api::arrow_utils::copy_array_into_sample(&mut sample, &array);
+
+                let mut closed = Vec::new();
+                for sub in &dataflow.log_subscribers {
+                    // Apply level filter
+                    if let Some(min_level) = &sub.filter.min_level {
+                        if !log_message.level.passes(min_level) {
+                            continue;
+                        }
+                    }
+                    // Apply node filter
+                    if let Some(node_filter) = &sub.filter.node_filter {
+                        if log_message.node_id.as_ref() != Some(node_filter) {
+                            continue;
+                        }
+                    }
+                    // Don't deliver logs to the subscriber itself (avoid loops)
+                    if log_message.node_id.as_ref() == Some(&sub.node_id) {
+                        continue;
+                    }
+
+                    let Some(channel) = dataflow.subscribe_channels.get(&sub.node_id) else {
+                        continue;
+                    };
+
+                    let metadata =
+                        metadata::Metadata::new(self.clock.new_timestamp(), type_info.clone());
+
+                    let send_result = send_with_timestamp(
+                        channel,
+                        NodeEvent::Input {
+                            id: sub.input_id.clone(),
+                            metadata,
+                            data: Some(DataMessage::Vec(sample.clone())),
+                        },
+                        &self.clock,
+                    );
+                    match send_result {
+                        Ok(()) => {
+                            dataflow.inc_pending(&sub.node_id);
+                        }
+                        Err(_) => {
+                            closed.push(sub.node_id.clone());
+                        }
+                    }
+                }
+                for id in &closed {
+                    dataflow.subscribe_channels.remove(id);
+                }
+                // Prune stale log subscribers whose channels were just removed
+                dataflow
+                    .log_subscribers
+                    .retain(|sub| !closed.contains(&sub.node_id));
+            }
             AdoraEvent::SpawnedNodeResult {
                 dataflow_id,
                 node_id,
@@ -3352,6 +3444,11 @@ pub enum AdoraEvent {
         output_id: OutputId,
         message: DataMessage,
         metadata: metadata::Metadata,
+    },
+    /// A parsed LogMessage from a node, to be fanned out to `adora/logs` subscribers.
+    LogBroadcast {
+        dataflow_id: DataflowId,
+        log_message: adora_message::common::LogMessage,
     },
     SpawnedNodeResult {
         dataflow_id: DataflowId,

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -144,6 +144,13 @@ pub(crate) struct DropTokenInformation {
     pub pending_nodes: BTreeSet<NodeId>,
 }
 
+/// A subscriber to the `adora/logs` virtual input.
+pub struct LogSubscriber {
+    pub node_id: NodeId,
+    pub input_id: DataId,
+    pub filter: adora_message::config::LogSubscriptionFilter,
+}
+
 pub struct RunningDataflow {
     pub(crate) id: uuid::Uuid,
     pub(crate) descriptor: Descriptor,
@@ -155,6 +162,8 @@ pub struct RunningDataflow {
     pub(crate) drop_channels: HashMap<NodeId, UnboundedSender<Timestamped<NodeDropEvent>>>,
     pub(crate) mappings: HashMap<OutputId, BTreeSet<(NodeId, DataId)>>,
     pub(crate) timers: BTreeMap<Duration, BTreeSet<(NodeId, DataId)>>,
+    /// Nodes subscribing to `adora/logs` virtual input.
+    pub(crate) log_subscribers: Vec<LogSubscriber>,
     pub(crate) open_inputs: BTreeMap<NodeId, BTreeSet<DataId>>,
     pub(crate) input_deadlines: HashMap<(NodeId, DataId), InputDeadline>,
     pub(crate) broken_inputs: HashMap<(NodeId, DataId), Duration>,
@@ -204,6 +213,7 @@ impl RunningDataflow {
             drop_channels: HashMap::new(),
             mappings: HashMap::new(),
             timers: BTreeMap::new(),
+            log_subscribers: Vec::new(),
             open_inputs: BTreeMap::new(),
             input_deadlines: HashMap::new(),
             broken_inputs: HashMap::new(),

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -50,6 +50,20 @@ struct LogLine {
     stream: LogStream,
 }
 
+/// Maximum length of a single log line before truncation (1 MB).
+/// Prevents a malicious or buggy node from causing heap exhaustion via
+/// a single multi-GB stdout/stderr line.
+const MAX_LOG_LINE_BYTES: usize = 1024 * 1024;
+
+/// Truncate a log line to `MAX_LOG_LINE_BYTES`, respecting UTF-8 char boundaries.
+fn truncate_log_line(content: &mut String) {
+    if content.len() > MAX_LOG_LINE_BYTES {
+        let boundary = content.floor_char_boundary(MAX_LOG_LINE_BYTES);
+        content.truncate(boundary);
+        content.push_str("... [truncated]");
+    }
+}
+
 #[derive(Clone, Default)]
 struct RestartConfig {
     max_restarts: u32,
@@ -410,7 +424,7 @@ impl PreparedNode {
         if !dataflow_dir.exists() {
             std::fs::create_dir_all(&dataflow_dir).context("could not create dataflow_dir")?;
         }
-        let (tx, mut rx) = mpsc::channel::<LogLine>(10);
+        let (tx, mut rx) = mpsc::channel::<LogLine>(100);
         let mut file = File::create(log::log_path(
             &self.node_working_dir,
             &self.dataflow_id,
@@ -467,8 +481,8 @@ impl PreparedNode {
                     }
                 };
 
-                // send the buffered lines
-                let content = std::mem::take(&mut buffer);
+                let mut content = std::mem::take(&mut buffer);
+                truncate_log_line(&mut content);
                 let sent = stdout_tx
                     .send(LogLine {
                         content: content.clone(),
@@ -527,8 +541,8 @@ impl PreparedNode {
 
                 self.node_stderr_most_recent.force_push(new);
 
-                // send the buffered lines
-                let content = std::mem::take(&mut buffer);
+                let mut content = std::mem::take(&mut buffer);
+                truncate_log_line(&mut content);
                 let sent = stderr_tx
                     .send(LogLine {
                         content: content.clone(),
@@ -602,6 +616,7 @@ impl PreparedNode {
         } else {
             None
         };
+        let daemon_tx_log_broadcast = self.daemon_tx.clone();
         let working_dir_c = self.node_working_dir.clone();
         let uhlc = self.clock.clone();
         let mut logger_c = logger.try_clone().await?;
@@ -680,6 +695,23 @@ impl PreparedNode {
                 if let Some(min_level) = &min_log_level {
                     if !log_message.level.passes(min_level) {
                         continue;
+                    }
+                }
+
+                // Broadcast to adora/logs subscribers (try_send to avoid
+                // blocking the log processing task if the daemon queue is full)
+                {
+                    let event = AdoraEvent::LogBroadcast {
+                        dataflow_id,
+                        log_message: log_message.clone(),
+                    }
+                    .into();
+                    let event = Timestamped {
+                        inner: event,
+                        timestamp: uhlc.new_timestamp(),
+                    };
+                    if daemon_tx_log_broadcast.try_send(event).is_err() {
+                        tracing::debug!("adora/logs broadcast queue full, dropping log event");
                     }
                 }
 

--- a/docs/api-python.md
+++ b/docs/api-python.md
@@ -214,9 +214,34 @@ See [patterns.md](patterns.md) for the full guide.
 
 ---
 
+#### Logging
+
+Python nodes can log using either Python's built-in `logging` module (recommended) or the explicit node API.
+
+**Python `logging` module (auto-bridged):**
+
+When `Node()` is created, it automatically installs a handler that routes Python's `logging` module through the adora daemon. No configuration needed:
+
+```python
+import logging
+from dora import Node
+
+node = Node()  # Installs the logging bridge
+
+logging.info("Sensor initialized")       # -> structured "info" log entry
+logging.warning("High temperature")      # -> structured "warn" log entry
+logging.debug("Raw bytes: %s", data)     # -> structured "debug" log entry
+```
+
+These log entries are captured with full metadata (level, message, file path, line number) and work with `min_log_level` filtering, `send_logs_as` routing, and `adora/logs` subscribers.
+
+> **Note:** Do not call `logging.basicConfig()` before creating `Node()`. The constructor sets up the bridge; calling `basicConfig()` first may install a conflicting handler.
+
+**Explicit node API:**
+
 #### `log(level, message, target=None, fields=None)`
 
-Emit a structured log message routed through the adora daemon.
+Emit a structured log message with optional target and key-value fields.
 
 ```python
 node.log("info", "Processing frame", target="vision")
@@ -229,7 +254,32 @@ node.log("error", "Sensor timeout", fields={"sensor": "lidar", "retry": "3"})
 - `target` (str, optional) -- Target module or subsystem name.
 - `fields` (dict[str, str], optional) -- Structured key-value context fields.
 
-Works with the daemon's `min_log_level` filtering and `send_logs_as` routing.
+Works with the daemon's `min_log_level` filtering, `send_logs_as` routing, and `adora/logs` subscribers.
+
+---
+
+#### `log_error(message)`, `log_warn(message)`, `log_info(message)`, `log_debug(message)`, `log_trace(message)`
+
+Convenience methods for common log levels:
+
+```python
+node.log_error("Connection failed")
+node.log_warn("Temperature elevated")
+node.log_info("Sensor initialized")
+node.log_debug("Raw bytes received")
+node.log_trace("Entering loop iteration")
+```
+
+Each is equivalent to `node.log(level, message)`.
+
+**When to use which:**
+
+| Method | Structured? | Fields? | Best for |
+|--------|------------|---------|----------|
+| `logging.info()` | Yes | No | General-purpose logging |
+| `node.log("info", msg, fields={...})` | Yes | Yes | Structured context (sensor_id, etc.) |
+| `node.log_info(msg)` | Yes | No | Quick one-liner |
+| `print()` | No | No | Legacy code, quick debugging |
 
 ---
 

--- a/docs/api-rust.md
+++ b/docs/api-rust.md
@@ -211,7 +211,11 @@ pub fn dataflow_descriptor(&self) -> NodeResult<&Descriptor>
 
 #### Logging
 
-All log methods emit structured JSONL to stdout, which the daemon parses automatically. Works with `min_log_level` filtering and `send_logs_as` routing.
+Rust nodes have two ways to emit structured logs. Both produce identical structured log entries in the daemon.
+
+**Option 1: Node API (recommended for most cases)**
+
+All log methods emit structured JSONL to stdout, which the daemon parses automatically. Works with `min_log_level` filtering, `send_logs_as` routing, and `adora/logs` subscribers.
 
 ```rust
 // General structured log. Level: "error", "warn", "info", "debug", "trace".
@@ -233,6 +237,24 @@ pub fn log_info(&self, message: &str)
 pub fn log_debug(&self, message: &str)
 pub fn log_trace(&self, message: &str)
 ```
+
+**Option 2: Rust `tracing` crate**
+
+When adora's tracing subscriber is initialized (via `init_tracing()` or the default feature), `tracing::info!()` etc. output structured JSON to stdout that the daemon parses identically:
+
+```rust
+tracing::info!("Sensor started");
+tracing::warn!(sensor_id = "temp-01", "High temperature");
+```
+
+Use `tracing` when you want ecosystem integration (spans, instrumentation, OpenTelemetry). Use `node.log_*()` when you want explicit control or structured fields as `BTreeMap`.
+
+| Method | Structured? | Fields? | OpenTelemetry? | Best for |
+|--------|------------|---------|----------------|----------|
+| `node.log_info(msg)` | Yes | No | No | Quick one-liner |
+| `node.log_with_fields(...)` | Yes | Yes (BTreeMap) | No | Structured key-value context |
+| `tracing::info!(key = val, msg)` | Yes | Yes (spans) | Yes | Ecosystem integration, OTel |
+| `println!()` | No (`stdout` level) | No | No | Quick debugging |
 
 ---
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -2,6 +2,85 @@
 
 Adora provides a structured logging system for real-time robotics and AI dataflows. Logs are captured per-node as structured JSONL files, forwarded to the coordinator for live streaming, and optionally routed through the dataflow graph as data messages.
 
+## Which Logging Approach Should I Use?
+
+Start here if you're unsure which approach fits your use case.
+
+| I want to... | Approach | Config |
+|--------------|----------|--------|
+| **Log from Python** | Use Python's `logging` module (auto-bridged) | Nothing -- just `import logging` |
+| **Log from Rust** | Use `node.log_info()` / `node.log_error()` etc. | Nothing -- works out of the box |
+| **Log from C/C++** | Use `adora_log()` / `log_message()` | Nothing -- works out of the box |
+| **Filter noisy nodes** | Set `min_log_level` in YAML | Per-node YAML field |
+| **Watch all logs in one place** | Subscribe to `adora/logs` virtual input | `inputs: logs: adora/logs` |
+| **Process one node's logs as data** | Use `send_logs_as` on that node | Per-node YAML + wire the output |
+| **Rotate log files** | Set `max_log_size` in YAML | Per-node YAML field |
+| **Build a custom log sink** | Use `adora-log-utils` crate | Rust dependency |
+| **Filter CLI display** | Use `--log-level` / `--log-filter` flags | CLI flags or env vars |
+
+### Language-Specific Quick Start
+
+**Python** -- the simplest path is Python's built-in `logging` module:
+
+```python
+import logging
+from dora import Node
+
+node = Node()  # Automatically bridges Python logging -> adora
+
+logging.info("Sensor started")       # Captured as structured "info" log
+logging.warning("High temp: 42C")    # Captured as structured "warn" log
+print("raw debug output")            # Captured as "stdout" level
+```
+
+When `Node()` is created, it installs a handler that routes all Python `logging` calls through Rust's `tracing` system. The daemon parses these as structured log entries with level, message, file, and line number. No extra configuration needed.
+
+You can also use the explicit API for structured fields:
+
+```python
+node.log_info("Reading acquired")
+node.log("info", "Reading acquired", fields={"sensor_id": "temp-01"})
+```
+
+**Rust** -- use the node API convenience methods:
+
+```rust
+let (node, mut events) = AdoraNode::init_from_env()?;
+
+// Convenience methods (recommended for most cases)
+node.log_info("Sensor started");
+node.log_warn("High temperature");
+
+// With structured fields
+let mut fields = BTreeMap::new();
+fields.insert("sensor_id".into(), "temp-01".into());
+node.log_with_fields("info", "Reading acquired", None, Some(&fields));
+```
+
+Alternatively, Rust nodes can use the `tracing` crate. When adora's tracing subscriber is initialized (via `init_tracing()`), `tracing::info!()` etc. output structured JSON to stdout, which the daemon parses automatically:
+
+```rust
+// Also works -- parsed as structured logs by the daemon
+tracing::info!("Sensor started");
+tracing::warn!(sensor_id = "temp-01", "High temperature");
+```
+
+Use `node.log_*()` when you want explicit control over the log format. Use `tracing::*!()` when you want ecosystem integration (spans, instrumentation, OpenTelemetry). Both produce identical structured log entries in the daemon.
+
+**C** -- use the `adora_log()` function:
+
+```c
+adora_log(ctx, "info", 4, "Sensor started", 14);
+```
+
+**C++** -- use the `log_message()` function:
+
+```cpp
+log_message(node.send_output, "info", "Sensor started");
+```
+
+---
+
 ## Features at a Glance
 
 | Feature | Scope | Config |
@@ -16,6 +95,7 @@ Adora provides a structured logging system for real-time robotics and AI dataflo
 | Rotation file limit | Per-node YAML | `max_rotated_files` |
 | Node log API | Rust/Python/C/C++ node | `node.log()`, `adora_log()`, etc. |
 | Log utilities library | Rust crate | `adora-log-utils` |
+| **Log aggregation** | **Dataflow input** | **`adora/logs` virtual input** |
 | Time-range filtering | `adora logs` | `--since`, `--until` |
 | Live log streaming | `adora logs` | `--follow` |
 | Text search | `adora logs` | `--grep` |
@@ -51,7 +131,7 @@ Each line has this structure:
 | `node_id` | string | Node ID |
 | `message` | string | The log message text |
 | `target` | string? | Rust module target (e.g. `"sensor::module"`), null if absent |
-| `fields` | object? | Structured key-value fields from the logging framework |
+| `fields` | object? | Structured key-value fields from the logging framework. **Trust model:** fields originate from node stdout and are passed through without sanitization. In mixed-trust environments, log consumers should validate field contents before acting on them |
 
 ### How Node Output Becomes Log Entries
 
@@ -331,6 +411,57 @@ Unlike `send_stdout_as`, this only sends lines that were successfully parsed as 
 
 Use this to build log aggregation, alerting, or monitoring nodes within the dataflow itself.
 
+### `adora/logs` -- Automatic Log Aggregation
+
+Subscribe to logs from **all nodes** with a single input line -- no manual wiring needed:
+
+```yaml
+nodes:
+  - id: sensor
+    path: sensor.py
+    inputs:
+      tick: adora/timer/millis/200
+    outputs:
+      - reading
+
+  - id: processor
+    path: processor.py
+    inputs:
+      reading: sensor/reading
+    outputs:
+      - result
+
+  - id: log-viewer
+    path: log_viewer.py
+    inputs:
+      logs: adora/logs              # all nodes, all levels
+      errors: adora/logs/error      # only error+ from all nodes
+      sensor: adora/logs/info/sensor  # info+ from one node
+```
+
+The `adora/logs` virtual input works like `adora/timer` -- the daemon handles subscription internally. Each log message arrives as a JSON-encoded `LogMessage` string in an Arrow array. To prevent infinite loops, a node never receives its own log messages.
+
+**Syntax:**
+
+| Input | Description |
+|-------|-------------|
+| `adora/logs` | All logs from all nodes |
+| `adora/logs/<level>` | Logs at `<level>` or above from all nodes |
+| `adora/logs/<level>/<node-id>` | Logs at `<level>` or above from a specific node |
+
+Levels: `stdout`, `error`, `warn`, `info`, `debug`, `trace`.
+
+**When to use `adora/logs` vs `send_logs_as`:**
+
+| | `adora/logs` | `send_logs_as` |
+|--|-------------|---------------|
+| Scope | All nodes at once | One node at a time |
+| YAML changes | Only the consumer | Each source node |
+| Adding a node | Zero wiring changes | Must update consumer |
+| Use case | Dashboard, monitoring | Per-node log processing |
+
+See `examples/log-aggregator/` for a complete working example.
+
 ### `max_log_size`
 
 Enable size-based log file rotation.
@@ -451,23 +582,44 @@ The `level` parameter accepts `"error"`, `"warn"` (or `"warning"`), `"info"`, `"
 
 ### Python
 
+Python nodes have three ways to log, all producing structured log entries:
+
 ```python
-from adora import Node
+from dora import Node
+import logging
 
 node = Node()
 
-# General log with level string and optional target
-node.log("info", "sensor initialized", target="sensor.init")
+# Option 1: Python's logging module (recommended -- auto-bridged by Node())
+logging.info("sensor initialized")
+logging.warning("temperature elevated")
+logging.debug("raw bytes: %s", data)
 
-# Structured fields
+# Option 2: Explicit adora API with level string
+node.log("info", "sensor initialized", target="sensor.init")
 node.log("info", "reading acquired", fields={"sensor_id": "temp-01", "reading": "42.5"})
 
-# For most cases, use Python's built-in logging module instead:
-import logging
-logging.info("sensor initialized")
+# Option 3: Convenience methods
+node.log_error("connection failed")
+node.log_warn("temperature elevated")
+node.log_info("reading acquired")
+node.log_debug("raw bytes received")
+node.log_trace("entering loop iteration")
+
+# This also works but produces "stdout"-level entries (no structure):
+print("raw output")
 ```
 
-The Python `node.log()` method has the same level normalization as Rust. However, Python nodes typically use the standard `logging` module, which the daemon parses into structured log entries automatically.
+**How the Python logging bridge works:** When `Node()` is created, it installs a custom `logging.Handler` that routes all Python `logging` calls through Rust's `tracing` system. The daemon parses these as structured log entries with level, message, file path, and line number. This happens automatically -- no configuration needed.
+
+| Method | Structured? | Fields support? | When to use |
+|--------|------------|-----------------|-------------|
+| `logging.info()` | Yes | No (use `extra=` for custom formatters) | General-purpose logging |
+| `node.log("info", msg, fields={...})` | Yes | Yes | When you need structured key-value context |
+| `node.log_info(msg)` | Yes | No | Quick one-liner, same as `node.log("info", msg)` |
+| `print()` | No (`stdout` level) | No | Legacy code, quick debugging |
+
+**Common pitfall:** Do not call `logging.basicConfig()` before creating `Node()`. The node constructor sets up the logging bridge; calling `basicConfig()` first may install a conflicting handler. If you need custom formatters, configure them after `Node()` creation.
 
 ### C
 
@@ -657,7 +809,7 @@ Understanding the internal pipeline helps with debugging and tuning. For each no
 Node Process (stdout/stderr)
     |
     v
-[1] Capture: lines buffered in mpsc channel (capacity 10)
+[1] Capture: lines buffered in mpsc channel (capacity 100)
     |
     v
 [2] send_stdout_as: raw line -> Arrow data -> dataflow output
@@ -1072,6 +1224,33 @@ With JSON format, each line is a complete `LogMessage` that can be processed by 
 ```bash
 # Extract error messages with jq
 cat test-logs.json | jq -r 'select(.level == "ERROR") | "\(.node_id): \(.message)"'
+```
+
+---
+
+## Performance Considerations
+
+Logging adds I/O overhead proportional to log volume. Here's how to tune it:
+
+**`min_log_level` is the most impactful setting.** It filters at the daemon before any I/O: no log file write, no coordinator forwarding, no `send_logs_as` routing. A node emitting 1000 debug lines/sec at `min_log_level: info` generates zero overhead for those lines.
+
+**`send_logs_as` adds a dataflow message per log line.** Each parsed log entry is serialized to JSON, converted to Arrow, and sent through the dataflow. For high-volume nodes, this can consume significant bandwidth. Use `min_log_level` to limit what gets routed.
+
+**`adora/logs` subscribers share a single serialization.** The daemon converts each log line to Arrow once and clones the result for each subscriber. The cost scales linearly with subscriber count, not log volume x subscriber count. For most dataflows (1-3 log subscribers), this is negligible.
+
+**Log line size is capped at 1 MB.** Lines longer than 1 MB from node stdout/stderr are truncated to prevent heap exhaustion. This protects against buggy nodes that dump large binary data to stdout.
+
+**Log file rotation is recommended for long-running dataflows.** Without `max_log_size`, log files grow unbounded. A node emitting 100 lines/sec at ~200 bytes/line fills 1 GB in ~14 hours.
+
+**Recommended production settings:**
+
+```yaml
+nodes:
+  - id: my-node
+    path: ./my-node
+    min_log_level: info        # drop debug/trace at source
+    max_log_size: "50MB"       # rotate at 50MB
+    max_rotated_files: 5       # keep 5 rotated files (300MB max)
 ```
 
 ---

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -124,6 +124,19 @@ inputs:
   fast: adora/timer/hz/30        # 30 Hz (~33ms)
 ```
 
+#### Built-in Log Aggregation
+
+Subscribe to structured log messages from all (or filtered) nodes:
+
+```yaml
+inputs:
+  all_logs: adora/logs               # all nodes, all levels
+  errors:   adora/logs/error         # error+ from all nodes
+  sensor:   adora/logs/info/sensor   # info+ from specific node
+```
+
+Each message arrives as a JSON-encoded `LogMessage` string. See [Logging](logging.md#adoralogs----automatic-log-aggregation) for details.
+
 #### Outputs
 
 A list of output identifiers the node produces:
@@ -235,6 +248,8 @@ Example:
 ```
 
 When using `send_stdout_as` or `send_logs_as`, include the output name in the `outputs` list so downstream nodes can subscribe to it.
+
+For a complete guide to all logging features, see [Logging](logging.md).
 
 ### Fault Tolerance
 

--- a/examples/log-aggregator/README.md
+++ b/examples/log-aggregator/README.md
@@ -1,0 +1,96 @@
+# Log Aggregator Example
+
+Demonstrates `adora/logs`, a virtual input that automatically aggregates structured log messages from all nodes in the dataflow -- no manual wiring needed.
+
+## Architecture
+
+```
+sensor (readings + logs) ----> processor (transforms + logs)
+                                        |
+                            [daemon collects all logs]
+                                        |
+                                   log-viewer
+                              (adora/logs virtual input)
+```
+
+## Nodes
+
+| Node | Role | Logging |
+|------|------|---------|
+| `sensor` | Emits temperature readings on a timer | `node.log_info()`, `node.log_warn()` |
+| `processor` | Converts Celsius to Fahrenheit | `node.log_debug()` |
+| `log-viewer` | Receives **all** logs via `adora/logs` | Parses and displays JSON log messages |
+
+## Key Concepts
+
+### `adora/logs` Virtual Input
+
+Works like `adora/timer` -- the daemon handles subscription internally. Each message is a JSON-encoded `LogMessage` string in an Arrow array.
+
+```yaml
+inputs:
+  logs: adora/logs              # all nodes, all levels
+  errors: adora/logs/error      # error+ from all nodes
+  sensor: adora/logs/info/sensor  # info+ from a specific node
+```
+
+A node **never receives its own logs** (prevents infinite loops).
+
+### vs `send_logs_as`
+
+| | `adora/logs` | `send_logs_as` |
+|--|-------------|---------------|
+| Scope | All nodes at once | One node at a time |
+| YAML changes | Only the consumer | Each source node |
+| Adding a node | Zero wiring changes | Must update consumer |
+| Use case | Dashboard, monitoring | Per-node log processing |
+
+## Running
+
+```bash
+# Local mode (quick test)
+adora run dataflow.yml --stop-after 5s
+
+# With level filtering
+adora run dataflow.yml --log-level info --stop-after 5s
+
+# Distributed mode
+adora up
+adora start dataflow.yml --attach
+```
+
+## Filter Syntax
+
+| Input | Description |
+|-------|-------------|
+| `adora/logs` | All logs from all nodes |
+| `adora/logs/<level>` | Logs at `<level>` or above from all nodes |
+| `adora/logs/<level>/<node-id>` | Logs at `<level>` or above from one node |
+
+Levels (most to least verbose): `stdout`, `trace`, `debug`, `info`, `warn`, `error`.
+
+## Consuming Logs in Python
+
+```python
+import json
+from dora import Node
+
+node = Node()
+for event in node:
+    if event["type"] == "INPUT" and event["id"] == "logs":
+        raw = bytes(event["value"]).decode("utf-8")
+        log = json.loads(raw)
+        print(f"[{log['level']}][{log['node_id']}] {log['message']}")
+```
+
+## Consuming Logs in Rust
+
+```rust
+use adora_log_utils;
+
+// In your event loop:
+let log = adora_log_utils::parse_log_from_arrow(&data)?;
+println!("{}", adora_log_utils::format_pretty(&log));
+```
+
+Add `adora-log-utils = { workspace = true }` to your `Cargo.toml`.

--- a/examples/log-aggregator/dataflow.yml
+++ b/examples/log-aggregator/dataflow.yml
@@ -1,0 +1,25 @@
+nodes:
+  - id: sensor
+    path: sensor.py
+    min_log_level: info
+    inputs:
+      tick: adora/timer/millis/200
+    outputs:
+      - reading
+
+  - id: processor
+    path: processor.py
+    inputs:
+      reading: sensor/reading
+    outputs:
+      - result
+
+  # This node receives ALL logs from ALL nodes automatically.
+  # No manual wiring needed -- adora/logs subscribes to the daemon's log stream.
+  - id: log-viewer
+    path: log_viewer.py
+    inputs:
+      logs: adora/logs           # all nodes, all levels
+      # Alternative filters:
+      #   errors_only: adora/logs/error         # only error+ from all nodes
+      #   sensor_logs: adora/logs/info/sensor   # info+ from specific node

--- a/examples/log-aggregator/log_viewer.py
+++ b/examples/log-aggregator/log_viewer.py
@@ -1,0 +1,25 @@
+"""Log viewer node that receives ALL logs via adora/logs virtual input.
+
+No manual wiring needed -- this node automatically receives structured
+log messages from every node in the dataflow.
+"""
+
+import json
+
+from dora import Node
+
+node = Node()
+
+print("=== Log Viewer Started (receiving all dataflow logs) ===")
+
+for event in node:
+    if event["type"] == "INPUT" and event["id"] == "logs":
+        raw = bytes(event["value"]).decode("utf-8")
+        try:
+            log = json.loads(raw)
+            level = log.get("level", "?").upper()
+            node_id = log.get("node_id", "unknown")
+            message = log.get("message", raw)
+            print(f"[{level:6}][{node_id}] {message}")
+        except json.JSONDecodeError:
+            print(f"[RAW] {raw}")

--- a/examples/log-aggregator/processor.py
+++ b/examples/log-aggregator/processor.py
@@ -1,0 +1,12 @@
+"""Processor node that transforms sensor readings."""
+
+from dora import Node
+
+node = Node()
+
+for event in node:
+    if event["type"] == "INPUT" and event["id"] == "reading":
+        value = float(bytes(event["value"]))
+        result = value * 1.8 + 32  # Celsius to Fahrenheit
+        node.send_output("result", str(round(result, 1)).encode())
+        node.log_debug(f"Converted {value}C -> {result:.1f}F")

--- a/examples/log-aggregator/sensor.py
+++ b/examples/log-aggregator/sensor.py
@@ -1,0 +1,17 @@
+"""Sensor node that emits readings and structured logs."""
+
+import random
+
+from dora import Node
+
+node = Node()
+
+for event in node:
+    if event["type"] == "INPUT" and event["id"] == "tick":
+        reading = round(random.uniform(20.0, 30.0), 1)
+        node.send_output("reading", str(reading).encode())
+
+        if reading > 28.0:
+            node.log_warn(f"High temperature: {reading}C")
+        else:
+            node.log_info(f"Temperature: {reading}C")

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -501,7 +501,7 @@ fn rewrite_module_input(
     optional_inputs: &BTreeSet<String>,
 ) -> eyre::Result<Option<Input>> {
     match &input.mapping {
-        InputMapping::Timer { .. } => Ok(Some(input.clone())),
+        InputMapping::Timer { .. } | InputMapping::Logs(_) => Ok(Some(input.clone())),
         InputMapping::User(user_mapping) => {
             let source_str = user_mapping.source.to_string();
 
@@ -612,7 +612,7 @@ fn rewrite_inputs_map(
                     input.clone()
                 }
             }
-            InputMapping::Timer { .. } => input.clone(),
+            InputMapping::Timer { .. } | InputMapping::Logs(_) => input.clone(),
         };
         new_inputs.insert(input_id.clone(), new_input);
     }

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -100,7 +100,7 @@ impl DescriptorExt for Descriptor {
             for mapping in input_mappings
                 .into_iter()
                 .filter_map(|i| match &mut i.mapping {
-                    InputMapping::Timer { .. } => None,
+                    InputMapping::Timer { .. } | InputMapping::Logs(_) => None,
                     InputMapping::User(m) => Some(m),
                 })
             {

--- a/libraries/core/src/descriptor/validate.rs
+++ b/libraries/core/src/descriptor/validate.rs
@@ -351,7 +351,7 @@ fn check_input(
     input_id_str: &str,
 ) -> Result<(), eyre::ErrReport> {
     match &input.mapping {
-        InputMapping::Timer { interval: _ } => {}
+        InputMapping::Timer { interval: _ } | InputMapping::Logs(_) => {}
         InputMapping::User(UserInputMapping { source, output }) => {
             let source_node = nodes.values().find(|n| &n.id == source).ok_or_else(|| {
                 eyre!("source node `{source}` mapped to input `{input_id_str}` does not exist",)
@@ -1078,6 +1078,8 @@ fn check_edge_mismatches_with_compat(
                     }
                 }
             }
+            // Log subscriptions deliver JSON strings — skip type checking.
+            InputMapping::Logs(_) => {}
         }
     }
 }

--- a/libraries/core/src/descriptor/visualize.rs
+++ b/libraries/core/src/descriptor/visualize.rs
@@ -96,7 +96,7 @@ fn collect_adora_nodes(
 ) {
     for input in values {
         match &input.mapping {
-            InputMapping::User(_) => {}
+            InputMapping::User(_) | InputMapping::Logs(_) => {}
             InputMapping::Timer { interval } => {
                 adora_timers.insert(*interval);
             }
@@ -207,7 +207,7 @@ fn visualize_inputs(
 ) {
     for (input_id, input) in inputs {
         match &input.mapping {
-            mapping @ InputMapping::Timer { .. } => {
+            mapping @ (InputMapping::Timer { .. } | InputMapping::Logs(_)) => {
                 writeln!(flowchart, "  {mapping} -- {input_id} --> {target}").unwrap();
             }
             InputMapping::User(mapping) => {

--- a/libraries/extensions/telemetry/tracing/src/lib.rs
+++ b/libraries/extensions/telemetry/tracing/src/lib.rs
@@ -25,11 +25,14 @@ pub mod telemetry;
 /// Setup tracing with a default configuration.
 ///
 /// This will set up a global subscriber that logs to stdout with a filter level of "warn".
+/// Outputs structured JSONL that the adora daemon parses as `LogMessage`,
+/// so `tracing::info!()` calls in user nodes are automatically routed through
+/// the adora log pipeline (file, coordinator, `adora/logs` subscribers).
 ///
 /// Should **ONLY** be used in `AdoraNode` implementations.
 pub fn set_up_tracing(name: &str) -> eyre::Result<()> {
     TracingBuilder::new(name)
-        .with_stdout("warn", false)
+        .with_node_stdout("warn")
         .build()
         .wrap_err(format!(
             "failed to set tracing global subscriber for {name}"
@@ -56,6 +59,33 @@ impl TracingBuilder {
             layers: Vec::new(),
             guard: None,
         }
+    }
+
+    /// Add a layer that writes structured JSONL to stdout, compatible with the
+    /// adora daemon's `LogMessageHelper` parser.
+    ///
+    /// This is the recommended layer for user nodes: `tracing::info!()` calls
+    /// are automatically parsed by the daemon and routed through the log pipeline.
+    pub fn with_node_stdout(mut self, filter: impl AsRef<str>) -> Self {
+        let mut parsed = EnvFilter::builder()
+            .parse_lossy(filter)
+            .add_directive("hyper=off".parse().unwrap())
+            .add_directive("tonic=off".parse().unwrap())
+            .add_directive("tokio=off".parse().unwrap())
+            .add_directive("process_wrap=off".parse().unwrap())
+            .add_directive("h2=off".parse().unwrap())
+            .add_directive("reqwest=off".parse().unwrap());
+        let env_log = std::env::var("RUST_LOG").unwrap_or_default();
+        if !env_log.contains("zenoh") {
+            parsed = parsed.add_directive("zenoh=warn".parse().unwrap());
+        }
+        let env_filter = EnvFilter::from_default_env().or(parsed);
+        let layer = tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(std::io::stdout)
+            .with_filter(env_filter);
+        self.layers.push(layer.boxed());
+        self
     }
 
     /// Add a layer that write logs to the [std::io::stdout] with the given filter.

--- a/libraries/extensions/telemetry/tracing/src/telemetry.rs
+++ b/libraries/extensions/telemetry/tracing/src/telemetry.rs
@@ -61,9 +61,15 @@ pub fn init_jaeger_tracing(
     init_tracing(name, endpoint)
 }
 
+/// Serialize the trace context (trace ID, span ID) into a compact string.
+/// Only W3C TraceContext keys (`traceparent`, `tracestate`) are included.
+/// OTel Baggage keys are stripped to prevent sensitive data from leaking
+/// across node boundaries in the dataflow.
 pub fn serialize_context(context: &Context) -> String {
     let mut map = HashMap::new();
     global::get_text_map_propagator(|propagator| propagator.inject_context(context, &mut map));
+    // Strip baggage to avoid propagating sensitive data across nodes
+    map.remove("baggage");
     let mut string_context = String::new();
     for (k, v) in map.iter() {
         string_context.push_str(k);

--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -11,6 +11,16 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::id::{DataId, NodeId, OperatorId};
 
+/// Filter for the `adora/logs` virtual input.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
+pub struct LogSubscriptionFilter {
+    /// Minimum log level to receive. `None` means all levels (including stdout).
+    #[schemars(with = "Option<String>")]
+    pub min_level: Option<crate::common::LogLevelOrStdout>,
+    /// Only receive logs from this specific node. `None` means all nodes.
+    pub node_filter: Option<NodeId>,
+}
+
 /// Default queue size when none is configured.
 pub const DEFAULT_QUEUE_SIZE: usize = 10;
 
@@ -174,7 +184,13 @@ impl From<InputDef> for Input {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, JsonSchema)]
 pub enum InputMapping {
-    Timer { interval: Duration },
+    Timer {
+        interval: Duration,
+    },
+    /// Subscribe to log messages from all (or filtered) nodes in the dataflow.
+    ///
+    /// Syntax: `adora/logs`, `adora/logs/{level}`, `adora/logs/{level}/{node_id}`
+    Logs(LogSubscriptionFilter),
     User(UserInputMapping),
 }
 
@@ -184,7 +200,9 @@ impl InputMapping {
 
         match self {
             InputMapping::User(mapping) => &mapping.source,
-            InputMapping::Timer { .. } => ADORA_NODE_ID.get_or_init(|| NodeId("adora".to_string())),
+            InputMapping::Timer { .. } | InputMapping::Logs(_) => {
+                ADORA_NODE_ID.get_or_init(|| NodeId("adora".to_string()))
+            }
         }
     }
 }
@@ -195,6 +213,16 @@ impl fmt::Display for InputMapping {
             InputMapping::Timer { interval } => {
                 let duration = format_duration(*interval);
                 write!(f, "adora/timer/{duration}")
+            }
+            InputMapping::Logs(filter) => {
+                write!(f, "adora/logs")?;
+                if let Some(level) = &filter.min_level {
+                    write!(f, "/{}", format_log_level(level))?;
+                    if let Some(node) = &filter.node_filter {
+                        write!(f, "/{node}")?;
+                    }
+                }
+                Ok(())
             }
             InputMapping::User(mapping) => {
                 write!(f, "{}/{}", mapping.source, mapping.output)
@@ -238,9 +266,32 @@ impl FromStr for InputMapping {
                     };
                     Self::Timer { interval }
                 }
+                Some(("logs", rest)) => {
+                    // adora/logs/{level} or adora/logs/{level}/{node_id}
+                    let (level_str, node_filter) = match rest.split_once('/') {
+                        Some((level, node)) => (Some(level), Some(NodeId(node.to_owned()))),
+                        None => {
+                            if rest.is_empty() {
+                                (None, None)
+                            } else {
+                                (Some(rest), None)
+                            }
+                        }
+                    };
+                    let min_level = level_str.map(parse_log_level_str).transpose()?;
+                    Self::Logs(LogSubscriptionFilter {
+                        min_level,
+                        node_filter,
+                    })
+                }
                 Some((other, _)) => {
                     return Err(format!("unknown adora input `{other}`"));
                 }
+                // "adora/logs" with no sub-path
+                None if output == "logs" => Self::Logs(LogSubscriptionFilter {
+                    min_level: None,
+                    node_filter: None,
+                }),
                 None => return Err("adora input has invalid format".into()),
             },
             _ => Self::User(UserInputMapping {
@@ -250,6 +301,35 @@ impl FromStr for InputMapping {
         };
 
         Ok(mapping)
+    }
+}
+
+fn parse_log_level_str(s: &str) -> Result<crate::common::LogLevelOrStdout, String> {
+    use crate::common::{LogLevel, LogLevelOrStdout};
+    match s.to_lowercase().as_str() {
+        "stdout" => Ok(LogLevelOrStdout::Stdout),
+        "error" => Ok(LogLevelOrStdout::LogLevel(LogLevel::Error)),
+        "warn" => Ok(LogLevelOrStdout::LogLevel(LogLevel::Warn)),
+        "info" => Ok(LogLevelOrStdout::LogLevel(LogLevel::Info)),
+        "debug" => Ok(LogLevelOrStdout::LogLevel(LogLevel::Debug)),
+        "trace" => Ok(LogLevelOrStdout::LogLevel(LogLevel::Trace)),
+        other => Err(format!(
+            "unknown log level `{other}` (expected: stdout, error, warn, info, debug, trace)"
+        )),
+    }
+}
+
+fn format_log_level(level: &crate::common::LogLevelOrStdout) -> &'static str {
+    use crate::common::{LogLevel, LogLevelOrStdout};
+    match level {
+        LogLevelOrStdout::Stdout => "stdout",
+        LogLevelOrStdout::LogLevel(l) => match *l {
+            LogLevel::Error => "error",
+            LogLevel::Warn => "warn",
+            LogLevel::Info => "info",
+            LogLevel::Debug => "debug",
+            LogLevel::Trace => "trace",
+        },
     }
 }
 
@@ -395,5 +475,91 @@ mod tests {
     #[test]
     fn queue_policy_default_is_drop_oldest() {
         assert_eq!(QueuePolicy::default(), QueuePolicy::DropOldest);
+    }
+
+    #[test]
+    fn parse_logs_all() {
+        let mapping: InputMapping = "adora/logs".parse().unwrap();
+        assert!(matches!(
+            mapping,
+            InputMapping::Logs(LogSubscriptionFilter {
+                min_level: None,
+                node_filter: None,
+            })
+        ));
+    }
+
+    #[test]
+    fn parse_logs_with_level() {
+        use crate::common::{LogLevel, LogLevelOrStdout};
+        let mapping: InputMapping = "adora/logs/info".parse().unwrap();
+        match mapping {
+            InputMapping::Logs(f) => {
+                assert_eq!(
+                    f.min_level,
+                    Some(LogLevelOrStdout::LogLevel(LogLevel::Info))
+                );
+                assert_eq!(f.node_filter, None);
+            }
+            _ => panic!("expected Logs variant"),
+        }
+    }
+
+    #[test]
+    fn parse_logs_with_level_and_node() {
+        use crate::common::{LogLevel, LogLevelOrStdout};
+        let mapping: InputMapping = "adora/logs/error/sensor".parse().unwrap();
+        match mapping {
+            InputMapping::Logs(f) => {
+                assert_eq!(
+                    f.min_level,
+                    Some(LogLevelOrStdout::LogLevel(LogLevel::Error))
+                );
+                assert_eq!(f.node_filter, Some(NodeId("sensor".to_string())));
+            }
+            _ => panic!("expected Logs variant"),
+        }
+    }
+
+    #[test]
+    fn parse_logs_invalid_level() {
+        let result: Result<InputMapping, _> = "adora/logs/banana".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn display_roundtrip_logs_all() {
+        let mapping: InputMapping = "adora/logs".parse().unwrap();
+        assert_eq!(mapping.to_string(), "adora/logs");
+    }
+
+    #[test]
+    fn display_roundtrip_logs_with_level() {
+        let mapping: InputMapping = "adora/logs/warn".parse().unwrap();
+        assert_eq!(mapping.to_string(), "adora/logs/warn");
+    }
+
+    #[test]
+    fn display_roundtrip_logs_with_level_and_node() {
+        let mapping: InputMapping = "adora/logs/debug/camera".parse().unwrap();
+        assert_eq!(mapping.to_string(), "adora/logs/debug/camera");
+    }
+
+    #[test]
+    fn logs_source_is_adora() {
+        let mapping: InputMapping = "adora/logs".parse().unwrap();
+        assert_eq!(mapping.source().to_string(), "adora");
+    }
+
+    #[test]
+    fn parse_logs_trailing_slash() {
+        let mapping: InputMapping = "adora/logs/".parse().unwrap();
+        assert!(matches!(
+            mapping,
+            InputMapping::Logs(LogSubscriptionFilter {
+                min_level: None,
+                node_filter: None,
+            })
+        ));
     }
 }

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -543,3 +543,12 @@ fn smoke_local_action_example() {
         15,
     );
 }
+
+#[test]
+fn smoke_local_log_aggregator() {
+    run_smoke_test_local(
+        "local-log-aggregator",
+        "examples/log-aggregator/dataflow.yml",
+        10,
+    );
+}


### PR DESCRIPTION
## Summary

- Add `adora/logs` virtual input for automatic log aggregation across all nodes without manual wiring (follows the `adora/timer` pattern)
- Add Python convenience log methods (`log_info`, `log_warn`, `log_error`, `log_debug`, `log_trace`)
- Add Rust tracing bridge (`with_node_stdout`) that outputs structured JSON for daemon parsing
- Add OpenTelemetry trace context auto-injection on `send_output_sample()` (baggage stripped for safety)
- Security hardening: 1MB log line cap with UTF-8-safe truncation, non-blocking `try_send` for broadcast, stale subscriber cleanup, log channel capacity increased to 100
- Comprehensive documentation: quick decision guide, Python logging bridge explanation, Rust tracing comparison, performance tuning section, log-aggregator example with README

## Motivation

Users (e.g., mofa-org/mofa-studio) build extensive custom logging systems because adora's existing logging features are hard to discover. This PR makes logging easier to use (convenience methods, auto-bridging) and adds `adora/logs` for zero-config log aggregation.

## Test plan

- [x] All 58 adora-message tests pass (including new `parse_logs_trailing_slash` test)
- [x] All existing tests pass across affected crates (daemon, core, cli, node-api)
- [x] `cargo clippy` clean (only pre-existing warnings)
- [x] `cargo fmt` clean
- [x] New smoke test added for log-aggregator example
- [ ] Manual test: run `examples/log-aggregator/` and verify log-viewer receives logs from sensor and processor

Generated with [Claude Code](https://claude.com/claude-code)
