### PR TITLE
feat: align versions and add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,181 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+  id-token: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # ── 1. Publish Rust crates to crates.io ──────────────────────────────────
+  publish-crates:
+    name: Publish crates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Publish in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          # Topological order: leaves first, binaries last.
+          # Skips Python crates (published to PyPI separately).
+          CRATES=(
+            adora-message
+            adora-arrow-convert
+            shared-memory-server
+            adora-coordinator-store
+            adora-core
+            adora-recording
+            adora-download
+            adora-tracing
+            adora-metrics
+            adora-operator-api-types
+            adora-operator-api-macros
+            adora-operator-api
+            adora-node-api
+            adora-node-api-c
+            adora-operator-api-c
+            adora-node-api-cxx
+            adora-operator-api-cxx
+            adora-ros2-bridge-msg-gen
+            adora-ros2-bridge
+            adora-ros2-bridge-arrow
+            adora-ros2-bridge-node
+            adora-runtime
+            adora-coordinator
+            adora-daemon
+            adora-record-node
+            adora-replay-node
+            adora-cli
+          )
+          for crate in "${CRATES[@]}"; do
+            echo "::group::Publishing $crate"
+            cargo publish -p "$crate" --no-verify || echo "::warning::$crate skipped (already published?)"
+            echo "::endgroup::"
+            sleep 5  # crates.io index propagation
+          done
+
+  # ── 2. Build Python wheels ────────────────────────────────────────────────
+  build-wheels:
+    name: Build wheels (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: x86_64-unknown-linux-gnu,  runner: ubuntu-22.04 }
+          - { target: aarch64-unknown-linux-gnu, runner: ubuntu-22.04 }
+          - { target: x86_64-apple-darwin,       runner: macos-latest }
+          - { target: aarch64-apple-darwin,      runner: macos-14     }
+          - { target: x86_64-pc-windows-msvc,    runner: windows-2022 }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Build adora-rs wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m apis/python/node/Cargo.toml
+          manylinux: auto
+      - name: Build adora-rs-cli wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m binaries/cli/Cargo.toml
+          manylinux: auto
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.target }}
+          path: dist/
+
+  # ── 3. Publish wheels to PyPI ─────────────────────────────────────────────
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/adora-rs
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+
+  # ── 4. Build CLI binaries via cargo-dist ──────────────────────────────────
+  dist:
+    name: Build CLI binaries (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: aarch64-apple-darwin,      runner: macos-14     }
+          - { target: aarch64-unknown-linux-gnu, runner: ubuntu-22.04 }
+          - { target: x86_64-unknown-linux-gnu,  runner: ubuntu-22.04 }
+          - { target: x86_64-pc-windows-msvc,    runner: windows-2022 }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build CLI for ${{ matrix.target }}
+        run: cargo build -p adora-cli --release --target ${{ matrix.target }}
+      - name: Package binary (unix)
+        if: runner.os != 'Windows'
+        run: |
+          mkdir -p artifacts
+          cp target/${{ matrix.target }}/release/adora-cli artifacts/adora
+          tar czf artifacts/adora-${{ matrix.target }}.tar.gz -C artifacts adora
+      - name: Package binary (windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts
+          Copy-Item "target/${{ matrix.target }}/release/adora-cli.exe" "artifacts/adora.exe"
+          Compress-Archive -Path "artifacts/adora.exe" -DestinationPath "artifacts/adora-${{ matrix.target }}.zip"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.target }}
+          path: artifacts/adora-*.*
+
+  # ── 5. Create GitHub Release with changelog ───────────────────────────────
+  github-release:
+    name: GitHub Release
+    needs: [publish-crates, publish-pypi, dist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: dist-*
+          merge-multiple: true
+          path: release-assets/
+      - name: Generate changelog
+        uses: orhun/git-cliff-action@v3
+        id: cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          body: ${{ steps.cliff.outputs.content }}
+          files: release-assets/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ adora run examples/python-dataflow/dataflow.yml --uv --stop-after 10s
 
 ## Workspace Layout
 
-- **Rust edition 2024, MSRV 1.85.0, version 0.4.1** (adora-message is independently versioned at 0.7.0)
+- **Rust edition 2024, MSRV 1.85.0, version 0.4.1** (all crates share workspace version)
 - Python packages use PyO3 0.23 and are built with **maturin**, not cargo
 
 ### Key crates

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,8 +68,46 @@ We use [`rustfmt`](https://github.com/rust-lang/rustfmt) with its default settin
 Please run `cargo fmt --all` on your code before submitting a pull request.
 Our CI will run an automatic formatting check of your code.
 
-## Publishing new Versions
+## Releasing
 
-The maintainers are responsible for publishing new versions of the `adora` crates.
-Please don't open unsolicited pull requests to create new releases.
-Instead, request a new version by opening an issue or by leaving a comment on a merged PR.
+Releases are automated via GitHub Actions. Only maintainers should cut releases.
+
+### Prerequisites (one-time)
+
+```bash
+cargo install cargo-release git-cliff
+```
+
+### Cutting a release
+
+```bash
+# 1. Ensure main is green and up to date
+git checkout main && git pull
+
+# 2. Generate/update changelog
+git cliff --tag v0.5.0 --output CHANGELOG.md
+git add CHANGELOG.md && git commit -m "docs: update changelog for v0.5.0"
+
+# 3. Bump version, commit, tag, and push (dry-run first)
+cargo release minor              # dry-run: review what will happen
+cargo release minor --execute    # bumps workspace version, tags v0.5.0, pushes
+```
+
+CI takes over from the tag push and automatically:
+- Publishes all crates to crates.io (in dependency order)
+- Builds and publishes Python wheels to PyPI (`adora-rs`, `adora-rs-cli`)
+- Builds CLI binaries for all platforms
+- Creates a GitHub Release with changelog and binary assets
+
+### Configuration
+
+| File | Purpose |
+|------|---------|
+| `release.toml` | cargo-release settings (version bump, tagging) |
+| `cliff.toml` | git-cliff changelog generation |
+| `.github/workflows/release.yml` | Tag-triggered publish pipeline |
+
+### Required GitHub secrets
+
+- `CARGO_REGISTRY_TOKEN`: crates.io API token
+- PyPI: configure [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/) for the `pypi` environment (no secret needed)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "adora-message"
-version = "0.7.0"
+version = "0.4.1"
 dependencies = [
  "aligned-vec",
  "arrow-data",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ members = [
 [workspace.package]
 edition = "2024"
 rust-version = "1.85.0"
-# Make sure to also bump `apis/node/python/__init__.py` version.
+# Python packages derive version from CARGO_PKG_VERSION automatically.
 version = "0.4.1"
 description = "`adora` goal is to be a low latency, composable, and distributed data flow."
 documentation = "https://adora-rs.ai"
@@ -90,8 +90,7 @@ adora-coordinator = { version = "0.4.1", path = "binaries/coordinator" }
 adora-ros2-bridge = { version = "0.4.1", path = "libraries/extensions/ros2-bridge" }
 adora-ros2-bridge-msg-gen = { version = "0.4.1", path = "libraries/extensions/ros2-bridge/msg-gen" }
 adora-ros2-bridge-python = { path = "libraries/extensions/ros2-bridge/python" }
-# versioned independently from the other adora crates
-adora-message = { version = "0.7.0", path = "libraries/message" }
+adora-message = { version = "0.4.1", path = "libraries/message" }
 arrow = { version = "58" }
 arrow-schema = { version = "58" }
 arrow-data = { version = "58" }

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,35 @@
+# git-cliff configuration
+# Usage: git cliff --output CHANGELOG.md
+# Docs: https://git-cliff.org
+
+[changelog]
+header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n"
+body = """
+{% if version %}\
+## {{ version | trim_start_matches(pat="v") }} ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}\
+## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {{ commit.message | split(pat="\n") | first | upper_first }} \
+([{{ commit.id | truncate(length=7, end="") }}](https://github.com/dora-rs/adora/commit/{{ commit.id }}))\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^docs", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^ci", group = "CI" },
+    { message = "^chore\\(release\\)|^chore: release", skip = true },
+]

--- a/libraries/message/Cargo.toml
+++ b/libraries/message/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "adora-message"
-# versioned separately from the other adora crates
-version = "0.7.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 documentation.workspace = true

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,21 @@
+# cargo-release configuration
+# Usage: cargo release [patch|minor|major] --execute
+# Docs: https://github.com/crate-ci/cargo-release
+
+# All workspace crates share a single version
+shared-version = true
+
+# CI publishes to crates.io, not cargo-release
+publish = false
+
+# Push the tag and commit to origin
+push = true
+push-remote = "origin"
+
+# Tag format
+tag = true
+tag-name = "v{{version}}"
+tag-message = "Release v{{version}}"
+
+# Commit message for the version bump
+pre-release-commit-message = "chore: release v{{version}}"


### PR DESCRIPTION
## Summary

- **Align adora-message to workspace version**: removed independent versioning (0.7.0 -> 0.4.1), now uses `version.workspace = true` like all other crates
- **Add cargo-release config** (`release.toml`): one-command version bumps with `cargo release [patch|minor|major] --execute`
- **Add git-cliff config** (`cliff.toml`): conventional-commit-based changelog generation
- **Add release workflow** (`.github/workflows/release.yml`): tag-triggered pipeline that publishes to crates.io (dependency order), builds Python wheels for 5 platforms and publishes to PyPI, builds CLI binaries, and creates a GitHub Release with changelog and assets
- **Update CONTRIBUTING.md** with release runbook and required GitHub secrets

### Release flow after this PR

```
cargo release minor --execute  # bumps, tags v0.5.0, pushes
# CI automatically: crates.io -> PyPI -> GitHub Release
```

### Required GitHub setup (one-time, after merge)

- Add `CARGO_REGISTRY_TOKEN` secret (crates.io API token)
- Configure PyPI OIDC trusted publishing for the `pypi` environment

## Test plan

- [x] `cargo check --all` passes with aligned adora-message version
- [x] `cargo test -p adora-message` passes (58 tests)
- [x] `cargo clippy --all -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] First real release: cut v0.4.2 after merge to validate the full pipeline

Generated with [Claude Code](https://claude.com/claude-code)
