### PR TITLE
Fix duplicate PyInit_adora_cli symbol by removing duplicate pymodule …

### DIFF
--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -145,11 +145,7 @@ pub fn lib_main(args: Args) {
 #[cfg(feature = "python")]
 use clap::Parser;
 #[cfg(feature = "python")]
-use pyo3::{
-    Bound, PyResult, Python, pyfunction, pymodule,
-    types::{PyModule, PyModuleMethods},
-    wrap_pyfunction,
-};
+use pyo3::{PyResult, Python, pyfunction};
 
 #[cfg(feature = "python")]
 #[pyfunction]
@@ -167,11 +163,6 @@ fn py_main(_py: Python) -> PyResult<()> {
     Ok(())
 }
 
-/// A Python module implemented in Rust.
-#[cfg(feature = "python")]
-#[pymodule]
-fn adora_cli(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(py_main, &m)?)?;
-    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    Ok(())
-}
+// The `adora_cli` PyO3 module is owned by `apis/python/cli`.
+// Keeping a second `#[pymodule]` here would export another
+// `PyInit_adora_cli` symbol and fail linking.


### PR DESCRIPTION
…from CLI crate
Fix duplicate PyInit_adora_cli symbol

## Problem
Building `adora-cli-api-python` failed due to duplicate PyO3 module definitions generating the same symbol `PyInit_adora_cli`.

Both:
- binaries/cli/src/lib.rs
- apis/python/cli/src/lib.rs

defined a #[pymodule] with the same name, causing a linker error.

## Fix
- Removed the duplicate #[pymodule] from binaries/cli/src/lib.rs
- Kept module definition in apis/python/cli (correct ownership)

## Result
- Build succeeds without linker error
- Only one PyInit_adora_cli symbol exists

## Notes
- No functional changes
- CLI behavior unchanged
- Fix is minimal and scoped

##Tested on:
- Windows (local build)
- cargo build --all succeeded