### PR TITLE
fix(ros2-bridge): fix U16String visibility for Rust 2024 edition comp…

### DIFF
--- a/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/lib.rs
@@ -432,7 +432,7 @@ fn generate_default_impls(create_cxx_bridge: bool) -> proc_macro2::TokenStream {
     let u16str_impl = quote! {
         impl ffi::U16String {
             #[allow(dead_code)]
-            fn from_str(arg: &str) -> Self {
+            pub fn from_str(arg: &str) -> Self {
                 Self {
                     chars: crate::_core::widestring::U16String::from_str(arg).into_vec(),
                 }

--- a/libraries/extensions/ros2-bridge/msg-gen/src/types/primitives.rs
+++ b/libraries/extensions/ros2-bridge/msg-gen/src/types/primitives.rs
@@ -257,7 +257,7 @@ impl GenericString {
         }
         let value = Literal::string(value);
         if self.is_wide() {
-            quote! { ffi::U16String::from_str(#value) }
+            quote! { crate::messages::ffi::U16String::from_str(#value) }
         } else {
             quote! { ::std::string::String::from(#value) }
         }


### PR DESCRIPTION
…atibility

Fix compilation errors in ROS2 bridge message generation caused by stricter visibility rules in Rust 2024 edition:

- Make U16String::from_str() public in generated impl block
- Use full path crate::messages::ffi::U16String instead of ffi::U16String in generated code to avoid private struct import issues with glob imports

This fixes E0603 (private struct import) and E0624 (private associated function) errors when building adora-ros2-bridge with ROS2 message types that have WString default values.