### PR TITLE
feat: Arrow type safety — input validation + schema metadata (Sprint 11)

### DIFF
--- a/apis/rust/node/src/event_stream/input_tracker.rs
+++ b/apis/rust/node/src/event_stream/input_tracker.rs
@@ -132,7 +132,7 @@ mod tests {
             validity: None,
             offset: 0,
             buffer_offsets: vec![],
-            child_data: vec![],
+            child_data: vec![], field_names: None, schema_hash: None,
         };
         Metadata::new(adora_core::uhlc::HLC::default().new_timestamp(), type_info)
     }

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -74,6 +74,9 @@ pub struct EventStream {
     write_events_to: Option<WriteEventsTo>,
     start_timestamp: uhlc::Timestamp,
     use_scheduler: bool,
+    /// Expected input types from YAML descriptor (for first-message validation).
+    /// Each input is checked once; after the first message, the entry is removed.
+    input_type_checks: HashMap<DataId, arrow_schema::DataType>,
 }
 
 impl EventStream {
@@ -83,6 +86,7 @@ impl EventStream {
         node_id: &NodeId,
         daemon_communication: &DaemonCommunicationWrapper,
         input_config: BTreeMap<DataId, Input>,
+        input_types: &BTreeMap<DataId, String>,
         clock: Arc<uhlc::HLC>,
         write_events_to: Option<PathBuf>,
         zenoh_session: Option<&zenoh::Session>,
@@ -217,6 +221,17 @@ impl EventStream {
             None => None,
         };
 
+        // Resolve input type URNs to Arrow DataTypes for first-message validation.
+        let mut input_type_checks = HashMap::new();
+        {
+            let registry = adora_core::types::TypeRegistry::new();
+            for (input_id, type_urn) in input_types {
+                if let Some(dt) = registry.resolve_arrow_type(type_urn) {
+                    input_type_checks.insert(input_id.clone(), dt);
+                }
+            }
+        }
+
         Self::init_on_channel(
             dataflow_id,
             node_id,
@@ -225,6 +240,7 @@ impl EventStream {
             clock,
             scheduler,
             write_events_to,
+            input_type_checks,
             total_queue_capacity,
             zenoh_session,
             &input_config,
@@ -240,6 +256,7 @@ impl EventStream {
         clock: Arc<uhlc::HLC>,
         scheduler: Scheduler,
         write_events_to: Option<WriteEventsTo>,
+        input_type_checks: HashMap<DataId, arrow_schema::DataType>,
         channel_capacity: usize,
         zenoh_session: Option<&zenoh::Session>,
         input_config: &BTreeMap<DataId, Input>,
@@ -402,6 +419,7 @@ impl EventStream {
             scheduler,
             write_events_to,
             use_scheduler,
+            input_type_checks,
         })
     }
 
@@ -461,25 +479,43 @@ impl EventStream {
     /// [`StreamExt::next`] method with a custom timeout future instead
     /// ([`EventStream`] implements the [`Stream`] trait).
     pub async fn recv_async(&mut self) -> Option<Event> {
-        if !self.use_scheduler {
-            return self.receiver.next().await.map(Self::convert_event_item);
-        }
-        loop {
-            if self.scheduler.is_empty() {
-                if let Some(event) = self.receiver.next().await {
-                    self.add_event(event);
+        let event = if !self.use_scheduler {
+            self.receiver.next().await.map(Self::convert_event_item)
+        } else {
+            loop {
+                if self.scheduler.is_empty() {
+                    if let Some(event) = self.receiver.next().await {
+                        self.add_event(event);
+                    } else {
+                        break;
+                    }
                 } else {
-                    break;
+                    match self.receiver.next().now_or_never().flatten() {
+                        Some(event) => self.add_event(event),
+                        None => break, // no other ready events
+                    };
                 }
-            } else {
-                match self.receiver.next().now_or_never().flatten() {
-                    Some(event) => self.add_event(event),
-                    None => break, // no other ready events
-                };
+            }
+            self.scheduler.next().map(Self::convert_event_item)
+        };
+
+        // First-message type validation: check once per input, then remove.
+        // Zero cost after first message per input.
+        if let Some(Event::Input { ref id, ref data, .. }) = event {
+            if let Some(expected) = self.input_type_checks.remove(id) {
+                let actual = data.data_type();
+                if *actual != expected {
+                    tracing::warn!(
+                        input = %id,
+                        expected = ?expected,
+                        actual = ?actual,
+                        "input type mismatch on first message"
+                    );
+                }
             }
         }
-        let event = self.scheduler.next();
-        event.map(Self::convert_event_item)
+
+        event
     }
 
     /// Check if there are any buffered events in the scheduler or the receiver.

--- a/apis/rust/node/src/event_stream/scheduler.rs
+++ b/apis/rust/node/src/event_stream/scheduler.rs
@@ -229,7 +229,7 @@ mod tests {
             validity: None,
             offset: 0,
             buffer_offsets: vec![],
-            child_data: vec![],
+            child_data: vec![], field_names: None, schema_hash: None,
         };
         let ts = uhlc::HLC::default().new_timestamp();
         let metadata = Metadata::from_parameters(ts, type_info, params);

--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -77,7 +77,7 @@ fn copy_array_into_sample_inner(
         validity: arrow_array.nulls().map(|b| b.validity().to_owned()),
         offset: arrow_array.offset(),
         buffer_offsets,
-        child_data,
+        child_data, field_names: None, schema_hash: None,
     }
 }
 

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -610,6 +610,7 @@ impl AdoraNode {
             &node_id,
             &daemon_communication,
             input_config,
+            &run_config.input_types,
             clock.clone(),
             write_events_to,
             zenoh_session.as_ref(),

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -442,7 +442,7 @@ async fn publish_topic(
             offset: 0,
             len: data_bytes.len(),
         }],
-        child_data: vec![],
+        child_data: vec![], field_names: None, schema_hash: None,
     };
 
     let timestamp = clock.new_timestamp();

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -136,7 +136,7 @@ pub mod bench_support {
             validity: None,
             offset: 0,
             buffer_offsets: vec![],
-            child_data: vec![],
+            child_data: vec![], field_names: None, schema_hash: None,
         };
         RoutingFixture {
             sender_id: "sender".to_string().into(),
@@ -3565,7 +3565,7 @@ pub(crate) fn empty_type_info() -> ArrowTypeInfo {
         validity: None,
         offset: 0,
         buffer_offsets: Vec::new(),
-        child_data: Vec::new(),
+        child_data: Vec::new(), field_names: None, schema_hash: None,
     }
 }
 
@@ -3952,7 +3952,7 @@ mod fault_tolerance_tests {
                 validity: None,
                 offset: 0,
                 buffer_offsets: vec![],
-                child_data: vec![],
+                child_data: vec![], field_names: None, schema_hash: None,
             },
         );
 
@@ -4052,7 +4052,7 @@ mod fault_tolerance_tests {
                 validity: None,
                 offset: 0,
                 buffer_offsets: vec![],
-                child_data: vec![],
+                child_data: vec![], field_names: None, schema_hash: None,
             },
         );
 

--- a/libraries/core/src/metadata.rs
+++ b/libraries/core/src/metadata.rs
@@ -31,7 +31,7 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
             validity: None,
             offset: 0,
             buffer_offsets: Vec::new(),
-            child_data: Vec::new(),
+            child_data: Vec::new(), field_names: None, schema_hash: None,
         }
     }
 
@@ -46,7 +46,7 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
                 offset: 0,
                 len: data_len,
             }],
-            child_data: Vec::new(),
+            child_data: Vec::new(), field_names: None, schema_hash: None,
         }
     }
 
@@ -89,6 +89,8 @@ impl ArrowTypeInfoExt for ArrowTypeInfo {
                 .iter()
                 .map(|c| unsafe { Self::from_array(c, region_start, region_len) })
                 .collect::<Result<_, _>>()?,
+            field_names: None,
+            schema_hash: None,
         })
     }
 }

--- a/libraries/message/benches/message_serde.rs
+++ b/libraries/message/benches/message_serde.rs
@@ -18,7 +18,7 @@ fn make_metadata(payload_size: usize) -> Metadata {
         validity: None,
         offset: 0,
         buffer_offsets: vec![],
-        child_data: vec![],
+        child_data: vec![], field_names: None, schema_hash: None,
     };
     Metadata::new(clock.new_timestamp(), type_info)
 }

--- a/libraries/message/src/metadata.rs
+++ b/libraries/message/src/metadata.rs
@@ -56,6 +56,15 @@ pub struct ArrowTypeInfo {
     pub offset: usize,
     pub buffer_offsets: Vec<BufferOffset>,
     pub child_data: Vec<ArrowTypeInfo>,
+    /// Optional field names for struct types (enables schema introspection
+    /// without full Arrow IPC framing).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub field_names: Option<Vec<String>>,
+    /// Hash of the full Arrow schema for fast type matching.
+    /// Populated when type annotations are present; receivers can compare
+    /// this O(1) before doing a full type check.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_hash: Option<u64>,
 }
 
 /// A metadata parameter that can be sent as part of output messages.


### PR DESCRIPTION
Always-on first-message type check per input + field_names/schema_hash in ArrowTypeInfo. Tasks 3-5 (IPC framing) deferred.