### PR TITLE
ci: add benchmark regression detection job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
   bench:
     name: Benchmark regression check
     runs-on: ubuntu-latest
+    needs: test
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -100,42 +102,45 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
 
-      # Restore baseline from the most recent main-branch run
+      # Restore baseline from the most recent main-branch run.
+      # The key uses a fixed prefix; restore-keys enables prefix matching
+      # so the most recent main-branch save is found.
       - name: Restore baseline
         id: cache-baseline
         uses: actions/cache/restore@v4
         with:
-          path: target/criterion-baseline
-          key: bench-baseline-${{ runner.os }}
+          path: target/criterion
+          key: bench-baseline-${{ runner.os }}-not-used
+          restore-keys: bench-baseline-${{ runner.os }}-
 
-      # Run benchmarks and save results
+      # Compile benchmarks first (separates build errors from bench issues)
+      - name: Compile benchmarks
+        run: |
+          cargo bench -p adora-message -p shared-memory-server --no-run
+          cargo bench -p adora-daemon --features bench --no-run
+
+      # Run benchmarks. Criterion automatically compares against any
+      # existing data in target/criterion/ (restored from cache above).
       - name: Run benchmarks
         run: |
-          cargo bench -p adora-message -p shared-memory-server \
-            -- --output-format bencher 2>&1 | tee bench-output.txt
-          cargo bench -p adora-daemon --features bench \
-            -- --output-format bencher 2>&1 | tee -a bench-output.txt
+          cargo bench -p adora-message -p shared-memory-server 2>/dev/null | tee bench-output.txt
+          cargo bench -p adora-daemon --features bench 2>/dev/null | tee -a bench-output.txt
 
-      # Compare against baseline (informational, does not fail CI)
-      - name: Compare against baseline
-        if: steps.cache-baseline.outputs.cache-hit == 'true'
+      # Always post results to step summary
+      - name: Post results
+        if: always()
         run: |
           echo "## Benchmark Results" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
-          cat bench-output.txt >> "$GITHUB_STEP_SUMMARY"
+          cat bench-output.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "(no output)" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
-      # On main branch: save new baseline for future comparisons
-      - name: Save baseline
-        if: github.ref == 'refs/heads/main'
-        run: |
-          mkdir -p target/criterion-baseline
-          cp -r target/criterion/* target/criterion-baseline/ 2>/dev/null || true
+      # On main branch: save criterion data as the new baseline
       - name: Cache baseline
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && success()
         uses: actions/cache/save@v4
         with:
-          path: target/criterion-baseline
+          path: target/criterion
           key: bench-baseline-${{ runner.os }}-${{ github.sha }}
 
   typos:


### PR DESCRIPTION
## Summary

- Add a `bench` job to CI that runs the three existing criterion benchmark suites on every push to main and every PR
- Benchmarks: message serde, shared memory round-trip, daemon message routing
- Results posted to GitHub Actions step summary for visibility
- Main-branch runs cache the baseline via `actions/cache` for future comparisons
- Informational only (does not fail CI), provides visibility into performance changes

Closes #91 (inspired by dora-rs/dora#1559)

## Benchmark suites run

| Crate | Benchmark | What it measures |
|-------|-----------|-----------------|
| `adora-message` | `message_serde` | Bincode serialize/deserialize at 64B-1MB |
| `shared-memory-server` | `shmem_bench` | Shared memory round-trip at 64B-16KB |
| `adora-daemon` | `routing` | Message routing with fan-out 1/4/8 at 64B-64KB |

## Test plan

- [x] All three benchmark crates compile with `cargo bench --no-run`
- [x] CI YAML is valid
- [x] Daemon benchmarks use `--features bench` flag

Generated with [Claude Code](https://claude.ai/code)