### PR TITLE
ci: restore macOS example testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,39 @@ jobs:
           cargo test --test fault-tolerance-e2e -- --test-threads=1
         timeout-minutes: 15
 
+  examples:
+    name: Examples (${{ matrix.platform }})
+    runs-on: ${{ matrix.platform }}
+    needs: test
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build CLI
+        run: cargo build -p adora-cli --release
+      - name: Install CLI (Linux)
+        if: runner.os == 'Linux'
+        run: cp target/release/adora /usr/local/bin/adora
+      - name: Install CLI (macOS)
+        if: runner.os == 'macOS'
+        run: cp target/release/adora /usr/local/bin/adora
+      - name: Build examples
+        timeout-minutes: 30
+        run: cargo build --examples
+      - name: Rust Dataflow example
+        timeout-minutes: 30
+        run: cargo run --example rust-dataflow
+      - name: Multiple Daemons example
+        timeout-minutes: 30
+        run: cargo run --example multiple-daemons
+
   bench:
     name: Benchmark regression check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Restore cross-platform example testing that was dropped during the CI rewrite
- Add an `examples` job running on both `ubuntu-latest` and `macos-latest`
- Runs `rust-dataflow` and `multiple-daemons` examples end-to-end

## Context

The old CI ran examples on all platforms (ubuntu, macos, windows). When CI was rebuilt, example testing was replaced with E2E tests that only run on Ubuntu. This left macOS without any end-to-end dataflow testing.

As a result, a daemon TCP deserialization regression on macOS aarch64 went undetected — dataflow execution is completely broken on Apple Silicon (see #135).

This PR will **intentionally fail on macOS** until #135 is fixed, which is the point — it makes the regression visible in CI.

Fixes #136

## Test plan
- [ ] CI runs the `examples` job on both Ubuntu and macOS
- [ ] Ubuntu examples should pass
- [ ] macOS examples will fail (expected — demonstrates the bug in #135)

🤖 Generated with [Claude Code](https://claude.com/claude-code)