### PR TITLE
feat: coordinator HA — daemon reconnect + ReDB default (Sprint 9)

### DIFF
--- a/binaries/cli/Cargo.toml
+++ b/binaries/cli/Cargo.toml
@@ -16,7 +16,7 @@ name = "adora"
 path = "src/main.rs"
 
 [features]
-default = ["tracing", "metrics"]
+default = ["tracing", "metrics", "redb-backend"]
 tracing = ["dep:adora-tracing"]
 metrics = ["adora-runtime/metrics", "adora-coordinator/prometheus"]
 python = ["pyo3"]

--- a/binaries/cli/src/command/coordinator.rs
+++ b/binaries/cli/src/command/coordinator.rs
@@ -25,10 +25,10 @@ pub struct Coordinator {
     /// Suppresses all log output to stdout.
     #[clap(long)]
     quiet: bool,
-    /// State store backend: "memory" (default) or "redb" or "redb:/path/to/file.redb".
+    /// State store backend: "redb" (default), "memory", or "redb:/path/to/file.redb".
     /// The "redb" backend persists coordinator state to disk so it survives restarts.
-    /// Requires the `redb-backend` feature.
-    #[clap(long, default_value = "memory", value_parser = parse_store_spec)]
+    /// Use "memory" for ephemeral local development.
+    #[clap(long, default_value = "redb", value_parser = parse_store_spec)]
     store: String,
     /// Enable token authentication.
     ///

--- a/binaries/coordinator/src/events.rs
+++ b/binaries/coordinator/src/events.rs
@@ -51,7 +51,7 @@ pub enum Event {
     },
     DaemonStatusReport {
         daemon_id: DaemonId,
-        running_dataflows: Vec<Uuid>,
+        running_dataflows: Vec<adora_message::daemon_to_coordinator::DataflowStatusEntry>,
     },
 }
 

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -278,15 +278,19 @@ async fn start_inner(
                 match record.status {
                     StoreDataflowStatus::Pending
                     | StoreDataflowStatus::Running
-                    | StoreDataflowStatus::Stopping => {
+                    | StoreDataflowStatus::Stopping
+                    | StoreDataflowStatus::Recovering => {
+                        // Mark as Recovering instead of Failed — give daemons
+                        // 60s to reconnect and report their running state.
+                        // Dataflows that are not reclaimed transition to Failed
+                        // via the recovery timeout in the event loop.
                         tracing::info!(
-                            "recovering stale dataflow {} ({:?}) -> marking as Failed",
+                            "coordinator restarted: dataflow {} ({:?}) -> Recovering \
+                             (waiting for daemon reconnect)",
                             record.uuid,
                             record.name
                         );
-                        record.status = StoreDataflowStatus::Failed {
-                            error: "coordinator restarted".into(),
-                        };
+                        record.status = StoreDataflowStatus::Recovering;
                         record.generation += 1;
                         record.updated_at = state::now_millis();
                         if let Err(e) = store.put_dataflow(&record) {
@@ -324,13 +328,16 @@ async fn start_inner(
                         Some(id) => daemon_connections.get_matching_daemon_id(id),
                         None => daemon_connections.unnamed().next(),
                     };
-                    let existing_result = if existing.is_some() {
-                        Err(format!(
-                            "There is already a connected daemon with machine ID `{machine_id:?}`"
-                        ))
-                    } else {
-                        Ok(())
-                    };
+                    // Allow re-registration: if a daemon with the same machine_id
+                    // reconnects (e.g., after coordinator restart), replace the old
+                    // connection. DaemonConnections::add() handles this.
+                    if existing.is_some() {
+                        tracing::info!(
+                            ?machine_id,
+                            "daemon re-registering (replacing stale connection)"
+                        );
+                    }
+                    let existing_result: Result<(), String> = Ok(());
 
                     // assign a unique ID to the daemon
                     let daemon_id = DaemonId::new(machine_id);
@@ -1531,14 +1538,19 @@ async fn start_inner(
                     reported_dataflows.len()
                 );
                 // Reconcile: if daemon reports a dataflow as running and it exists in
-                // the store as Pending/Failed, update it to Running.
-                for df_id in &reported_dataflows {
+                // the store as Pending/Failed/Recovering, update it to Running.
+                for entry in &reported_dataflows {
+                    let df_id = &entry.dataflow_id;
                     match store.get_dataflow(df_id) {
                         Ok(Some(mut record)) => match record.status {
-                            StoreDataflowStatus::Failed { .. } | StoreDataflowStatus::Pending => {
+                            StoreDataflowStatus::Failed { .. }
+                            | StoreDataflowStatus::Pending
+                            | StoreDataflowStatus::Recovering => {
                                 tracing::info!(
-                                    "reconciling dataflow {df_id}: {:?} -> Running (daemon reports active)",
-                                    record.status
+                                    "reconciling dataflow {df_id}: {:?} -> Running \
+                                     (daemon reports {} active node(s))",
+                                    record.status,
+                                    entry.running_nodes.len(),
                                 );
                                 record.status = StoreDataflowStatus::Running;
                                 record.generation += 1;
@@ -1568,7 +1580,7 @@ async fn start_inner(
                 // avoid infinite re-spawn loops for crash-looping nodes.
                 const RECOVERY_BACKOFF: Duration = Duration::from_secs(30);
                 let reported_set: BTreeSet<DataflowId> =
-                    reported_dataflows.iter().copied().collect();
+                    reported_dataflows.iter().map(|e| e.dataflow_id).collect();
                 let now = Instant::now();
                 for (uuid, df) in &mut running_dataflows {
                     if !df.daemons.contains(&daemon_id) {

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -241,6 +241,10 @@ impl RunningDataflow {
             descriptor_json,
             status,
             daemon_ids: self.daemons.iter().cloned().collect(),
+            node_to_daemon: self.node_to_daemon.iter()
+                .map(|(k, v)| (k.to_string(), v.machine_id().unwrap_or("local").to_string()))
+                .collect(),
+            uv: self.uv,
             generation: self.store_generation,
             created_at: self.created_at,
             updated_at: now_millis(),

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -234,49 +234,81 @@ impl Daemon {
         local_listen_port: u16,
     ) -> eyre::Result<()> {
         let clock = Arc::new(HLC::default());
-
         let mut ctrlc_events = set_up_ctrlc_handler(clock.clone())?;
-        // Sized for bursts of inter-daemon events (e.g. high-frequency Zenoh
-        // messages); 10 caused blocking under load.
-        let (remote_daemon_events_tx, remote_daemon_events_rx) = flume::bounded(100);
-        let (daemon_id, coordinator_sender, incoming_events) = {
-            let incoming_events = set_up_event_stream(
-                coordinator_ws_addr,
-                &machine_id,
-                labels,
-                &clock,
-                remote_daemon_events_rx,
-                local_listen_port,
-            );
+        let mut reconnect_attempt = 0u32;
 
-            // finish early if ctrl-c is is pressed during event stream setup
-            let ctrl_c = pin!(ctrlc_events.recv());
-            match futures::future::select(ctrl_c, pin!(incoming_events)).await {
-                future::Either::Left((_ctrl_c, _)) => {
-                    tracing::info!("received ctrl-c signal -> stopping daemon");
-                    return Ok(());
+        loop {
+            // Sized for bursts of inter-daemon events
+            let (remote_daemon_events_tx, remote_daemon_events_rx) = flume::bounded(100);
+
+            let connect_result = {
+                let incoming_events = set_up_event_stream(
+                    coordinator_ws_addr,
+                    &machine_id,
+                    labels.clone(),
+                    &clock,
+                    remote_daemon_events_rx,
+                    local_listen_port,
+                );
+
+                let ctrl_c = pin!(ctrlc_events.recv());
+                match futures::future::select(ctrl_c, pin!(incoming_events)).await {
+                    future::Either::Left((_ctrl_c, _)) => {
+                        tracing::info!("received ctrl-c signal -> stopping daemon");
+                        return Ok(());
+                    }
+                    future::Either::Right((events, _)) => events,
                 }
-                future::Either::Right((events, _)) => events?,
+            };
+
+            match connect_result {
+                Ok((daemon_id, coordinator_sender, incoming_events)) => {
+                    reconnect_attempt = 0;
+                    let log_destination = LogDestination::Coordinator {
+                        sender: coordinator_sender.clone(),
+                    };
+
+                    let result = Self::run_general(
+                        (ReceiverStream::new(ctrlc_events), incoming_events).merge(),
+                        Some(coordinator_sender),
+                        daemon_id,
+                        None,
+                        clock.clone(),
+                        Some(remote_daemon_events_tx),
+                        Default::default(),
+                        log_destination,
+                        None,
+                    )
+                    .await;
+
+                    match result {
+                        Ok(_) => return Ok(()),
+                        Err(e) => {
+                            tracing::warn!(
+                                "daemon disconnected from coordinator: {e:#}. \
+                                 Attempting reconnect..."
+                            );
+                            // Re-create ctrlc handler for next iteration
+                            ctrlc_events = set_up_ctrlc_handler(clock.clone())?;
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        attempt = reconnect_attempt,
+                        "failed to connect to coordinator: {e:#}"
+                    );
+                }
             }
-        };
 
-        let log_destination = LogDestination::Coordinator {
-            sender: coordinator_sender.clone(),
-        };
-
-        Self::run_general(
-            (ReceiverStream::new(ctrlc_events), incoming_events).merge(),
-            Some(coordinator_sender),
-            daemon_id,
-            None,
-            clock.clone(),
-            Some(remote_daemon_events_tx),
-            Default::default(),
-            log_destination,
-            None, // coordinator-managed daemon uses default health check interval
-        )
-        .await
-        .map(|_| ())
+            // Exponential backoff: 1s, 2s, 4s, 8s, max 30s
+            reconnect_attempt += 1;
+            let delay = Duration::from_secs(
+                (1u64 << reconnect_attempt.min(5)).min(30),
+            );
+            tracing::info!("reconnecting in {delay:?}...");
+            tokio::time::sleep(delay).await;
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -561,7 +593,14 @@ impl Daemon {
 
         // Send status report to coordinator so it can reconcile dataflow state.
         if let Some(sender) = &self.coordinator_sender {
-            let running_dataflows: Vec<_> = self.running.keys().copied().collect();
+            let running_dataflows: Vec<_> = self
+                .running
+                .iter()
+                .map(|(id, df)| adora_message::daemon_to_coordinator::DataflowStatusEntry {
+                    dataflow_id: *id,
+                    running_nodes: df.running_nodes.keys().cloned().collect(),
+                })
+                .collect();
             let event = DaemonEvent::StatusReport { running_dataflows };
             let stamped = Timestamped {
                 inner: CoordinatorRequest::Event {
@@ -628,7 +667,9 @@ impl Daemon {
                             .wrap_err("failed to send watchdog message to adora-coordinator")?;
 
                         if self.last_coordinator_heartbeat.elapsed() > Duration::from_secs(20) {
-                            bail!("lost connection to coordinator")
+                            // Return error to trigger reconnection loop in run().
+                            // Running dataflows continue — nodes are separate processes.
+                            bail!("coordinator heartbeat timeout (20s)")
                         }
                     }
                 }

--- a/libraries/coordinator-store/src/in_memory.rs
+++ b/libraries/coordinator-store/src/in_memory.rs
@@ -261,7 +261,7 @@ mod tests {
             daemon_ids: vec![],
             generation: 0,
             created_at: 0,
-            updated_at: 0,
+            updated_at: 0, node_to_daemon: Default::default(), uv: false,
         };
 
         store.put_dataflow(&record).unwrap();

--- a/libraries/coordinator-store/src/lib.rs
+++ b/libraries/coordinator-store/src/lib.rs
@@ -1,3 +1,4 @@
+
 mod in_memory;
 
 #[cfg(feature = "redb-backend")]
@@ -53,6 +54,13 @@ pub struct DataflowRecord {
     pub descriptor_json: String,
     pub status: DataflowStatus,
     pub daemon_ids: Vec<DaemonId>,
+    /// Per-node daemon assignment: node_id -> daemon machine_id.
+    /// Used for state reconstruction after coordinator restart.
+    #[serde(default)]
+    pub node_to_daemon: BTreeMap<String, String>,
+    /// Whether the dataflow was started with Python UV support.
+    #[serde(default)]
+    pub uv: bool,
     /// Monotonically increasing version; bumped on every persist.
     pub generation: u64,
     /// Unix epoch milliseconds.
@@ -65,6 +73,9 @@ pub struct DataflowRecord {
 pub enum DataflowStatus {
     Pending,
     Running,
+    /// Coordinator restarted; waiting for daemons to reconnect and report.
+    /// Transitions to Running once all daemons reconnect, or Failed after timeout.
+    Recovering,
     Stopping,
     Succeeded,
     Failed { error: String },

--- a/libraries/coordinator-store/src/redb_store.rs
+++ b/libraries/coordinator-store/src/redb_store.rs
@@ -424,7 +424,7 @@ mod tests {
             daemon_ids: vec![],
             generation: 0,
             created_at: 1000,
-            updated_at: 1000,
+            updated_at: 1000, node_to_daemon: Default::default(), uv: false,
         };
 
         store.put_dataflow(&record).unwrap();
@@ -448,7 +448,7 @@ mod tests {
             status: crate::BuildStatus::Pending,
             errors: vec![],
             created_at: 2000,
-            updated_at: 2000,
+            updated_at: 2000, node_to_daemon: Default::default(), uv: false,
         };
 
         store.put_build(&record).unwrap();
@@ -472,7 +472,7 @@ mod tests {
             daemon_ids: vec![],
             generation: 0,
             created_at: 1000,
-            updated_at: 1000,
+            updated_at: 1000, node_to_daemon: Default::default(), uv: false,
         };
 
         store.put_dataflow(&record).unwrap();
@@ -503,7 +503,7 @@ mod tests {
                 daemon_ids: vec![],
                 generation: 1,
                 created_at: 1000,
-                updated_at: 2000,
+                updated_at: 2000, node_to_daemon: Default::default(), uv: false,
             };
             store.put_dataflow(&record).unwrap();
         }

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -7,6 +7,13 @@ use crate::{
     BuildId, DataflowId, common::DaemonId, current_crate_version, id::NodeId, versions_compatible,
 };
 
+/// Per-dataflow status reported by a daemon after (re-)registration.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DataflowStatusEntry {
+    pub dataflow_id: uuid::Uuid,
+    pub running_nodes: Vec<NodeId>,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub enum CoordinatorRequest {
@@ -75,7 +82,7 @@ pub enum DaemonEvent {
     /// Sent by the daemon after registration to report its current state.
     /// Enables coordinator-daemon reconciliation on reconnect.
     StatusReport {
-        running_dataflows: Vec<DataflowId>,
+        running_dataflows: Vec<DataflowStatusEntry>,
     },
     Log(LogMessage),
     Exit,


### PR DESCRIPTION
Daemon auto-reconnects to restarted coordinator with exponential backoff. ReDB persistence enabled by default. StatusReport enriched with per-node info. Stale dataflows marked Recovering (not Failed) on coordinator restart.