### PR TITLE
chore(coordinator): polish replay follow up from #78

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -29,7 +29,8 @@ use futures_concurrency::stream::Merge;
 use indexmap::IndexMap;
 use log_subscriber::LogSubscriber;
 use petname::petname;
-use serde::de::IgnoredAny;
+use serde::Serialize;
+use serde_json::value::RawValue;
 pub(crate) use state::DaemonConnections;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -1998,22 +1999,38 @@ fn build_set_param_message_from_raw_json(
     value_json: &[u8],
     timestamp: adora_core::uhlc::Timestamp,
 ) -> eyre::Result<Vec<u8>> {
-    // Validate payload is valid JSON without allocating a full Value.
-    serde_json::from_slice::<IgnoredAny>(value_json)
+    #[derive(Serialize)]
+    struct SetParamPayloadRaw<'a> {
+        dataflow_id: DataflowId,
+        node_id: &'a adora_core::config::NodeId,
+        key: &'a str,
+        value: &'a RawValue,
+    }
+    #[derive(Serialize)]
+    enum DaemonCoordinatorEventRaw<'a> {
+        SetParam(SetParamPayloadRaw<'a>),
+    }
+    #[derive(Serialize)]
+    struct TimestampedDaemonEventRaw<'a> {
+        inner: DaemonCoordinatorEventRaw<'a>,
+        timestamp: adora_core::uhlc::Timestamp,
+    }
+
+    // Parse persisted bytes as raw JSON once, then rely on serde for
+    // envelope serialization instead of manual string JSON assembly.
+    let value = serde_json::from_slice::<Box<RawValue>>(value_json)
         .map_err(|e| eyre!("invalid persisted param JSON: {e}"))?;
 
-    let value_json = std::str::from_utf8(value_json)
-        .map_err(|e| eyre!("persisted param is not valid UTF-8 JSON: {e}"))?;
-
-    let dataflow_id_json = serde_json::to_string(&dataflow_id)?;
-    let node_id_json = serde_json::to_string(node_id)?;
-    let key_json = serde_json::to_string(key)?;
-    let timestamp_json = serde_json::to_string(&timestamp)?;
-
-    Ok(format!(
-        r#"{{"inner":{{"SetParam":{{"dataflow_id":{dataflow_id_json},"node_id":{node_id_json},"key":{key_json},"value":{value_json}}}}},"timestamp":{timestamp_json}}}"#
-    )
-    .into_bytes())
+    serde_json::to_vec(&TimestampedDaemonEventRaw {
+        inner: DaemonCoordinatorEventRaw::SetParam(SetParamPayloadRaw {
+            dataflow_id,
+            node_id,
+            key,
+            value: value.as_ref(),
+        }),
+        timestamp,
+    })
+    .map_err(Into::into)
 }
 
 fn schedule_param_replay_for_ready_dataflow(

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -99,7 +99,11 @@ impl DaemonConnection {
     ///
     /// Embeds raw JSON bytes directly to preserve u128 fidelity
     /// for uhlc::ID inside timestamps.
-    /// Maximum number of in-flight requests per daemon connection.
+    /// Maximum number of in-flight requests per `DaemonConnection` clone.
+    ///
+    /// `DaemonConnection` is cloneable and each clone keeps an independent
+    /// pending-reply map, so this cap is enforced per clone rather than
+    /// globally per WebSocket connection.
     const MAX_PENDING_REPLIES: usize = 256;
 
     pub(crate) async fn send_and_receive(&self, message: &[u8]) -> eyre::Result<Vec<u8>> {


### PR DESCRIPTION
 Follow up to merged PR #78 (blocking review notes only).

  ## Context

  In #78, replay on ready was merged and approved. During re-review, a few minor polish items were noted as safe follow up work.

  ## What This PR Changes

  1. Clarifies pending-reply cap semantics in `DaemonConnection`
  - Adds explicit documentation that `MAX_PENDING_REPLIES` is enforced per `DaemonConnection` clone.

  2. Hardens replay message serialization
  - Replaces manual `format!`-based JSON assembly in `build_set_param_message_from_raw_json`.
  - Uses structured serde serialization with `serde_json::value::RawValue` for safer envelope construction while preserving raw JSON payload handling.

  ## What This PR Does NOT Change

  - No protocol/message contract changes.
  - No replay lifecycle/behavior changes.
  - No architecture changes.

  ## Files Changed

  - `binaries/coordinator/src/state.rs`
  - `binaries/coordinator/src/lib.rs`

  ## Validation

  Executed locally:

  - `cargo fmt --all`
  - `cargo clippy -p adora-coordinator -- -D warnings`
  - `cargo test -p adora-coordinator replay_ -q`

  All passed.