### PR TITLE
fix: replace expect() on pipe capture with proper error return

### DIFF
--- a/libraries/core/src/build/build_command.rs
+++ b/libraries/core/src/build/build_command.rs
@@ -53,8 +53,18 @@ pub async fn run_build_command(
             .spawn()
             .wrap_err_with(|| format!("failed to spawn `{build}`"))?;
 
-        let child_stdout = BufReader::new(child.stdout.take().expect("failed to take stdout"));
-        let child_stderr = BufReader::new(child.stderr.take().expect("failed to take stderr"));
+        let child_stdout = BufReader::new(
+            child
+                .stdout
+                .take()
+                .ok_or_else(|| eyre!("failed to capture stdout pipe from build command"))?,
+        );
+        let child_stderr = BufReader::new(
+            child
+                .stderr
+                .take()
+                .ok_or_else(|| eyre!("failed to capture stderr pipe from build command"))?,
+        );
         let stdout_tx = stdout_tx.clone();
 
         tokio::spawn(async move {


### PR DESCRIPTION
## Summary

Replace `.expect()` with `.ok_or_else(|| eyre!(...))` when taking stdout/stderr pipes from spawned build commands. A missing pipe now returns a descriptive error instead of panicking.

Only one location in adora was affected: `libraries/core/src/build/build_command.rs:56-57`. The daemon spawn path already handles this correctly.

Closes #113 (inspired by dora-rs/dora#1499)

## Test plan

- [x] `cargo test -p adora-core` (101 tests pass)
- [x] `cargo clippy -p adora-core -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)

Generated with [Claude Code](https://claude.ai/code)