### PR TITLE
fix: replace deprecated ArrowTimestampType::make_value

### DIFF
--- a/libraries/arrow-convert/src/into_impls.rs
+++ b/libraries/arrow-convert/src/into_impls.rs
@@ -98,10 +98,11 @@ impl IntoArrow for Vec<String> {
 impl IntoArrow for NaiveDateTime {
     type A = arrow::array::TimestampNanosecondArray;
     fn into_arrow(self) -> Self::A {
-        let timestamp = match arrow::datatypes::TimestampNanosecondType::make_value(self) {
-            Some(timestamp) => timestamp,
-            None => arrow::datatypes::TimestampNanosecondType::default_value(),
-        };
+        let timestamp =
+            match arrow::datatypes::TimestampNanosecondType::from_naive_datetime(self, None) {
+                Some(timestamp) => timestamp,
+                None => arrow::datatypes::TimestampNanosecondType::default_value(),
+            };
         TimestampNanosecondArray::from(vec![timestamp])
     }
 }


### PR DESCRIPTION
## Summary

- Replace deprecated `ArrowTimestampType::make_value` with `from_naive_datetime` in `adora-arrow-convert`
- `make_value` was deprecated in arrow 58; CI clippy (`-D warnings`) rejects it

## Test plan

- [x] `cargo clippy -p adora-arrow-convert -- -D warnings` passes
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)