### PR TITLE
feat: support Arrow IPC and hex binary input in interactive testing mode

### DIFF
--- a/apis/rust/node/src/daemon_connection/interactive.rs
+++ b/apis/rust/node/src/daemon_connection/interactive.rs
@@ -7,7 +7,7 @@ use adora_message::{
     metadata::{ArrowTypeInfo, Metadata},
     node_to_daemon::DaemonRequest,
 };
-use arrow::array::{Array, StructArray, UInt8Array};
+use arrow::array::{Array, UInt8Array};
 use colored::Colorize;
 use eyre::{Context, ContextCompat};
 
@@ -175,36 +175,52 @@ impl InteractiveEvents {
 }
 
 /// Read the first batch from an Arrow IPC file and return it as `ArrayData`.
+///
+/// This opens arbitrary user-provided file paths. It is intended for
+/// interactive (REPL) testing only and should not be used in
+/// non-interactive contexts without path validation.
 fn read_arrow_ipc_file(path: &Path) -> eyre::Result<arrow::array::ArrayData> {
+    eyre::ensure!(!path.as_os_str().is_empty(), "FILE: path is empty");
     let file =
         std::fs::File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
     let mut reader = arrow::ipc::reader::FileReader::try_new(file, None)
         .context("failed to read Arrow IPC file")?;
+    if reader.num_batches() > 1 {
+        tracing::warn!(
+            "Arrow IPC file {} has {} batches, only the first will be used",
+            path.display(),
+            reader.num_batches()
+        );
+    }
     let batch = reader
         .next()
         .context("Arrow IPC file has no batches")?
         .context("failed to read batch from Arrow IPC file")?;
-    // Return first column if single-column, otherwise return as struct
-    if batch.num_columns() == 1 {
-        Ok(batch.column(0).to_data())
-    } else {
-        Ok(StructArray::from(batch).to_data())
-    }
+    eyre::ensure!(
+        batch.num_columns() == 1,
+        "Arrow IPC file must have exactly 1 column, got {}",
+        batch.num_columns()
+    );
+    Ok(batch.column(0).to_data())
 }
 
 /// Decode a hex string into a `UInt8Array`.
 fn decode_hex_as_uint8_array(hex: &str) -> eyre::Result<arrow::array::ArrayData> {
     eyre::ensure!(!hex.is_empty(), "HEX: input is empty");
+    eyre::ensure!(hex.is_ascii(), "HEX: input contains non-ASCII characters");
     eyre::ensure!(
         hex.len() % 2 == 0,
         "HEX: odd number of characters ({}), hex bytes must come in pairs",
         hex.len()
     );
-    let bytes: Vec<u8> = (0..hex.len())
-        .step_by(2)
-        .map(|i| {
-            u8::from_str_radix(&hex[i..i + 2], 16)
-                .with_context(|| format!("invalid hex at position {i}"))
+    let bytes: Vec<u8> = hex
+        .as_bytes()
+        .chunks(2)
+        .enumerate()
+        .map(|(i, chunk)| {
+            let s = std::str::from_utf8(chunk)
+                .with_context(|| format!("non-ASCII at byte {}", i * 2))?;
+            u8::from_str_radix(s, 16).with_context(|| format!("invalid hex at position {}", i * 2))
         })
         .collect::<eyre::Result<Vec<u8>>>()?;
     let array = UInt8Array::from(bytes);
@@ -267,5 +283,50 @@ mod tests {
         assert_eq!(i32arr.values().as_ref(), &[1, 2, 3]);
 
         std::fs::remove_file(&tmpfile).ok();
+    }
+
+    #[test]
+    fn test_read_arrow_ipc_file_multi_column_rejected() {
+        use arrow::array::Int32Array;
+        use arrow::datatypes::{DataType, Field, Schema};
+        use arrow::ipc::writer::FileWriter;
+        use arrow::record_batch::RecordBatch;
+        use std::sync::Arc;
+
+        let tmpfile = std::env::temp_dir().join("test_interactive_multi.arrow");
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                Arc::new(Int32Array::from(vec![3, 4])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let file = std::fs::File::create(&tmpfile).unwrap();
+        let mut writer = FileWriter::try_new(file, &schema).unwrap();
+        writer.write(&batch).unwrap();
+        writer.finish().unwrap();
+
+        let err = read_arrow_ipc_file(&tmpfile).unwrap_err();
+        assert!(err.to_string().contains("exactly 1 column"));
+
+        std::fs::remove_file(&tmpfile).ok();
+    }
+
+    #[test]
+    fn test_read_arrow_ipc_file_empty_path() {
+        assert!(read_arrow_ipc_file(Path::new("")).is_err());
+    }
+
+    #[test]
+    fn test_decode_hex_utf8_input() {
+        // Multi-byte UTF-8 should be rejected by the ASCII check
+        assert!(decode_hex_as_uint8_array("\u{00e9}\u{00e9}").is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Extend the interactive testing mode Data prompt to accept `FILE:<path>` for Arrow IPC files and `HEX:<hexstring>` for raw binary bytes
- Previously only text/JSON was supported, blocking manual testing of nodes that receive images, sensor buffers, or other binary Arrow types
- Reuses existing Arrow IPC reading patterns from the integration testing module
- 5 unit tests covering hex decode (valid, empty, odd-length, invalid chars) and Arrow IPC file round-trip

Closes #89 (inspired by dora-rs/dora#1560)

## Test plan

- [x] `cargo test -p adora-node-api -- interactive` (5 tests pass)
- [x] `cargo clippy -p adora-node-api -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Generated with [Claude Code](https://claude.ai/code)