### PR TITLE
fix(release): fix Python wheel builds for all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,13 +86,15 @@ jobs:
         with:
           target: ${{ matrix.target }}
           args: --release --out dist -m apis/python/node/Cargo.toml
-          manylinux: auto
+          manylinux: "2_28"
+          before-script-linux: yum install -y perl-IPC-Cmd openssl-devel || apt-get update && apt-get install -y libssl-dev
       - name: Build adora-rs-cli wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
           args: --release --out dist -m binaries/cli/Cargo.toml
-          manylinux: auto
+          manylinux: "2_28"
+          before-script-linux: yum install -y perl-IPC-Cmd openssl-devel || apt-get update && apt-get install -y libssl-dev
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.target }}

--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -91,9 +91,12 @@ tempfile = "3.23.0"
 [lib]
 name = "adora_cli"
 path = "src/lib.rs"
-# cdylib is only needed for the Python wrapper (PyO3 extension module).
-# Use: cargo build -p adora-cli --features python
-crate-type = ["lib"]
+# cdylib is required by maturin for the Python wheel build.
+# Cargo builds all listed crate-types for the lib target, so this adds
+# a small overhead to every build.  The alternative (removing cdylib and
+# using a wrapper crate) is more complex and breaks the pyproject.toml
+# scripts entry that provides the `adora` console command.
+crate-type = ["lib", "cdylib"]
 
 [package.metadata.dist]
 # Enable adora-cli binary to be distributed

--- a/binaries/cli/pyproject.toml
+++ b/binaries/cli/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.8"
 dependencies = ['adora-rs >= 0.3.9', 'uv']
 
 [tool.maturin]
-features = ["python", "pyo3/extension-module"]
+bindings = "pyo3"
+features = ["python-extension-module"]
 
 [tool.ruff.lint]
 extend-select = [


### PR DESCRIPTION
## Summary

- Restore cdylib crate-type for adora-cli (required by maturin for PyO3 extension)
- Set bindings = pyo3 in pyproject.toml to fix 'scripts and binary don't mix' error on macOS/Windows
- Use python-extension-module feature instead of raw pyo3/extension-module
- Switch manylinux from auto (2014) to 2_28 and install openssl-devel to fix OpenSSL 3.5.5 Perl build failure

## Test plan

- [ ] Release workflow wheel builds pass on all 5 platforms after retagging v0.1.0