### PR TITLE
fix(cli): guard locked builds with descriptor source fingerprint

### DIFF
--- a/binaries/cli/src/command/build/lockfile.rs
+++ b/binaries/cli/src/command/build/lockfile.rs
@@ -3,17 +3,15 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use adora_message::{common::GitSource, descriptor::GitRepoRev, id::NodeId};
+use adora_message::{
+    common::GitSource,
+    descriptor::{GitRepoRev, NodeSource},
+    id::NodeId,
+};
 use eyre::{Context, ContextCompat};
 
 const LOCKFILE_VERSION: u32 = 2;
 const MIN_SUPPORTED_LOCKFILE_VERSION: u32 = 1;
-
-#[derive(Debug, Clone)]
-pub struct DescriptorGitSource {
-    pub repo: String,
-    pub rev: Option<GitRepoRev>,
-}
 
 #[derive(serde::Serialize)]
 struct BuildLockfileView<'a> {
@@ -56,33 +54,47 @@ impl BuildLockfile {
         Ok(lockfile)
     }
 
-    pub fn fingerprint_descriptor_git_sources(
-        descriptor_git_sources: &BTreeMap<NodeId, DescriptorGitSource>,
+    pub(crate) fn fingerprint_descriptor_git_sources(
+        descriptor_git_sources: &BTreeMap<NodeId, NodeSource>,
     ) -> String {
-        let mut out = String::new();
-        out.push_str(&format!("adora-lockfile-v{LOCKFILE_VERSION}\n"));
+        let mut canonical = String::new();
+        // Intentional: include schema version in canonical content so lockfile format
+        // bumps force regeneration even if descriptor sources are unchanged.
+        canonical.push_str(&format!("adora-lockfile-v{LOCKFILE_VERSION}\n"));
 
         for (node_id, source) in descriptor_git_sources {
-            out.push_str(node_id.as_ref());
-            out.push('\n');
-            out.push_str(&source.repo);
-            out.push('\n');
-            let (kind, value) = match &source.rev {
+            let NodeSource::GitBranch { repo, rev } = source else {
+                continue;
+            };
+            canonical.push_str(node_id.as_ref());
+            canonical.push('\n');
+            canonical.push_str(repo);
+            canonical.push('\n');
+            let (kind, value) = match rev {
                 Some(GitRepoRev::Branch(v)) => ("branch", v.as_str()),
                 Some(GitRepoRev::Tag(v)) => ("tag", v.as_str()),
                 Some(GitRepoRev::Rev(v)) => ("rev", v.as_str()),
                 None => ("head", ""),
             };
-            out.push_str(kind);
-            out.push(':');
-            out.push_str(value);
-            out.push('\n');
+            canonical.push_str(kind);
+            canonical.push(':');
+            canonical.push_str(value);
+            canonical.push('\n');
         }
 
-        out
+        // Deterministic compact digest (FNV-1a 64-bit). This is for reproducibility
+        // drift detection, not cryptographic integrity.
+        const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+        const FNV_PRIME: u64 = 0x100000001b3;
+        let mut hash = FNV_OFFSET_BASIS;
+        for byte in canonical.as_bytes() {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+        format!("{hash:016x}")
     }
 
-    pub fn ensure_descriptor_fingerprint_matches(&self, expected: &str) -> eyre::Result<()> {
+    pub(crate) fn ensure_descriptor_fingerprint_matches(&self, expected: &str) -> eyre::Result<()> {
         let Some(actual) = self.descriptor_fingerprint.as_deref() else {
             eyre::bail!(
                 "lockfile is missing `descriptor_fingerprint` (v1 format). \
@@ -162,7 +174,7 @@ mod tests {
         );
         descriptor_git_sources.insert(
             "node-a".parse().unwrap(),
-            DescriptorGitSource {
+            NodeSource::GitBranch {
                 repo: "https://example.com/repo".to_string(),
                 rev: Some(GitRepoRev::Branch("main".to_string())),
             },
@@ -204,7 +216,7 @@ mod tests {
         let mut before = BTreeMap::new();
         before.insert(
             "node-a".parse().unwrap(),
-            DescriptorGitSource {
+            NodeSource::GitBranch {
                 repo: "https://example.com/repo".to_string(),
                 rev: Some(GitRepoRev::Branch("main".to_string())),
             },
@@ -212,7 +224,7 @@ mod tests {
         let mut after = before.clone();
         after.insert(
             "node-b".parse().unwrap(),
-            DescriptorGitSource {
+            NodeSource::GitBranch {
                 repo: "https://example.com/repo2".to_string(),
                 rev: Some(GitRepoRev::Tag("v1.2.3".to_string())),
             },

--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -66,7 +66,7 @@ use crate::{
 
 use distributed::{build_distributed_dataflow, wait_until_dataflow_built};
 use local::build_dataflow_locally;
-use lockfile::{BuildLockfile, DescriptorGitSource};
+use lockfile::BuildLockfile;
 
 mod distributed;
 mod git;
@@ -215,27 +215,21 @@ pub fn build(
     let resolved_nodes = dataflow_descriptor
         .resolve_aliases_and_set_defaults()
         .context("failed to resolve nodes")?;
-    for (node_id, node) in resolved_nodes {
+    // Pass 1 (fail-fast): derive descriptor git-source fingerprint and validate lockfile
+    // provenance before any per-node locked-source lookups.
+    for (node_id, node) in &resolved_nodes {
         if let CoreNodeKind::Custom(CustomNode {
             source: NodeSource::GitBranch { repo, rev },
             ..
-        }) = node.kind
+        }) = &node.kind
         {
             descriptor_git_sources.insert(
                 node_id.clone(),
-                DescriptorGitSource {
+                NodeSource::GitBranch {
                     repo: repo.clone(),
                     rev: rev.clone(),
                 },
             );
-            let source = match &build_lockfile {
-                Some(lockfile) => lockfile
-                    .get_source(&node_id, &repo)
-                    .with_context(|| format!("failed to resolve locked git source `{node_id}`"))?,
-                None => git::fetch_commit_hash(repo, rev)
-                    .with_context(|| format!("failed to find commit hash for `{node_id}`"))?,
-            };
-            git_sources.insert(node_id, source);
         }
     }
     let descriptor_fingerprint =
@@ -249,6 +243,24 @@ pub fn build(
                     dataflow_path.display()
                 )
             })?;
+    }
+    // Pass 2: resolve each node's concrete source, now that lockfile provenance
+    // has been validated (when `--locked` is enabled).
+    for (node_id, node) in resolved_nodes {
+        if let CoreNodeKind::Custom(CustomNode {
+            source: NodeSource::GitBranch { repo, rev },
+            ..
+        }) = node.kind
+        {
+            let source = match &build_lockfile {
+                Some(lockfile) => lockfile
+                    .get_source(&node_id, &repo)
+                    .with_context(|| format!("failed to resolve locked git source `{node_id}`"))?,
+                None => git::fetch_commit_hash(repo, rev)
+                    .with_context(|| format!("failed to find commit hash for `{node_id}`"))?,
+            };
+            git_sources.insert(node_id, source);
+        }
     }
     if write_lockfile {
         BuildLockfile::write_git_sources(&lockfile_path, &git_sources, &descriptor_fingerprint)


### PR DESCRIPTION
## Summary

  This PR strengthens lockfile reproducibility by adding a descriptor/source fingerprint guard for `adora build --locked`.

  `--locked` now validates that the lockfile was generated from the same descriptor git-source graph currently being built, preventing stale lockfile usage.

  Closes: #127

  ## Problem / Impact

  Lockfiles introduced in #69 pin git commits, but they did not validate provenance against the current descriptor graph.

  As a result, `--locked` could still proceed when descriptor/source intent had drifted, reducing determinism across:

  - descriptor -> resolution
  - lockfile -> build execution
  - local/CI reproducibility

  ## What changed

  ### 1) Lockfile schema extension

  - Lockfile version remains `2` for this feature line.
  - Added `descriptor_fingerprint` field to lockfile payload.

  ### 2) Deterministic fingerprint generation (compact digest)

  - Fingerprint input is a canonical descriptor git-source representation:
    - node id
    - repo
    - rev kind/value (`branch` / `tag` / `rev` / default `head`)
  - Fingerprint output is a deterministic compact digest:
    - **FNV-1a 64-bit hex**
  - Fingerprint canonical content intentionally includes a version prefix:
    - `adora-lockfile-v{LOCKFILE_VERSION}`
    - This intentionally forces regeneration when lockfile schema version changes.

  ### 3) Fail-fast locked-mode validation order

  `--locked` path is now explicitly two-pass:

  - **Pass 1 (fail-fast):**
    - collect descriptor git-source graph
    - compute expected fingerprint
    - validate lockfile fingerprint
  - **Pass 2:**
    - resolve per-node locked git sources (`get_source`) / normal fetch path

  This ensures users get the correct top-level drift error before per-node lockfile entry errors.

  ### 4) Backward-compat behavior

  - Reader accepts lockfile versions in `1..=2`.
  - In `--locked`, v1 lockfiles are rejected if fingerprint is missing, with clear remediation:
    - regenerate via `adora build --write-lockfile`.

  ### 5) Type/visibility cleanup from review

  - Reused existing descriptor type (`NodeSource::GitBranch`) for descriptor source map.
  - Removed duplicated helper struct.
  - Reduced helper visibility to `pub(crate)` for:
    - `fingerprint_descriptor_git_sources`
    - `ensure_descriptor_fingerprint_matches`

  ## Files changed

  - `binaries/cli/src/command/build/lockfile.rs`
  - `binaries/cli/src/command/build/mod.rs`

  (Previous preparatory commit also touched `Cargo.toml` / `Cargo.lock`; final implementation no longer needs extra crypto dependency.)

  ## Design decisions / tradeoffs

  - Kept implementation self-contained in CLI build lockfile flow.
  - Used deterministic non-cryptographic digest (FNV-1a) for compactness and speed.
  - This is reproducibility drift detection, not cryptographic integrity.
  - No coordinator/daemon/runtime protocol changes.

  ## Tests added/updated

  - lockfile read/write roundtrip includes fingerprint validation.
  - drift test confirms descriptor git-source graph change alters fingerprint.
  - v1 lockfile rejection in `--locked` mode (missing fingerprint).
  - existing lockfile behavior tests remain passing.

  ## Validation

  Following `CONTRIBUTING.md` expectations:

  - `cargo fmt --all`
  - `cargo clippy -p adora-cli -- -D warnings`
  - `cargo test -p adora-cli lockfile -- --nocapture`
  - `cargo test --test ws-cli-e2e -- --test-threads=1`
  - `cargo test --test fault-tolerance-e2e -- --test-threads=1`

  All passed locally.

  ## Scope

  ### In scope

  - lockfile integrity guard for `--locked`
  - deterministic descriptor/source fingerprinting
  - fail-fast validation ordering
  - focused CLI lockfile + e2e validation

  ### Out of scope

  - package manager semantics redesign
  - transitive dependency solving
  - runtime/coordinator protocol changes