### PR TITLE
fix(node): prevent tokio timer panic in rust-dataflow example

### DIFF
--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -1611,8 +1611,13 @@ pub fn init_tracing(
     // dataflow_id is only used when metrics feature is enabled
     let _ = &dataflow_id;
 
+    // Only start the OTLP metrics exporter when an endpoint is configured.
+    // The exporter schedules via `tokio::time::interval` and would otherwise
+    // panic on callers whose runtime lacks the time driver, and would also
+    // attempt to connect to `localhost:4317` on every node startup. Mirrors
+    // the gating applied to tracing above.
     #[cfg(feature = "metrics")]
-    {
+    if std::env::var("ADORA_OTLP_ENDPOINT").is_ok() {
         let id = format!("{dataflow_id}/{node_id}");
         let monitor_task = async move {
             use adora_metrics::run_metrics_monitor;
@@ -1626,7 +1631,7 @@ pub fn init_tracing(
         };
         let rt = Handle::try_current().context("failed to get tokio runtime handle")?;
         rt.spawn(monitor_task);
-    };
+    }
     Ok(guard)
 }
 

--- a/examples/rust-dataflow/node/src/main.rs
+++ b/examples/rust-dataflow/node/src/main.rs
@@ -12,6 +12,7 @@ fn main() -> eyre::Result<()> {
 
     let (node, events) = AdoraNode::init_from_env()?;
     let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
         .build()
         .context("failed to build tokio runtime")?;
     let rt_guard = rt.enter();


### PR DESCRIPTION
## Summary

- Fixes the `"A Tokio 1.x context was found, but timers are disabled"` panic in the `rust-dataflow` example (#133)
- Root cause is two coupled bugs: the example's runtime was built without `enable_all()`, and `init_tracing` unconditionally started the OTLP metrics monitor (which schedules via `tokio::time::interval`)
- Gate the metrics monitor on `ADORA_OTLP_ENDPOINT`, matching the gate already on the tracing setup directly above it. This also stops every node from silently connecting to `localhost:4317` on startup

## Details

**`examples/rust-dataflow/node/src/main.rs`** — add `.enable_all()` to the runtime builder. Every other runtime builder in the repo already does this (e.g. `binaries/cli/src/command/run.rs:142`, `binaries/cli/src/command/daemon.rs:77`, `binaries/runtime/src/lib.rs:65`). The omission was introduced when the example was simplified upstream and ported into adora.

**`apis/rust/node/src/node/mod.rs`** — gate the `#[cfg(feature = "metrics")]` block on `ADORA_OTLP_ENDPOINT`. `init_metrics` always builds a gRPC OTLP exporter aimed at `localhost:4317` and registers it as a periodic exporter, so it was running on every node built with default features regardless of user intent. The tracing setup immediately above already gates on the same env var — this change just brings metrics in line with it.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-node-api -p rust-dataflow-example-node -- -D warnings`
- [x] `cargo test --release --test example-smoke smoke_rust_dataflow*` — 3/3 pass (`smoke_rust_dataflow`, `smoke_rust_dataflow_dynamic`, `smoke_rust_dataflow_url`)
- [x] `adora run examples/rust-dataflow/dataflow.yml --stop-after 3s` — no more tokio timer panic

## Note on a separate issue surfaced during triage

While verifying the fix I observed a distinct pre-existing bug specific to `adora run` single-shot mode: `rust-status-node` reports `"failed to deserialize DaemonReply: io error"` at `apis/rust/node/src/daemon_connection/tcp.rs:61` immediately after the dataflow starts, and the dataflow terminates before any ticks are processed. This error is present in the original report on #133 as well, just buried under the panic cascade. The `adora up` / `adora start --detach` / `adora stop` path (used by `run_smoke_test`) is unaffected — smoke tests pass cleanly. Will file as a separate issue; it is **not** addressed by this PR.

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)
