### PR TITLE
fix: resolve build errors and clippy warnings across multiple crates

### DIFF
--- a/apis/python/node/src/lib.rs
+++ b/apis/python/node/src/lib.rs
@@ -142,7 +142,7 @@ impl Node {
             AdoraNode::init_from_env().context("Could not initiate node from environment variable. For dynamic node, please add a node id in the initialization function.")?
         };
         let id = node.id().clone();
-        let dataflow_id = node.dataflow_id().clone();
+        let dataflow_id = *node.dataflow_id();
         runtime()?.spawn(async move {
             let _guard = init_tracing(&id, &dataflow_id).unwrap();
             loop {
@@ -248,10 +248,7 @@ impl Node {
     #[allow(clippy::should_implement_trait)]
     pub fn try_recv(&mut self, py: Python) -> Option<Py<PyDict>> {
         match self.events.try_recv() {
-            Ok(event) => match event.to_py_dict(py) {
-                Ok(dict) => Some(dict),
-                Err(_) => None,
-            },
+            Ok(event) => event.to_py_dict(py).ok(),
             Err(_) => None,
         }
     }
@@ -603,25 +600,18 @@ impl Events {
     fn drain(&self) -> Option<Vec<PyEvent>> {
         let mut inner = self.inner.blocking_lock();
         match &mut *inner {
-            EventsInner::Adora(events) => match events.drain() {
-                Some(items) => {
-                    return Some(
-                        items
-                            .into_iter()
-                            .map(MergedEvent::Adora)
-                            .map(|event| PyEvent { event })
-                            .collect(),
-                    );
-                }
-                None => return None,
-            },
+            EventsInner::Adora(events) => events.drain().map(|items| items
+                .into_iter()
+                .map(MergedEvent::Adora)
+                .map(|event| PyEvent { event })
+                .collect()),
             EventsInner::Merged(_events) => {
                 // drain is not supported on merged event streams; return None
                 // to indicate no buffered events, matching the semantics of an
                 // empty Adora stream.
-                return None;
+                None
             }
-        };
+        }
     }
 
     fn is_empty(&self) -> bool {

--- a/binaries/cli/src/lib.rs
+++ b/binaries/cli/src/lib.rs
@@ -142,36 +142,3 @@ pub fn lib_main(args: Args) {
     }
 }
 
-#[cfg(feature = "python")]
-use clap::Parser;
-#[cfg(feature = "python")]
-use pyo3::{
-    Bound, PyResult, Python, pyfunction, pymodule,
-    types::{PyModule, PyModuleMethods},
-    wrap_pyfunction,
-};
-
-#[cfg(feature = "python")]
-#[pyfunction]
-fn py_main(_py: Python) -> PyResult<()> {
-    Python::initialize();
-    // Skip first argument as it is a python call.
-    let args = std::env::args_os().skip(1).collect::<Vec<_>>();
-
-    match Args::try_parse_from(args) {
-        Ok(args) => lib_main(args),
-        Err(err) => {
-            eprintln!("{err}");
-        }
-    }
-    Ok(())
-}
-
-/// A Python module implemented in Rust.
-#[cfg(feature = "python")]
-#[pymodule]
-fn adora_cli(_py: Python, m: Bound<'_, PyModule>) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(py_main, &m)?)?;
-    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
-    Ok(())
-}

--- a/examples/rust-dataflow-git/run.rs
+++ b/examples/rust-dataflow-git/run.rs
@@ -14,7 +14,7 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(dataflow.clone(), None, None, false, true)?;
+    build(dataflow.clone(), None, None, false, true, false)?;
 
     run(dataflow, false)?;
 

--- a/examples/rust-dataflow/run.rs
+++ b/examples/rust-dataflow/run.rs
@@ -14,7 +14,7 @@ fn main() -> eyre::Result<()> {
         "dataflow.yml".to_string()
     };
 
-    build(dataflow.clone(), None, None, false, true)?;
+    build(dataflow.clone(), None, None, false, true, false)?;
 
     run(dataflow, false)?;
 

--- a/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
+++ b/libraries/extensions/ros2-bridge/python/src/typed/mod.rs
@@ -37,7 +37,6 @@ mod tests {
     use serde_assert::Deserializer;
     #[test]
     fn test_python_array_code() -> Result<()> {
-        pyo3::prepare_freethreaded_python();
         let context = Ros2Context::new(None).context("Could not create a context")?;
         let messages = context.messages.clone();
         let serializer = Serializer::builder().build();
@@ -60,10 +59,10 @@ mod tests {
 
             let arrays = my_module.getattr("TEST_ARRAYS")?;
             let arrays = arrays
-                .downcast::<PyList>()
+                .cast::<PyList>()
                 .map_err(|err| eyre!("Could not downcast PyAny. Err: {}", err))?;
             for array_wrapper in arrays.iter() {
-                let arrays = array_wrapper.downcast::<PyTuple>().map_err(|err| {
+                let arrays = array_wrapper.cast::<PyTuple>().map_err(|err| {
                     eyre!("Could not downcast expected tuple test array. Err: {}", err)
                 })?;
                 let package_name: String = arrays.get_item(0)?.extract()?;


### PR DESCRIPTION
## What

Fixes several pre-existing build errors and clippy warnings that cause `cargo build --all` and `cargo clippy --all -- -D warnings` to fail on a clean checkout.

## Changes

**`binaries/cli/src/lib.rs`**
- Remove dead `#[pymodule]` block from `binaries/cli/src/lib.rs` that exported a duplicate `PyInit_adora_cli` symbol, causing a linker error when building `adora-cli-api-python`

**`apis/python/node/src/lib.rs`**
- `clone_on_copy`: replace `.clone()` with dereference on `Uuid` (line 145)
- `manual_ok_err`: replace manual `Ok/Err` match with `.ok()` (line 251)
- `manual_map`: replace manual `Some/None` match with `.map()` (line 603)
- `needless_return`: remove unnecessary `return` statements (lines 608, 616, 622)
- Fix trailing semicolon in `drain()` that suppressed the return value

**`libraries/extensions/ros2-bridge/python/src/typed/mod.rs`**
- Remove `pyo3::prepare_freethreaded_python()` which was removed in pyo3 0.23+
- Replace deprecated `.downcast::<PyList>()` with `.cast::<PyList>()`
- Replace deprecated `.downcast::<PyTuple>()` with `.cast::<PyTuple>()`

**`examples/rust-dataflow-git/run.rs` + `examples/rust-dataflow/run.rs`**
- Fix `build()` call sites missing the `strict_types: bool` argument added to the function signature

## Why

These are all pre-existing issues in the repo on a clean checkout of `main`. None were introduced by this PR. They block `cargo build --all` and `cargo clippy --all -- -D warnings` from passing.

## Testing

```bash
cargo build --all \
  --exclude adora-node-api-python \
  --exclude adora-operator-api-python \
  --exclude adora-ros2-bridge-python

cargo clippy --all -- -D warnings
cargo fmt --all
```

