### PR TITLE
feat(message): implement adora/timer/hz/N timer unit

### DIFF
--- a/libraries/message/src/config.rs
+++ b/libraries/message/src/config.rs
@@ -247,7 +247,7 @@ impl FromStr for InputMapping {
             "adora" => match output.split_once('/') {
                 Some(("timer", output)) => {
                     let (unit, value) = output.split_once('/').ok_or(
-                        "timer input must specify unit and value (e.g. `secs/5` or `millis/100`)",
+                        "timer input must specify unit and value (e.g. `secs/5`, `millis/100`, or `hz/30`)",
                     )?;
                     let interval = match unit {
                         "secs" => {
@@ -262,9 +262,20 @@ impl FromStr for InputMapping {
                             })?;
                             Duration::from_millis(value)
                         }
+                        "hz" => {
+                            let hz: f64 = value.parse().map_err(|_| {
+                                format!("hz must be a positive number (got `{value}`)")
+                            })?;
+                            if !hz.is_finite() || hz <= 0.0 {
+                                return Err(format!(
+                                    "hz must be a positive finite number (got `{value}`)"
+                                ));
+                            }
+                            Duration::from_secs_f64(1.0 / hz)
+                        }
                         other => {
                             return Err(format!(
-                                "timer unit must be either secs or millis (got `{other}`"
+                                "timer unit must be `secs`, `millis`, or `hz` (got `{other}`)"
                             ));
                         }
                     };
@@ -458,6 +469,52 @@ mod tests {
         let yaml = serde_yaml::to_string(&input).unwrap();
         let parsed: Input = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(input, parsed);
+    }
+
+    /// Regression tests for dora-rs/adora#144: `adora/timer/hz/N` is
+    /// documented across README, guide, schema, and real examples
+    /// (`streaming-example`, `dynamic-agent-tools`) but the parser
+    /// previously only accepted `secs` / `millis`.
+    #[test]
+    fn parse_timer_hz_integer() {
+        let mapping: InputMapping = "adora/timer/hz/30".parse().unwrap();
+        match mapping {
+            InputMapping::Timer { interval } => {
+                // 1 / 30 Hz ≈ 33.333 ms
+                assert_eq!(interval, Duration::from_secs_f64(1.0 / 30.0));
+            }
+            other => panic!("expected Timer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_timer_hz_fractional() {
+        // Used in examples/streaming-example/dataflow.yml
+        let mapping: InputMapping = "adora/timer/hz/0.5".parse().unwrap();
+        match mapping {
+            InputMapping::Timer { interval } => {
+                assert_eq!(interval, Duration::from_secs(2));
+            }
+            other => panic!("expected Timer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_timer_hz_rejects_zero() {
+        let err = "adora/timer/hz/0".parse::<InputMapping>().unwrap_err();
+        assert!(err.contains("hz"), "error should mention hz: {err}");
+    }
+
+    #[test]
+    fn parse_timer_hz_rejects_negative() {
+        let err = "adora/timer/hz/-1".parse::<InputMapping>().unwrap_err();
+        assert!(err.contains("hz"), "error should mention hz: {err}");
+    }
+
+    #[test]
+    fn parse_timer_hz_rejects_non_numeric() {
+        let err = "adora/timer/hz/foo".parse::<InputMapping>().unwrap_err();
+        assert!(err.contains("hz"), "error should mention hz: {err}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`adora/timer/hz/N` is documented across README, CLAUDE.md, yaml-spec.md, cli.md, python-guide.md, the quickstart guide, and the JSON schema. Two real example dataflows already use it:

- `examples/streaming-example/dataflow.yml` → `adora/timer/hz/0.5`
- `examples/dynamic-agent-tools/dataflow.yml` → `adora/timer/hz/1`

But the parser only accepted `secs` and `millis`, so any dataflow using `hz` fails at load time with:

```
Error: timer unit must be either secs or millis (got `hz`
```

(Note the stray unclosed backtick and missing `)` — also pre-existing, fixed here.)

## Fix

Add the `hz` branch to `InputMapping::from_str` in `libraries/message/src/config.rs`:

- Accepts any positive finite number (integer or fractional)
- Converts frequency to interval via `Duration::from_secs_f64(1.0 / hz)`
- Rejects zero, negative, non-finite, and non-numeric values with clear errors
- Updates the fallback error to advertise `hz` alongside `secs`/`millis`

## Wire format note

The canonical `Duration` is stored in the descriptor and re-serialized via `FormattedDuration`, which emits `secs/N` or `millis/N`. Round-tripping `hz/30` produces `millis/33` — about 1% drift. Users who need exact sub-millisecond timing should continue using `millis/N` directly; `hz` is intended for human-readable rate declarations where 1% is acceptable (e.g. 0.5 Hz, 1 Hz, 30 Hz). `hz/0.5` round-trips losslessly as `secs/2`.

## Regression tests

Five new tests in `libraries/message/src/config.rs::tests`:

- `parse_timer_hz_integer` — `hz/30` → `Duration::from_secs_f64(1.0 / 30.0)`
- `parse_timer_hz_fractional` — `hz/0.5` → `Duration::from_secs(2)` (matches the real streaming-example value)
- `parse_timer_hz_rejects_zero`
- `parse_timer_hz_rejects_negative`
- `parse_timer_hz_rejects_non_numeric`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-message -- -D warnings`
- [x] `cargo test -p adora-message` — 77/77 pass (72 existing + 5 new)
- [x] `adora validate examples/streaming-example/dataflow.yml` — OK
- [x] `adora validate examples/dynamic-agent-tools/dataflow.yml` — OK

Fixes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
