### PR TITLE
docs: resolve PyArrow FFI memory leak TODO with investigation findings

### DIFF
--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -173,7 +173,10 @@ impl PyEvent {
     fn value(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         match &self.event {
             MergedEvent::Adora(Event::Input { data, .. }) => {
-                // TODO: Does this call leak data?&
+                // Ownership transfer: to_data() clones buffer Arcs, to_pyarrow()
+                // creates an FFI_ArrowArray with a release callback. PyArrow's
+                // _import_from_c takes ownership and calls release when the Python
+                // object is GC'd, which drops the cloned Arcs. No leak.
                 let array_data = data.to_data().to_pyarrow(py)?.unbind();
                 Ok(Some(array_data))
             }


### PR DESCRIPTION
## Summary

Replace the TODO comment in `apis/python/operator/src/lib.rs:176` ("Does this call leak data?") with a documented explanation of why it does not leak.

## Investigation

Traced the full ownership chain through arrow-pyarrow-58.0.0:

1. `FFI_ArrowArray::new(data)` clones buffer Arc refs and sets `release: Some(release_array)`
2. PyArrow's `_import_from_c` takes ownership, calls release callback
3. `release_array` drops `ArrayPrivateData` (frees cloned Arcs)
4. Rust Drop finds `release = None`, no double-free

**Conclusion: The FFI transfer is correct. No memory leak.**

If users observe OOM in long-running operators, likely causes are Python-side reference retention or GC not running frequently enough, not the FFI boundary.

Refs #107

## Test plan

- [x] `cargo clippy -p adora-operator-api -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Generated with [Claude Code](https://claude.ai/code)