### PR TITLE
fix(release): use system OpenSSL instead of vendored for wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,24 +81,31 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Install OpenSSL (macOS)
+        if: runner.os == 'macOS'
+        run: brew install openssl@3
       - name: Build adora-rs wheel
         uses: PyO3/maturin-action@v1
-        env:
-          OPENSSL_NO_VENDOR: "1"
         with:
           target: ${{ matrix.target }}
           args: --release --out dist -m apis/python/node/Cargo.toml
           manylinux: "2_28"
-          before-script-linux: dnf install -y perl-IPC-Cmd openssl-devel || yum install -y perl-IPC-Cmd openssl-devel
+          before-script-linux: |
+            if command -v dnf &>/dev/null; then dnf install -y openssl-devel perl-IPC-Cmd;
+            elif command -v yum &>/dev/null; then yum install -y openssl-devel perl-IPC-Cmd;
+            elif command -v apk &>/dev/null; then apk add openssl-dev perl;
+            fi
       - name: Build adora-rs-cli wheel
         uses: PyO3/maturin-action@v1
-        env:
-          OPENSSL_NO_VENDOR: "1"
         with:
           target: ${{ matrix.target }}
           args: --release --out dist -m binaries/cli/Cargo.toml
           manylinux: "2_28"
-          before-script-linux: dnf install -y perl-IPC-Cmd openssl-devel || yum install -y perl-IPC-Cmd openssl-devel
+          before-script-linux: |
+            if command -v dnf &>/dev/null; then dnf install -y openssl-devel perl-IPC-Cmd;
+            elif command -v yum &>/dev/null; then yum install -y openssl-devel perl-IPC-Cmd;
+            elif command -v apk &>/dev/null; then apk add openssl-dev perl;
+            fi
       - uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ pyo3 = { version = "0.28", features = [
     "multiple-pymethods",
 ] }
 pythonize = "0.28"
-git2 = { version = "0.20.4", features = ["vendored-openssl"] }
+git2 = { version = "0.20.4" }
 serde_yaml = "0.9.33"
 zenoh = "1.1.1"
 serde_json = "1.0.145"


### PR DESCRIPTION
## Summary

- Remove vendored-openssl from workspace git2 dep (avoids Perl issues in containers)
- Install system openssl-devel in Linux manylinux containers via dnf/yum/apk detection
- Add brew install openssl on macOS runners for cross-compilation support

## Test plan

- [ ] All 5 wheel builds pass in Release workflow
- [ ] CI passes on all platforms