### PR TITLE
fix(node-api): skip type checks on polymorphic pattern messages

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -525,21 +525,42 @@ impl EventStream {
 
         // First-message type validation: check once per input, then remove.
         // Zero cost after first message per input.
+        //
+        // Skip the check when the message carries pattern metadata
+        // (`request_id`, `goal_id`, or `goal_status`) — the input is
+        // polymorphic by pattern design and a single declared type
+        // cannot cover all variants. The check stays armed so a later
+        // non-pattern message can still validate (dora-rs/adora#150).
         if let Some(Event::Input {
-            ref id, ref data, ..
+            ref id,
+            ref metadata,
+            ref data,
         }) = event
-            && let Some(expected) = self.input_type_checks.remove(id)
+            && let Some(expected) = self.input_type_checks.get(id).cloned()
         {
-            let actual = data.data_type();
-            // Skip check for Null type (timer ticks, empty payloads)
-            // to avoid spurious warnings on annotated timer inputs.
-            if *actual != arrow_schema::DataType::Null && *actual != expected {
-                tracing::warn!(
-                    input = %id,
-                    expected = ?expected,
-                    actual = ?actual,
-                    "input type mismatch on first message"
-                );
+            let is_pattern_message = metadata
+                .parameters
+                .contains_key(adora_message::metadata::REQUEST_ID)
+                || metadata
+                    .parameters
+                    .contains_key(adora_message::metadata::GOAL_ID)
+                || metadata
+                    .parameters
+                    .contains_key(adora_message::metadata::GOAL_STATUS);
+            if !is_pattern_message {
+                // Consume the check and validate.
+                self.input_type_checks.remove(id);
+                let actual = data.data_type();
+                // Skip check for Null type (timer ticks, empty payloads)
+                // to avoid spurious warnings on annotated timer inputs.
+                if *actual != arrow_schema::DataType::Null && *actual != expected {
+                    tracing::warn!(
+                        input = %id,
+                        expected = ?expected,
+                        actual = ?actual,
+                        "input type mismatch on first message"
+                    );
+                }
             }
         }
 

--- a/apis/rust/node/src/node/mod.rs
+++ b/apis/rust/node/src/node/mod.rs
@@ -803,9 +803,19 @@ impl AdoraNode {
 
         let arrow_array = data.to_data();
 
-        // Runtime type check (only when ADORA_RUNTIME_TYPE_CHECK is set)
+        // Runtime type check (only when ADORA_RUNTIME_TYPE_CHECK is set).
+        //
+        // Skip the check when this message carries pattern metadata
+        // (`request_id`, `goal_id`, or `goal_status`). Service, action,
+        // and streaming patterns legitimately multiplex multiple Arrow
+        // schemas through a single output — a service server may reply
+        // with different response shapes for different request types —
+        // so a single declared Arrow type cannot cover all variants.
+        // Non-pattern messages still get full validation
+        // (dora-rs/adora#150).
         if let Some((mode, checks)) = &self.runtime_type_checks
             && let Some(expected) = checks.get(&output_id)
+            && !carries_pattern_correlation(&parameters)
         {
             let actual = arrow_array.data_type();
             if actual != expected {
@@ -1566,6 +1576,20 @@ impl DerefMut for ShmemHandle {
 unsafe impl Send for ShmemHandle {}
 unsafe impl Sync for ShmemHandle {}
 
+/// Returns `true` if the given metadata carries any pattern-correlation
+/// key (`request_id`, `goal_id`, or `goal_status`).
+///
+/// Messages marked with these keys belong to a service, action, or
+/// streaming pattern where multiple Arrow schemas can legitimately
+/// flow through a single output/input, distinguished by metadata
+/// rather than a fixed Arrow type. Type checks are skipped for such
+/// messages (dora-rs/adora#150).
+pub(crate) fn carries_pattern_correlation(params: &MetadataParameters) -> bool {
+    params.contains_key(adora_message::metadata::REQUEST_ID)
+        || params.contains_key(adora_message::metadata::GOAL_ID)
+        || params.contains_key(adora_message::metadata::GOAL_STATUS)
+}
+
 /// Init Opentelemetry Tracing
 ///
 /// This requires a tokio runtime spawning this function to be functional
@@ -1824,6 +1848,54 @@ mod tests {
         let outputs: Vec<_> = rx.try_iter().collect();
         assert_eq!(outputs.len(), 1);
         assert_eq!(outputs[0]["id"], "response");
+    }
+
+    // ---- dora-rs/adora#150: pattern polymorphism exemption ----
+
+    #[test]
+    fn carries_pattern_correlation_detects_request_id() {
+        let mut params = MetadataParameters::default();
+        params.insert(
+            adora_message::metadata::REQUEST_ID.to_string(),
+            adora_message::metadata::Parameter::String("req-1".into()),
+        );
+        assert!(carries_pattern_correlation(&params));
+    }
+
+    #[test]
+    fn carries_pattern_correlation_detects_goal_id() {
+        let mut params = MetadataParameters::default();
+        params.insert(
+            adora_message::metadata::GOAL_ID.to_string(),
+            adora_message::metadata::Parameter::String("goal-1".into()),
+        );
+        assert!(carries_pattern_correlation(&params));
+    }
+
+    #[test]
+    fn carries_pattern_correlation_detects_goal_status() {
+        let mut params = MetadataParameters::default();
+        params.insert(
+            adora_message::metadata::GOAL_STATUS.to_string(),
+            adora_message::metadata::Parameter::String("succeeded".into()),
+        );
+        assert!(carries_pattern_correlation(&params));
+    }
+
+    #[test]
+    fn carries_pattern_correlation_empty_is_not_a_pattern() {
+        let params = MetadataParameters::default();
+        assert!(!carries_pattern_correlation(&params));
+    }
+
+    #[test]
+    fn carries_pattern_correlation_ignores_non_pattern_keys() {
+        let mut params = MetadataParameters::default();
+        params.insert(
+            "custom_key".to_string(),
+            adora_message::metadata::Parameter::String("value".into()),
+        );
+        assert!(!carries_pattern_correlation(&params));
     }
 
     #[test]

--- a/docs/types.md
+++ b/docs/types.md
@@ -276,6 +276,9 @@ Valid values: `1`, `warn`, `true` (warn mode), `error` (error mode). Unset or an
 - Covers all languages that send Arrow arrays (Rust, Python, C++ Arrow path)
 - Raw byte sends (`send_output_bytes`, C nodes) are untyped and skip checking
 - Complex types (Struct-based: Image, Vector3, etc.) are skipped -- only primitive types, String, Bytes, and Bool are validated at runtime
+- **Pattern messages are skipped.** When a message carries `request_id`, `goal_id`, or `goal_status` in its metadata parameters, runtime type checking is bypassed for that message. Service, action, and streaming patterns legitimately multiplex multiple Arrow schemas through a single output — a service server may reply with different response shapes for different request types — so a single declared Arrow type cannot cover all variants. Non-pattern messages on the same output are still validated normally (dora-rs/adora#150).
+
+The same exemption applies to the receive-side first-message type check: if the first input message carries pattern metadata, the check stays armed and defers to the next non-pattern message. This avoids false positives on inputs that receive a polymorphic first message.
 
 ## Graph Visualization
 


### PR DESCRIPTION
## Summary

Fixes #150. Adora's type validation assumes one Arrow type per output/input, but service, action, and streaming patterns legitimately multiplex multiple Arrow schemas through a single channel. Both the `ADORA_RUNTIME_TYPE_CHECK` send-side gate and the first-message receive-side check rejected or spuriously warned on these polymorphic variants, making `ADORA_RUNTIME_TYPE_CHECK=error` unusable with service/action servers.

## Fix

Conservative exemption: when a message carries any of the pattern correlation keys (`request_id`, `goal_id`, `goal_status`), skip the type check. Non-pattern messages on the same output are still validated normally.

### Send side — `apis/rust/node/src/node/mod.rs`

New module-private helper:

```rust
pub(crate) fn carries_pattern_correlation(params: &MetadataParameters) -> bool {
    params.contains_key(adora_message::metadata::REQUEST_ID)
        || params.contains_key(adora_message::metadata::GOAL_ID)
        || params.contains_key(adora_message::metadata::GOAL_STATUS)
}
```

Called in `send_output` before the runtime type check. If it returns `true`, the check is skipped.

### Receive side — `apis/rust/node/src/event_stream/mod.rs`

The first-message type check previously used `remove(id)` which consumed the entry even on pattern messages, meaning the check fired exactly once on whatever variant happened to arrive first and never validated subsequent messages. Changed to peek with `get(id).cloned()` and only `remove(id)` when the first message is NOT a pattern message. The check stays armed across polymorphic variants and a later non-pattern message still validates.

## Docs

`docs/types.md` — "Runtime Type Checking" section updated with a new scope bullet:

> **Pattern messages are skipped.** When a message carries `request_id`, `goal_id`, or `goal_status` in its metadata parameters, runtime type checking is bypassed for that message. Service, action, and streaming patterns legitimately multiplex multiple Arrow schemas through a single output — a service server may reply with different response shapes for different request types — so a single declared Arrow type cannot cover all variants. Non-pattern messages on the same output are still validated normally.

Plus a note on the matching receive-side exemption.

## Tests

5 new unit tests in `node::tests`:

| Test | Scenario |
|---|---|
| `carries_pattern_correlation_detects_request_id` | service request/response |
| `carries_pattern_correlation_detects_goal_id` | action goal/feedback |
| `carries_pattern_correlation_detects_goal_status` | action terminal result |
| `carries_pattern_correlation_empty_is_not_a_pattern` | no keys → full validation |
| `carries_pattern_correlation_ignores_non_pattern_keys` | custom metadata keys don't suppress checks |

All 48 `adora-node-api` lib tests pass.

## Out of scope

The build-time `check_metadata_annotations` validator in `libraries/core/src/descriptor/validate.rs` could also warn when an output has `pattern: service-server` together with `output_types`, but the warning would be noisy for legitimate single-type uses and the user couldn't easily silence it. Leaving that for a later iteration once we have a way to declare polymorphism explicitly in YAML.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-node-api -- -D warnings`
- [x] `cargo test -p adora-node-api --lib` — 48/48 pass

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
