### PR TITLE
fix(python): expose NodeRestarted/InputRecovered/Reload/Param events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,8 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "pyo3",
+ "pythonize",
+ "serde_json",
  "serde_yaml",
 ]
 

--- a/apis/python/operator/Cargo.toml
+++ b/apis/python/operator/Cargo.toml
@@ -23,3 +23,5 @@ aligned-vec = "0.5.0"
 futures = { workspace = true }
 futures-concurrency = "7.3.0"
 chrono = { version = "0.4", features = ["serde"] }
+pythonize = { workspace = true }
+serde_json = { workspace = true }

--- a/apis/python/operator/src/lib.rs
+++ b/apis/python/operator/src/lib.rs
@@ -156,20 +156,32 @@ impl PyEvent {
             .unbind())
     }
 
-    fn ty(event: &Event) -> &str {
+    fn ty(event: &Event) -> &'static str {
         match event {
             Event::Stop(_) => "STOP",
             Event::Input { .. } => "INPUT",
             Event::InputClosed { .. } => "INPUT_CLOSED",
+            Event::InputRecovered { .. } => "INPUT_RECOVERED",
+            Event::NodeRestarted { .. } => "NODE_RESTARTED",
+            Event::Reload { .. } => "RELOAD",
+            Event::ParamUpdate { .. } => "PARAM_UPDATE",
+            Event::ParamDeleted { .. } => "PARAM_DELETED",
             Event::Error(_) => "ERROR",
+            // `Event` is `#[non_exhaustive]`; surface genuinely new variants
+            // as UNKNOWN rather than failing to build on future adora upgrades.
             _other => "UNKNOWN",
         }
     }
 
     fn id(event: &Event) -> Option<&str> {
         match event {
-            Event::Input { id, .. } => Some(id),
-            Event::InputClosed { id } => Some(id),
+            Event::Input { id, .. } => Some(id.as_ref()),
+            Event::InputClosed { id } => Some(id.as_ref()),
+            Event::InputRecovered { id } => Some(id.as_ref()),
+            Event::NodeRestarted { id } => Some(id.as_ref()),
+            Event::Reload { operator_id } => operator_id.as_ref().map(|id| id.as_ref()),
+            Event::ParamUpdate { key, .. } => Some(key.as_str()),
+            Event::ParamDeleted { key } => Some(key.as_str()),
             Event::Stop(cause) => match cause {
                 StopCause::Manual => Some("MANUAL"),
                 StopCause::AllInputsClosed => Some("ALL_INPUTS_CLOSED"),
@@ -179,7 +191,10 @@ impl PyEvent {
         }
     }
 
-    /// Returns the payload of an input event as an arrow array (if any).
+    /// Returns the payload of an event as a Python object (if any).
+    ///
+    /// - `Input`: the Arrow array payload.
+    /// - `ParamUpdate`: the new parameter value, converted from JSON.
     fn value(&self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         match &self.event {
             MergedEvent::Adora(Event::Input { data, .. }) => {
@@ -189,6 +204,14 @@ impl PyEvent {
                 // object is GC'd, which drops the cloned Arcs. No leak.
                 let array_data = data.to_data().to_pyarrow(py)?.unbind();
                 Ok(Some(array_data))
+            }
+            MergedEvent::Adora(Event::ParamUpdate { value, .. }) => {
+                // `pythonize` converts serde_json::Value recursively into native
+                // Python types (None, bool, int, float, str, list, dict).
+                let obj = pythonize::pythonize(py, value)
+                    .context("failed to convert ParamUpdate value to Python")?
+                    .unbind();
+                Ok(Some(obj))
             }
             _ => Ok(None),
         }
@@ -468,5 +491,69 @@ mod tests {
         assert_roundtrip(&list_array).context("ListArray roundtrip failed")?;
 
         Ok(())
+    }
+
+    // Regression tests for dora-rs/adora#147: Python event conversion used
+    // to return "UNKNOWN" with no id for five event types, making fault
+    // tolerance and runtime parameters unusable from Python.
+    mod py_event_types {
+        use super::super::PyEvent;
+        use adora_node_api::{
+            Event,
+            adora_core::config::{DataId, NodeId, OperatorId},
+        };
+
+        #[test]
+        fn node_restarted_has_type_and_id() {
+            let event = Event::NodeRestarted {
+                id: NodeId::from("upstream".to_string()),
+            };
+            assert_eq!(PyEvent::ty(&event), "NODE_RESTARTED");
+            assert_eq!(PyEvent::id(&event), Some("upstream"));
+        }
+
+        #[test]
+        fn input_recovered_has_type_and_id() {
+            let event = Event::InputRecovered {
+                id: DataId::from("sensor".to_string()),
+            };
+            assert_eq!(PyEvent::ty(&event), "INPUT_RECOVERED");
+            assert_eq!(PyEvent::id(&event), Some("sensor"));
+        }
+
+        #[test]
+        fn reload_has_type_and_operator_id() {
+            let event = Event::Reload {
+                operator_id: Some(OperatorId::from("op-1".to_string())),
+            };
+            assert_eq!(PyEvent::ty(&event), "RELOAD");
+            assert_eq!(PyEvent::id(&event), Some("op-1"));
+        }
+
+        #[test]
+        fn reload_without_operator_has_no_id() {
+            let event = Event::Reload { operator_id: None };
+            assert_eq!(PyEvent::ty(&event), "RELOAD");
+            assert_eq!(PyEvent::id(&event), None);
+        }
+
+        #[test]
+        fn param_update_has_type_and_key() {
+            let event = Event::ParamUpdate {
+                key: "threshold".to_string(),
+                value: serde_json::json!(0.85),
+            };
+            assert_eq!(PyEvent::ty(&event), "PARAM_UPDATE");
+            assert_eq!(PyEvent::id(&event), Some("threshold"));
+        }
+
+        #[test]
+        fn param_deleted_has_type_and_key() {
+            let event = Event::ParamDeleted {
+                key: "threshold".to_string(),
+            };
+            assert_eq!(PyEvent::ty(&event), "PARAM_DELETED");
+            assert_eq!(PyEvent::id(&event), Some("threshold"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #147. The Python event conversion at `apis/python/operator/src/lib.rs` mapped five event types to `{"type": "UNKNOWN"}` with no accessible id or value. Any Python node that relied on fault-tolerance recovery (`restart_policy`, `input_timeout`) or runtime parameters (`adora param set`/`delete`) was effectively blind — it saw an opaque `UNKNOWN` event with no way to extract the restarted node id, the recovered input id, or the parameter key and value.

`adora-node-api-python` re-exports `PyEvent` from this crate, so the fix reaches both the node and the operator Python APIs.

## Events now exposed

| Event variant | `type` | `id` | `value` |
|---|---|---|---|
| `NodeRestarted { id }` | `NODE_RESTARTED` | node id | — |
| `InputRecovered { id }` | `INPUT_RECOVERED` | input id | — |
| `Reload { operator_id }` | `RELOAD` | operator id (if present) | — |
| `ParamUpdate { key, value }` | `PARAM_UPDATE` | key | JSON value converted to Python (None/bool/int/float/str/list/dict via `pythonize`) |
| `ParamDeleted { key }` | `PARAM_DELETED` | key | — |

`Event` is `#[non_exhaustive]`, so the `_other => "UNKNOWN"` arm is kept as a forward-compat fallback for genuinely new variants.

## Dependencies

Added `pythonize` and `serde_json` to `apis/python/operator/Cargo.toml`. Both are already workspace dependencies (`pythonize` is used by `adora-node-api-python`, `serde_json` is used throughout the codebase).

## Tests

Six new regression tests in `tests::py_event_types`, covering every previously-UNKNOWN variant plus the `Reload { operator_id: None }` edge case:

- `node_restarted_has_type_and_id`
- `input_recovered_has_type_and_id`
- `reload_has_type_and_operator_id`
- `reload_without_operator_has_no_id`
- `param_update_has_type_and_key`
- `param_deleted_has_type_and_key`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-operator-api-python -p adora-node-api-python -- -D warnings`
- [x] `cargo test -p adora-operator-api-python` — 7/7 pass (1 existing + 6 new)

Fixes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
