### PR TITLE
cli: add reproducible git-source build lockfile

### DIFF
--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -37,6 +37,9 @@ pub fn build(
         uv.unwrap_or_default(),
         force_local,
         false,
+        false,
+        false,
+        None,
     )
 }
 

--- a/binaries/cli/src/command/build/lockfile.rs
+++ b/binaries/cli/src/command/build/lockfile.rs
@@ -8,6 +8,12 @@ use eyre::{Context, ContextCompat};
 
 const LOCKFILE_VERSION: u32 = 1;
 
+#[derive(serde::Serialize)]
+struct BuildLockfileView<'a> {
+    version: u32,
+    git_sources: &'a BTreeMap<NodeId, GitSource>,
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BuildLockfile {
     version: u32,
@@ -15,13 +21,6 @@ pub struct BuildLockfile {
 }
 
 impl BuildLockfile {
-    pub fn from_git_sources(git_sources: BTreeMap<NodeId, GitSource>) -> Self {
-        Self {
-            version: LOCKFILE_VERSION,
-            git_sources,
-        }
-    }
-
     pub fn path_for_dataflow(dataflow_path: &Path, override_path: Option<PathBuf>) -> PathBuf {
         override_path.unwrap_or_else(|| {
             let file_stem = dataflow_path
@@ -46,11 +45,18 @@ impl BuildLockfile {
         Ok(lockfile)
     }
 
-    pub fn write_to(&self, path: &Path) -> eyre::Result<()> {
+    pub fn write_git_sources(
+        path: &Path,
+        git_sources: &BTreeMap<NodeId, GitSource>,
+    ) -> eyre::Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).context("failed to create lockfile directory")?;
         }
-        let serialized = serde_yaml::to_string(self).context("failed to serialize lockfile")?;
+        let view = BuildLockfileView {
+            version: LOCKFILE_VERSION,
+            git_sources,
+        };
+        let serialized = serde_yaml::to_string(&view).context("failed to serialize lockfile")?;
         std::fs::write(path, serialized).context("failed to write lockfile")?;
         Ok(())
     }
@@ -98,8 +104,7 @@ mod tests {
             source("https://example.com/repo", "abc123"),
         );
 
-        let lockfile = BuildLockfile::from_git_sources(git_sources.clone());
-        lockfile.write_to(&lockfile_path).unwrap();
+        BuildLockfile::write_git_sources(&lockfile_path, &git_sources).unwrap();
         let loaded = BuildLockfile::read_from(&lockfile_path).unwrap();
 
         assert_eq!(loaded.version, LOCKFILE_VERSION);
@@ -113,7 +118,10 @@ mod tests {
             "node-a".parse().unwrap(),
             source("https://example.com/repo", "abc123"),
         );
-        let lockfile = BuildLockfile::from_git_sources(git_sources);
+        let lockfile = BuildLockfile {
+            version: LOCKFILE_VERSION,
+            git_sources,
+        };
 
         let err = lockfile
             .get_source(&"node-a".parse().unwrap(), "https://example.com/other")

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -95,7 +95,7 @@ pub struct Build {
     #[clap(long, action)]
     strict_types: bool,
     /// Use pinned git source commits from a lockfile.
-    #[clap(long, action)]
+    #[clap(long, action, conflicts_with = "write_lockfile")]
     locked: bool,
     /// Write resolved git source commits to a lockfile.
     #[clap(long, action)]
@@ -225,8 +225,7 @@ pub fn build(
         }
     }
     if write_lockfile {
-        let lockfile = BuildLockfile::from_git_sources(git_sources.clone());
-        lockfile.write_to(&lockfile_path).with_context(|| {
+        BuildLockfile::write_git_sources(&lockfile_path, &git_sources).with_context(|| {
             format!(
                 "failed to write build lockfile to `{}`",
                 lockfile_path.display()

--- a/binaries/cli/src/command/mod.rs
+++ b/binaries/cli/src/command/mod.rs
@@ -246,6 +246,16 @@ mod tests {
     }
 
     #[test]
+    fn parse_run_locked() {
+        parse_ok(&["adora", "run", "foo.yml", "--locked"]);
+    }
+
+    #[test]
+    fn reject_run_locked_and_write_lockfile() {
+        parse_err(&["adora", "run", "foo.yml", "--locked", "--write-lockfile"]);
+    }
+
+    #[test]
     fn parse_up() {
         parse_ok(&["adora", "up"]);
     }
@@ -278,6 +288,16 @@ mod tests {
     #[test]
     fn parse_build() {
         parse_ok(&["adora", "build", "foo.yml"]);
+    }
+
+    #[test]
+    fn parse_build_locked() {
+        parse_ok(&["adora", "build", "foo.yml", "--locked"]);
+    }
+
+    #[test]
+    fn reject_build_locked_and_write_lockfile() {
+        parse_err(&["adora", "build", "foo.yml", "--locked", "--write-lockfile"]);
     }
 
     #[test]

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -4,7 +4,7 @@
 
 use super::{Executable, system::status::daemon_running};
 use crate::{
-    LOCALHOST,
+    LOCALHOST, build as build_dataflow,
     common::{connect_with_retry, handle_dataflow_result, resolve_dataflow, write_events_to},
     output::{
         LogFormat, LogOutputConfig, parse_log_filter, parse_log_level_str, print_log_message,
@@ -22,7 +22,7 @@ use adora_message::{
 };
 use duration_str::parse as parse_duration_str;
 use eyre::{Context, ContextCompat, bail};
-use std::{collections::BTreeMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, net::SocketAddr, path::PathBuf, sync::Arc, time::Duration};
 use tokio::runtime::Builder;
 
 #[derive(Debug, clap::Args)]
@@ -81,6 +81,15 @@ pub struct Run {
     /// Enable debug mode (publishes all messages to Zenoh for topic echo/hz/info)
     #[clap(long, action)]
     pub debug: bool,
+    /// Use pinned git source commits from a lockfile during pre-run build.
+    #[clap(long, action, conflicts_with = "write_lockfile")]
+    pub locked: bool,
+    /// Write resolved git source commits to a lockfile during pre-run build.
+    #[clap(long, action)]
+    pub write_lockfile: bool,
+    /// Path to build lockfile (defaults to `<dataflow-stem>.adora-lock.yaml`).
+    #[clap(long, value_name = "PATH")]
+    pub lockfile: Option<PathBuf>,
 }
 
 impl Run {
@@ -94,6 +103,9 @@ impl Run {
             log_filter: None,
             allow_shell_nodes: false,
             debug: false,
+            locked: false,
+            write_lockfile: false,
+            lockfile: None,
         }
     }
 }
@@ -146,7 +158,19 @@ impl Executable for Run {
         };
 
         let dataflow_path =
-            resolve_dataflow(self.dataflow).context("could not resolve dataflow")?;
+            resolve_dataflow(self.dataflow.clone()).context("could not resolve dataflow")?;
+        build_dataflow(
+            dataflow_path.to_string_lossy().into_owned(),
+            None,
+            None,
+            self.uv,
+            true,
+            false,
+            self.locked,
+            self.write_lockfile,
+            self.lockfile.clone(),
+        )
+        .context("failed to build dataflow before run")?;
         let dataflow_session = DataflowSession::read_session(&dataflow_path)
             .context("failed to read DataflowSession")?;
 


### PR DESCRIPTION
## Summary

  `adora build` already resolves git-based node sources (`git + branch/tag/rev`) into concrete commit hashes before building.
  Today, those resolved commits are persisted only in `out/*.adora-session.yaml` (local cache, gitignored), which is not a shareable artifact.

  This PR adds a **shareable lockfile workflow** for git node sources so builds can be reproduced consistently across developers and CI.

  Related issue: #68

  ## Motivation

  Current behavior can drift across environments:

  - git refs are resolved dynamically at build time
  - resolved commits are stored in per-machine session cache
  - session cache is not meant to be committed

  This means two users building the same dataflow at different times can resolve different git revisions (especially for branch/default refs).

  ## What This PR Changes

  ### 1. Add lockfile support for git node sources

  New module:

  - `binaries/cli/src/command/build/lockfile.rs`

  Lockfile format:

  ```yaml
  version: 1
  git_sources:
    node-a:
      repo: https://github.com/org/repo.git
      commit_hash: 7b5d...
    node-b:
      repo: https://github.com/org/other.git
      commit_hash: f1e2...
```
  Default lockfile location:

  - <dataflow-stem>.adora-lock.yaml (co-located with the dataflow file)
    Example: dataflow.yml -> dataflow.adora-lock.yaml

  ### 2. Add CLI flags to adora build

  - --write-lockfile
    Writes resolved git source commits to lockfile.
  - --locked
    Reads git source commits from lockfile only (no dynamic ref re-resolution).
  - --lockfile <PATH>
    Uses a custom lockfile path.

  Validation:

  - --lockfile <PATH> requires either --locked or --write-lockfile.

  ### 3. Integrate lockfile into build resolution flow

  - Unlocked mode: existing behavior is preserved.
  - Locked mode: git node resolution uses lockfile entries.
  - Build fails with clear errors when:
      - lockfile is missing/unreadable
      - node entry is missing
      - repo in lockfile does not match descriptor
      - lockfile version is unsupported

  ### 4. Add focused tests

  Unit tests cover:

  - default lockfile path derivation
  - read/write roundtrip
  - repo mismatch validation

  ## Why This Matters (Project 2 Alignment)

  This is a narrow, incremental step toward package/dependency reproducibility:

  - improves reproducibility without introducing a full package manager
  - makes dependency pinning explicit and reviewable
  - strengthens trust in node build/install/publish workflows

  ## Backward Compatibility

  Default adora build behavior is unchanged unless lockfile flags are used.

  ## Scope

  ### In Scope

  - reproducibility for git-based node source dependencies in adora build

  ### Out of Scope / Non-Goals

  - full package manager
  - registry protocol changes
  - transitive dependency solving
  - runtime/deployment architecture changes

  ## Files Changed

  - binaries/cli/src/command/build/mod.rs
  - binaries/cli/src/command/build/lockfile.rs

  ## Testing

  Executed:

  - cargo test -p adora-cli lockfile
  - cargo check -p adora-cli
  - cargo fmt --check

  All passed.

  ## Example Usage

  - Resolve refs and persist lockfile
  adora build dataflow.yml --write-lockfile

  - Use pinned commits from lockfile
  adora build dataflow.yml --locked

 - Use custom lockfile path
  adora build dataflow.yml --locked --lockfile ./locks/prod.lock.yaml
