### PR TITLE
perf: cache Python datetime module import on operator hot path

### DIFF
--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -14,9 +14,19 @@ use futures::{Stream, StreamExt};
 use futures_concurrency::stream::Merge as _;
 use pyo3::{
     prelude::*,
+    sync::GILOnceCell,
     types::{IntoPyDict, PyBool, PyDict, PyFloat, PyInt, PyList, PyModule, PyString, PyTuple},
 };
 use std::time::UNIX_EPOCH;
+
+/// Cached Python `datetime` module to avoid repeated `PyModule::import` on the hot path.
+static DATETIME_MODULE: GILOnceCell<Py<PyModule>> = GILOnceCell::new();
+
+fn datetime_module<'py>(py: Python<'py>) -> PyResult<&'py Bound<'py, PyModule>> {
+    Ok(DATETIME_MODULE
+        .get_or_try_init(py, || PyModule::import(py, "datetime").map(|m| m.unbind()))?
+        .bind(py))
+}
 
 /// Adora Event
 pub struct PyEvent {
@@ -239,8 +249,8 @@ pub fn pydict_to_metadata(dict: Option<Bound<'_, PyDict>>) -> Result<MetadataPar
                 parameters.insert(key, Parameter::ListString(list))
             } else {
                 // Check if it's a datetime.datetime object
-                let datetime_module = PyModule::import(value.py(), "datetime")
-                    .context("Failed to import datetime module")?;
+                let datetime_module =
+                    datetime_module(value.py()).context("Failed to import datetime module")?;
                 let datetime_class = datetime_module.getattr("datetime")?;
 
                 if value.is_instance(datetime_class.as_ref())? {
@@ -300,8 +310,7 @@ pub fn metadata_to_pydict<'a>(
     // Get UTC timezone from Python's datetime module and create timezone-aware datetime
     // We use Python's datetime.fromtimestamp() to create a UTC-aware datetime object
     // This avoids float precision loss by using integer seconds and microseconds
-    let datetime_module =
-        PyModule::import(py, "datetime").context("Failed to import datetime module")?;
+    let datetime_module = datetime_module(py).context("Failed to import datetime module")?;
     let datetime_class = datetime_module.getattr("datetime")?;
     let utc_timezone = datetime_module.getattr("timezone")?.getattr("utc")?;
 
@@ -347,7 +356,7 @@ pub fn metadata_to_pydict<'a>(
 
                 // Get UTC timezone from Python's datetime module
                 let datetime_module =
-                    PyModule::import(py, "datetime").context("Failed to import datetime module")?;
+                    datetime_module(py).context("Failed to import datetime module")?;
                 let datetime_class = datetime_module.getattr("datetime")?;
                 let utc_timezone = datetime_module.getattr("timezone")?.getattr("utc")?;
 


### PR DESCRIPTION
## Summary

Replace 3 per-message `PyModule::import(py, "datetime")` calls with a `GILOnceCell` that imports once and reuses the reference. The datetime module is now cached statically and imported exactly once per process lifetime.

**Before:** Every message triggers 3 Python module lookups in the operator metadata parsing path.
**After:** Module is resolved once, subsequent calls return a cached reference.

Closes #117 (inspired by dora-rs/dora#1550)

## Changed call sites

| Line | Function | Before | After |
|------|----------|--------|-------|
| 252 | `pydict_to_metadata_parameters` | `PyModule::import()` | `datetime_module()` |
| 313 | `timestamp_to_pydatetime` | `PyModule::import()` | `datetime_module()` |
| 359 | datetime parameter parsing | `PyModule::import()` | `datetime_module()` |

## Test plan

- [x] `cargo clippy -p adora-operator-api -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check` (clean)
- [x] No remaining direct `PyModule::import.*datetime` calls except the one-time init

Generated with [Claude Code](https://claude.ai/code)