### PR TITLE
fix: dynamic node startup respects daemon's configured listen port

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -270,10 +270,15 @@ impl AdoraNode {
     ///
     pub fn init_from_node_id(node_id: NodeId) -> NodeResult<(Self, EventStream)> {
         // Make sure that the node is initialized outside of adora start.
-        let port = std::env::var(ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV)
-            .ok()
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT);
+        let port = match std::env::var(ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV) {
+            Ok(p) => p.parse().unwrap_or_else(|e| {
+                tracing::warn!(
+                    "invalid {ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV}={p:?}: {e}, using default port"
+                );
+                ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT
+            }),
+            Err(_) => ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
+        };
         let daemon_address = (LOCALHOST, port).into();
 
         let mut channel =

--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -1,7 +1,8 @@
 use super::Executable;
 use crate::{common::handle_dataflow_result, session::DataflowSession};
 use adora_core::topics::{
-    ADORA_COORDINATOR_PORT_WS_DEFAULT, ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST,
+    ADORA_COORDINATOR_PORT_WS_DEFAULT, ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT,
+    ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST,
 };
 
 use adora_daemon::LogDestination;
@@ -61,6 +62,15 @@ impl Executable for Daemon {
             // SAFETY: Called before spawning any threads (tokio runtime not yet built),
             // so there are no concurrent reads of environment variables.
             unsafe { std::env::set_var("ADORA_ALLOW_SHELL_NODES", "true") };
+        }
+        // Export the listen port so dynamic nodes (and spawned child processes)
+        // can discover it via env var.
+        // SAFETY: Called before the tokio runtime is built (no threads yet).
+        unsafe {
+            std::env::set_var(
+                ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV,
+                self.local_listen_port.to_string(),
+            );
         }
 
         let mut builder = Builder::new_multi_thread();

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -6,8 +6,8 @@ use adora_core::{
         read_as_descriptor,
     },
     topics::{
-        ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV, LOCALHOST,
-        open_zenoh_session, zenoh_output_publish_topic,
+        ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT, LOCALHOST, open_zenoh_session,
+        zenoh_output_publish_topic,
     },
     uhlc::{self, HLC},
 };
@@ -450,15 +450,6 @@ impl Daemon {
         labels: BTreeMap<String, String>,
         local_listen_port: u16,
     ) -> eyre::Result<()> {
-        // Export the port so dynamic nodes can discover it via env var.
-        // SAFETY: called once at daemon startup before spawning threads.
-        unsafe {
-            std::env::set_var(
-                ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV,
-                local_listen_port.to_string(),
-            );
-        }
-
         let clock = Arc::new(HLC::default());
         let mut ctrlc_events = set_up_ctrlc_handler(clock.clone())?;
         let mut reconnect_attempt = 0u32;


### PR DESCRIPTION
## Summary

- `AdoraNode::init_from_node_id()` now reads `ADORA_DAEMON_LOCAL_LISTEN_PORT` env var before falling back to port 53291
- Daemon exports this env var at startup so spawned child processes inherit it
- New constant `ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV` in `libraries/core/src/topics.rs`

Previously, dynamic nodes always connected to port 53291 regardless of the daemon's `--local-listen-port` setting, causing "Connection refused" errors.

Closes #103 (inspired by dora-rs/dora#1548)

## Changed files

| File | Change |
|------|--------|
| `libraries/core/src/topics.rs` | New `ADORA_DAEMON_LOCAL_LISTEN_PORT_ENV` constant |
| `apis/rust/node/src/node/mod.rs` | `init_from_node_id` reads env var for port |
| `binaries/daemon/src/lib.rs` | Exports env var at daemon startup |

## Test plan

- [x] `cargo clippy -p adora-node-api -p adora-daemon -p adora-core -- -D warnings` (clean)
- [x] `cargo test -p adora-core -p adora-node-api` (all pass)
- [x] `cargo fmt --all -- --check` (clean)

Generated with [Claude Code](https://claude.ai/code)