### PR TITLE
fix(python): use TryRecvError::Closed instead of non-existent Other variant

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -577,11 +577,9 @@ impl Events {
         let event = match &mut *inner {
             EventsInner::Adora(events) => events.try_recv().map(MergedEvent::Adora),
             EventsInner::Merged(_events) => {
-                return Err(TryRecvError::Other(
-                    "try_recv is not supported after merge_external_events(); \
-                     use recv() or recv_async() instead"
-                        .into(),
-                ));
+                // try_recv is not supported on merged event streams;
+                // return Closed so callers fall back to recv().
+                return Err(TryRecvError::Closed);
             }
         };
         event.map(|event| PyEvent { event })


### PR DESCRIPTION
## Summary

- Fix TryRecvError::Other compile error that broke all Python wheel builds in the Release workflow
- The TryRecvError enum only has Empty and Closed variants; Other does not exist
- Use Closed to signal that try_recv is unsupported on merged event streams

## Test plan

- [ ] CI passes (especially Python wheel builds in Release workflow)