### PR TITLE
fix: resolve clippy errors for variant size and MSRV compatibility

### DIFF
--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 #[derive(Debug)]
 pub enum ControlEvent {
     IncomingRequest {
-        request: ControlRequest,
+        request: Box<ControlRequest>,
         reply_sender: oneshot::Sender<eyre::Result<ControlRequestReply>>,
     },
     LogSubscribe {

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -550,7 +550,7 @@ async fn start_inner(
                     request,
                     reply_sender,
                 } => {
-                    match request {
+                    match *request {
                         ControlRequest::Build {
                             session_id,
                             dataflow,

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -356,7 +356,7 @@ pub(crate) async fn handle_control_ws(
                 // Normal request-reply
                 let (reply_tx, reply_rx) = oneshot::channel();
                 let event = ControlEvent::IncomingRequest {
-                    request: control_request,
+                    request: Box::new(control_request),
                     reply_sender: reply_tx,
                 };
 

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -58,7 +58,12 @@ const MAX_LOG_LINE_BYTES: usize = 1024 * 1024;
 /// Truncate a log line to `MAX_LOG_LINE_BYTES`, respecting UTF-8 char boundaries.
 fn truncate_log_line(content: &mut String) {
     if content.len() > MAX_LOG_LINE_BYTES {
-        let boundary = content.floor_char_boundary(MAX_LOG_LINE_BYTES);
+        // Find the last valid UTF-8 char boundary at or before MAX_LOG_LINE_BYTES.
+        // This is equivalent to str::floor_char_boundary (stable in 1.91).
+        let mut boundary = MAX_LOG_LINE_BYTES;
+        while boundary > 0 && !content.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
         content.truncate(boundary);
         content.push_str("... [truncated]");
     }

--- a/examples/multiple-daemons/run.rs
+++ b/examples/multiple-daemons/run.rs
@@ -144,7 +144,7 @@ async fn start_dataflow(
     let (reply_sender, reply) = oneshot::channel();
     coordinator_events_tx
         .send(Event::Control(ControlEvent::IncomingRequest {
-            request: ControlRequest::Start {
+            request: Box::new(ControlRequest::Start {
                 build_id: dataflow_session.build_id,
                 session_id: dataflow_session.session_id,
                 dataflow: dataflow_descriptor,
@@ -152,7 +152,7 @@ async fn start_dataflow(
                 name: None,
                 uv: false,
                 write_events_to: None,
-            },
+            }),
             reply_sender,
         }))
         .await?;
@@ -166,7 +166,7 @@ async fn start_dataflow(
     let (reply_sender, reply) = oneshot::channel();
     coordinator_events_tx
         .send(Event::Control(ControlEvent::IncomingRequest {
-            request: ControlRequest::WaitForSpawn { dataflow_id: uuid },
+            request: Box::new(ControlRequest::WaitForSpawn { dataflow_id: uuid }),
             reply_sender,
         }))
         .await?;
@@ -185,7 +185,7 @@ async fn connected_machines(
     let (reply_sender, reply) = oneshot::channel();
     coordinator_events_tx
         .send(Event::Control(ControlEvent::IncomingRequest {
-            request: ControlRequest::ConnectedMachines,
+            request: Box::new(ControlRequest::ConnectedMachines),
             reply_sender,
         }))
         .await?;
@@ -204,7 +204,7 @@ async fn running_dataflows(
     let (reply_sender, reply) = oneshot::channel();
     coordinator_events_tx
         .send(Event::Control(ControlEvent::IncomingRequest {
-            request: ControlRequest::List,
+            request: Box::new(ControlRequest::List),
             reply_sender,
         }))
         .await?;
@@ -221,7 +221,7 @@ async fn destroy(coordinator_events_tx: &Sender<Event>) -> eyre::Result<()> {
     let (reply_sender, reply) = oneshot::channel();
     coordinator_events_tx
         .send(Event::Control(ControlEvent::IncomingRequest {
-            request: ControlRequest::Destroy,
+            request: Box::new(ControlRequest::Destroy),
             reply_sender,
         }))
         .await?;


### PR DESCRIPTION
## Summary

- Box `ControlRequest` in `ControlEvent::IncomingRequest` to fix `clippy::large_enum_variant` (272 vs 48 bytes)
- Replace `str::floor_char_boundary()` (stable since Rust 1.91) with manual UTF-8 boundary scan for MSRV 1.85 compatibility

## Test plan

- [x] `cargo clippy --all --exclude adora-node-api-python --exclude adora-operator-api-python --exclude adora-ros2-bridge-python -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes

Generated with [Claude Code](https://claude.com/claude-code)