### PR TITLE
fix: resolve build errors and clippy warnings across multiple crates

### DIFF
--- a/apis/python/cli/src/lib.rs
+++ b/apis/python/cli/src/lib.rs
@@ -68,6 +68,5 @@ fn adora_cli_python(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(run, &m)?)?;
     m.add_function(wrap_pyfunction!(build, &m)?)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-
     Ok(())
 }

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -141,37 +141,3 @@ pub fn lib_main(args: Args) {
         std::process::exit(1);
     }
 }
-
-#[cfg(feature = "python")]
-use clap::Parser;
-#[cfg(feature = "python")]
-use pyo3::{
-    Bound, PyResult, Python, pyfunction, pymodule,
-    types::{PyModule, PyModuleMethods},
-    wrap_pyfunction,
-};
-
-#[cfg(feature = "python")]
-#[pyfunction]
-fn py_main(_py: Python) -> PyResult<()> {
-    Python::initialize();
-    // Skip first argument as it is a python call.
-    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
-
-    match Args::try_parse_from(args) {
-        Ok(args) => lib_main(args),
-        Err(err) => {
-            eprintln!("{err}");
-        }
-    }
-    Ok(())
-}
-
-/// A Python module implemented in Rust.
-#[cfg(feature = "python")]
-#[pymodule]
-fn adora_cli(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(py_main, &m)?)?;
-    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    Ok(())
-}


### PR DESCRIPTION
## What

This PR fixes several pre-existing build errors and clippy warnings that cause `cargo build --all \
  --exclude adora-node-api-python \
  --exclude adora-operator-api-python \
  --exclude adora-ros2-bridge-python` and `cargo clippy --all -- -D warnings` to fail on a clean checkout.

### Changes

- **`binaries/cli/src/lib.rs`** — Remove dead `#[pymodule]` block that exported a duplicate `PyInit_adora_cli` symbol, causing a linker error when building `adora-cli-api-python`
- **`apis/python/cli/src/lib.rs`** — Remove stale reference to `py_main` which no longer exists
- **`apis/python/node/src/lib.rs`** — Fix 6 clippy warnings:
  - `clone_on_copy`: replace `.clone()` with dereference on `Uuid` (line 145)
  - `manual_ok_err`: replace manual `Ok/Err` match with `.ok()` (line 251)
  - `manual_map`: replace manual `Some/None` match with `.map()` (line 603)
  - `needless_return`: remove 3 unnecessary `return` statements (lines 608, 616, 622)
- **`libraries/extensions/ros2-bridge/python/src/typed/mod.rs`** — Migrate deprecated pyo3 0.28 APIs:
  - Remove `pyo3::prepare_freethreaded_python()` (removed in pyo3 0.23+)
  - Replace `.downcast::<PyList>()` with `.cast::<PyList>()`
  - Replace `.downcast::<PyTuple>()` with `.cast::<PyTuple>()`
- **`examples/rust-dataflow-git/run.rs`** — Fix `build()` call site missing `strict_types` argument
- **`examples/rust-dataflow/run.rs`** — Fix `build()` call site missing `strict_types` argument

## Why

These are pre-existing issues in the repo that prevent a clean build and block CI. None of these were introduced by this PR.

## Testing

```bash
cargo build --all \
  --exclude adora-node-api-python \
  --exclude adora-operator-api-python \
  --exclude adora-ros2-bridge-python

cargo clippy --all -- -D warnings
cargo fmt --all
```
