### PR TITLE
fix(daemon): input_timeout unarmed until first message arrives

### DIFF
--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1738,7 +1738,11 @@ impl Daemon {
                 {
                     continue;
                 }
-                if deadline.last_received.elapsed() > deadline.timeout {
+                // Only count elapsed time once the input has actually
+                // received a message. Inputs that never saw traffic are
+                // considered "not yet armed" — see InputDeadline::is_timed_out
+                // (dora-rs/adora#149).
+                if deadline.is_timed_out() {
                     timed_out.push((node_id.clone(), input_id.clone(), deadline.timeout));
                 }
             }
@@ -2070,7 +2074,9 @@ impl Daemon {
                                     (node.id.clone(), input_id.clone()),
                                     InputDeadline {
                                         timeout: Duration::from_secs_f64(timeout),
-                                        last_received: Instant::now(),
+                                        // Unarmed until the first message
+                                        // arrives — see issue #149.
+                                        last_received: None,
                                     },
                                 );
                             }
@@ -3552,7 +3558,7 @@ async fn send_output_to_local_receivers(
                         .input_deadlines
                         .get_mut(&(receiver_id.clone(), input_id.clone()))
                     {
-                        deadline.last_received = Instant::now();
+                        deadline.last_received = Some(Instant::now());
                     }
                     // Circuit breaker recovery: re-open broken input
                     if let Some(timeout) = dataflow
@@ -3577,7 +3583,8 @@ async fn send_output_to_local_receivers(
                             (receiver_id.clone(), input_id.clone()),
                             InputDeadline {
                                 timeout,
-                                last_received: Instant::now(),
+                                // A message just arrived — arm immediately.
+                                last_received: Some(Instant::now()),
                             },
                         );
                         match send_with_timestamp(
@@ -4232,7 +4239,7 @@ mod fault_tolerance_tests {
             (receiver.clone(), input.clone()),
             InputDeadline {
                 timeout,
-                last_received: Instant::now(),
+                last_received: Some(Instant::now()),
             },
         );
 

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -46,7 +46,30 @@ use process_wrap::tokio::TokioChildWrapper;
 
 pub(crate) struct InputDeadline {
     pub timeout: Duration,
-    pub last_received: Instant,
+    /// Wall-clock time of the most recent message delivery.
+    ///
+    /// `None` means the input has never received a message and the
+    /// circuit-breaker clock should NOT count against it yet. This
+    /// prevents false-positive timeouts on on-demand inputs that are
+    /// legitimately idle at dataflow startup — most notably service
+    /// response inputs on clients that haven't sent a request yet
+    /// (dora-rs/adora#149).
+    pub last_received: Option<Instant>,
+}
+
+impl InputDeadline {
+    /// Returns `true` if the circuit breaker should fire for this input.
+    ///
+    /// An input is only considered timed out once it has received at
+    /// least one message (`last_received = Some(_)`) and the elapsed
+    /// time since that message exceeds the configured timeout. An
+    /// input that has never received a message is never timed out
+    /// — its clock is unarmed (dora-rs/adora#149).
+    pub fn is_timed_out(&self) -> bool {
+        self.last_received
+            .map(|t| t.elapsed() > self.timeout)
+            .unwrap_or(false)
+    }
 }
 
 #[derive(Debug)]
@@ -524,5 +547,62 @@ impl RunningDataflow {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- dora-rs/adora#149: InputDeadline::is_timed_out ----
+
+    #[test]
+    fn unarmed_deadline_is_never_timed_out() {
+        // An input that has never received a message (last_received = None)
+        // must not trip the circuit breaker, even if `timeout` has long
+        // since elapsed relative to dataflow start. This prevents false
+        // positives on service response inputs that are legitimately idle
+        // until the client sends its first request.
+        let deadline = InputDeadline {
+            timeout: Duration::from_millis(1),
+            last_received: None,
+        };
+        std::thread::sleep(Duration::from_millis(5));
+        assert!(!deadline.is_timed_out());
+    }
+
+    #[test]
+    fn armed_deadline_within_timeout_is_not_timed_out() {
+        let deadline = InputDeadline {
+            timeout: Duration::from_secs(60),
+            last_received: Some(Instant::now()),
+        };
+        assert!(!deadline.is_timed_out());
+    }
+
+    #[test]
+    fn armed_deadline_past_timeout_is_timed_out() {
+        let deadline = InputDeadline {
+            timeout: Duration::from_millis(1),
+            last_received: Some(Instant::now() - Duration::from_millis(10)),
+        };
+        assert!(deadline.is_timed_out());
+    }
+
+    #[test]
+    fn arming_a_previously_unarmed_deadline_starts_the_clock() {
+        // Simulates: input starts unarmed, first message arrives, the
+        // clock begins counting, timeout must elapse before firing.
+        let mut deadline = InputDeadline {
+            timeout: Duration::from_millis(50),
+            last_received: None,
+        };
+        assert!(!deadline.is_timed_out(), "unarmed should not fire");
+
+        deadline.last_received = Some(Instant::now());
+        assert!(
+            !deadline.is_timed_out(),
+            "just-armed should not fire immediately"
+        );
     }
 }

--- a/docs/fault-tolerance.md
+++ b/docs/fault-tolerance.md
@@ -174,28 +174,32 @@ nodes:
 
 The `input_timeout` is set per input, not per node. Different inputs can have different timeouts.
 
+> **Warning — not for on-demand inputs.** `input_timeout` assumes the upstream publishes continuously. Do **not** set it on inputs that are only populated in response to an outbound request (service response inputs, action result inputs, or any other bursty / on-demand channel). Natural idle periods will look identical to a dead upstream and trip the circuit breaker spuriously. For per-request waits, use [`EventStream::recv_service_response(request_id, server, timeout)`](../apis/rust/node/src/event_stream/mod.rs) or [`EventStream::recv_action_result(goal_id, server, timeout)`](../apis/rust/node/src/event_stream/mod.rs) instead — they bound each individual request without tripping the dataflow-level circuit breaker. See `docs/patterns.md` §6 "Fault tolerance for correlated patterns".
+
 ### How It Works Internally
 
 The daemon maintains an `InputDeadline` for each input with a timeout:
 
 ```
 struct InputDeadline {
-    timeout: Duration,        // configured timeout
-    last_received: Instant,   // last time data arrived
+    timeout: Duration,                   // configured timeout
+    last_received: Option<Instant>,      // last time data arrived (None = unarmed)
 }
 ```
 
 These are stored in `RunningDataflow.input_deadlines` keyed by `(NodeId, DataId)`.
 
+**Deadline arming**: `last_received` starts as `None` at dataflow start. The circuit-breaker clock does not count against the input until the first message actually arrives (see `InputDeadline::is_timed_out`). This prevents false positives on inputs that are idle at startup — dora-rs/adora#149.
+
 **Timeout detection** runs during the same 5-second health check interval. The `check_input_timeouts` function:
 
 1. Scans all `input_deadlines` entries
-2. If `last_received.elapsed() > timeout`, the input is "broken"
+2. For armed entries only (`last_received = Some(_)`), if `last_received.elapsed() > timeout`, the input is "broken"
 3. The `(node_id, input_id)` pair is moved from `input_deadlines` to `broken_inputs`
 4. The daemon calls `break_input()` which sends `InputClosed { id }` to the downstream node
 5. If all of a node's inputs are now closed (and none are broken/recoverable), `AllInputsClosed` is sent and the node's restart is disabled
 
-**Deadline reset**: Every time data arrives on an input, its `last_received` is reset to `Instant::now()`.
+**Deadline arming/reset**: Every time data arrives on an input, its `last_received` is set to `Some(Instant::now())`, both arming a previously-unarmed deadline and resetting an already-armed one.
 
 ### Circuit Breaker: Auto-Recovery
 


### PR DESCRIPTION
## Summary

Fixes #149. The `input_timeout` circuit breaker previously started its clock at dataflow launch, so on-demand inputs that were legitimately idle at startup — most notably a service client's response input before it sent its first request — would trip the breaker the moment their configured timeout elapsed, even though the upstream was completely healthy.

## Fix

Change `InputDeadline::last_received` from `Instant` to `Option<Instant>`:

| State | Value | Behavior |
|---|---|---|
| Dataflow start | `None` | **Unarmed** — clock does not count, timeout cannot fire |
| First message arrives | `Some(now)` | Armed, clock starts |
| Subsequent messages | `Some(now)` | Reset, clock restarts |
| Circuit breaker recovery | `Some(now)` | Armed immediately (recovery is triggered by a message that just arrived) |

`check_input_timeouts` skips unarmed entries. The predicate is extracted into a small `InputDeadline::is_timed_out()` helper so the decision logic is unit-testable without a full daemon fixture.

## Semantic compatibility

Subtle change: an input that **never receives any message** is no longer caught by `input_timeout`. For dead-on-arrival upstreams, `health_check_timeout` + `restart_policy` are the right tools — they specifically catch "upstream never started." `input_timeout` is now strictly for the "went stale after being healthy" case, which matches its intent and the existing docs language ("detect stale upstream data").

Inputs that do receive traffic behave identically to before — same reset-on-receive, same cascading `InputClosed` / `AllInputsClosed` semantics, same circuit-breaker recovery flow.

## Tests

Four new unit tests in `binaries/daemon/src/running_dataflow.rs::tests`:

| Test | Scenario |
|---|---|
| `unarmed_deadline_is_never_timed_out` | Core fix: `None` + 5ms sleep + 1ms timeout → not timed out |
| `armed_deadline_within_timeout_is_not_timed_out` | Baseline |
| `armed_deadline_past_timeout_is_timed_out` | Baseline |
| `arming_a_previously_unarmed_deadline_starts_the_clock` | Transition: unarmed → first message → armed, no immediate fire |

All 20 existing daemon tests pass unchanged (fault tolerance + log rotation), confirming behavior compatibility for inputs that do receive traffic.

## Docs

`docs/fault-tolerance.md`:

1. **New warning** under the `input_timeout` YAML example explicitly telling users NOT to set it on service response / action result inputs. Points at `recv_service_response` / `recv_action_result` (added in #162) for per-request timeouts that don't involve the dataflow-level circuit breaker.
2. **"How It Works Internally"** updated to describe the unarmed start state and the new `is_timed_out()` helper.

## Relationship to other PRs

Conceptually related to #161 (NodeRestarted delivery + InputTracker) and #162 (pattern-aware recv helpers) — together they cover the fault-tolerance story for correlated patterns. No file conflicts with either. Either can merge first.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-daemon -- -D warnings`
- [x] `cargo test -p adora-daemon` — 24/24 pass (20 existing + 4 new)

Fixes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
