### PR TITLE
fix(daemon): isolate process-op channel per incarnation (restart race)

### DIFF
--- a/binaries/daemon/src/event_types.rs
+++ b/binaries/daemon/src/event_types.rs
@@ -154,6 +154,18 @@ pub enum AdoraEvent {
         restart: bool,
         restart_count: u32,
     },
+    /// The per-node `restart_loop` spawned a fresh process after an exit
+    /// and now wants the daemon to swap the tracked `ProcessHandle` in
+    /// `running_nodes` so subsequent kill/stop operations reach the new
+    /// incarnation rather than the dead predecessor.
+    ///
+    /// Restores per-incarnation isolation of the process-operation
+    /// channel and closes the stale-kill race in dora-rs/adora#152.
+    ProcessHandleReplaced {
+        dataflow_id: DataflowId,
+        node_id: NodeId,
+        new_handle: crate::ProcessHandle,
+    },
 }
 
 #[must_use]

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3418,6 +3418,38 @@ impl Daemon {
                         .await?;
                 }
             }
+            AdoraEvent::ProcessHandleReplaced {
+                dataflow_id,
+                node_id,
+                new_handle,
+            } => {
+                // The per-node restart_loop just spawned a replacement
+                // process with a fresh op_tx/op_rx pair. Swap it into
+                // running_nodes so subsequent stop/kill operations
+                // target the new incarnation rather than a dead
+                // predecessor's channel (dora-rs/adora#152).
+                if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
+                    if let Some(node) = dataflow.running_nodes.get_mut(&node_id) {
+                        // Overwriting the previous Some(old_handle)
+                        // drops it, which currently fires its `Kill`
+                        // send on the already-closed old op_rx — a
+                        // no-op.
+                        node.process = Some(new_handle);
+                    } else {
+                        tracing::warn!(
+                            %dataflow_id,
+                            %node_id,
+                            "ProcessHandleReplaced for unknown node"
+                        );
+                    }
+                } else {
+                    tracing::warn!(
+                        %dataflow_id,
+                        %node_id,
+                        "ProcessHandleReplaced for unknown dataflow"
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -462,8 +462,15 @@ impl RunningDataflow {
             .get_mut(node_id)
             .ok_or_else(|| eyre!("node `{node_id}` not found in running dataflow"))?;
         let process = node.process.take();
-        // Re-enable restart only after the process handle is taken, so the
-        // restart loop cannot fire before the grace timer has a chance to run.
+        // Clear any prior disable (e.g. from an earlier stop_single_node
+        // or a cascading AllInputsClosed) so the restart_loop will pick
+        // up the next exit and spawn a replacement.
+        //
+        // With the per-incarnation channel pair introduced for
+        // dora-rs/adora#152, the old grace-kill task sends to a closed
+        // op_rx and cannot reach the replacement process, so ordering
+        // between this store and the grace-kill submission no longer
+        // matters.
         node.disable_restart.store(false, atomic::Ordering::Release);
         self.send_stop_and_schedule_kill(
             node_id,
@@ -558,11 +565,6 @@ mod tests {
 
     #[test]
     fn unarmed_deadline_is_never_timed_out() {
-        // An input that has never received a message (last_received = None)
-        // must not trip the circuit breaker, even if `timeout` has long
-        // since elapsed relative to dataflow start. This prevents false
-        // positives on service response inputs that are legitimately idle
-        // until the client sends its first request.
         let deadline = InputDeadline {
             timeout: Duration::from_millis(1),
             last_received: None,
@@ -591,18 +593,48 @@ mod tests {
 
     #[test]
     fn arming_a_previously_unarmed_deadline_starts_the_clock() {
-        // Simulates: input starts unarmed, first message arrives, the
-        // clock begins counting, timeout must elapse before firing.
         let mut deadline = InputDeadline {
             timeout: Duration::from_millis(50),
             last_received: None,
         };
         assert!(!deadline.is_timed_out(), "unarmed should not fire");
-
         deadline.last_received = Some(Instant::now());
         assert!(
             !deadline.is_timed_out(),
             "just-armed should not fire immediately"
+        );
+    }
+
+    // ---- dora-rs/adora#152: restart isolation via fresh op_tx/op_rx ----
+
+    #[test]
+    fn submit_to_dropped_receiver_returns_false() {
+        let (tx, rx) = flume::bounded::<ProcessOperation>(2);
+        let handle = ProcessHandle::new(tx);
+        drop(rx);
+        assert!(!handle.submit(ProcessOperation::SoftKill));
+        assert!(!handle.submit(ProcessOperation::Kill));
+    }
+
+    #[test]
+    fn submit_to_live_receiver_succeeds() {
+        let (tx, rx) = flume::bounded::<ProcessOperation>(2);
+        let handle = ProcessHandle::new(tx);
+        assert!(handle.submit(ProcessOperation::SoftKill));
+        let received = rx.try_recv().expect("op should have been queued");
+        assert!(matches!(received, ProcessOperation::SoftKill));
+    }
+
+    #[test]
+    fn two_independent_channels_do_not_cross_deliver() {
+        let (old_tx, old_rx) = flume::bounded::<ProcessOperation>(2);
+        let old_handle = ProcessHandle::new(old_tx);
+        drop(old_rx);
+        let (_new_tx, new_rx) = flume::bounded::<ProcessOperation>(2);
+        let _ = old_handle.submit(ProcessOperation::Kill);
+        assert!(
+            new_rx.try_recv().is_err(),
+            "kill from the previous incarnation must not reach the replacement process"
         );
     }
 }

--- a/binaries/daemon/src/spawn/prepared.rs
+++ b/binaries/daemon/src/spawn/prepared.rs
@@ -179,7 +179,7 @@ impl PreparedNode {
         let mut window_count: u32 = 0;
 
         loop {
-            let Ok(NodeProcessFinished { exit_status, op_rx }) = finished_rx.await else {
+            let Ok(NodeProcessFinished { exit_status }) = finished_rx.await else {
                 logger
                     .log(
                         LogLevel::Error,
@@ -325,15 +325,34 @@ impl PreparedNode {
                         )
                         .await;
                 }
+                // Fresh `(op_tx, op_rx)` per incarnation so any
+                // grace-kill task holding an older `op_tx` cannot
+                // reach the new process — closes the race in
+                // dora-rs/adora#152.
+                let (op_tx_new, op_rx_new) = flume::bounded(2);
                 let (finished_tx, finished_rx_new) = oneshot::channel();
                 let result = self
                     .clone()
-                    .spawn_inner(&mut logger, op_rx, finished_tx)
+                    .spawn_inner(&mut logger, op_rx_new, finished_tx)
                     .await;
                 match result {
                     Ok(NodeKind::Spawned { pid: new_pid }) => {
                         finished_rx = finished_rx_new;
                         pid.store(new_pid, atomic::Ordering::Release);
+                        // Install the new `ProcessHandle` in
+                        // `running_nodes` so subsequent stop/kill
+                        // operations target this incarnation.
+                        let handle_replaced = AdoraEvent::ProcessHandleReplaced {
+                            dataflow_id: self.dataflow_id,
+                            node_id: self.node.id.clone(),
+                            new_handle: crate::ProcessHandle::new(op_tx_new),
+                        }
+                        .into();
+                        let msg = Timestamped {
+                            inner: handle_replaced,
+                            timestamp: self.clock.clone().new_timestamp(),
+                        };
+                        let _ = self.daemon_tx.clone().send(msg).await;
                     }
                     Ok(NodeKind::Dynamic) => {
                         logger
@@ -629,7 +648,12 @@ impl PreparedNode {
             };
 
             let _ = log_finish_rx.await;
-            let _ = finished_tx.send(NodeProcessFinished { exit_status, op_rx });
+            // Drop `op_rx` here so any grace-kill task still holding
+            // the paired `op_tx` sees a closed channel on the next
+            // `submit()` instead of routing operations to the
+            // subsequent incarnation (dora-rs/adora#152).
+            drop(op_rx);
+            let _ = finished_tx.send(NodeProcessFinished { exit_status });
         });
 
         let node_id = self.node.id.clone();
@@ -909,5 +933,11 @@ enum NodeKind {
 
 struct NodeProcessFinished {
     exit_status: NodeExitStatus,
-    op_rx: flume::Receiver<ProcessOperation>,
+    // Note: `op_rx` used to be returned here and recycled for the next
+    // incarnation. That allowed a grace-kill task holding the old
+    // `op_tx` to send SoftKill/Kill to the *new* process after a
+    // restart, because both incarnations shared the same channel
+    // (dora-rs/adora#152). The receiver is now dropped at the end of
+    // the spawn_inner task and each restart creates a fresh channel
+    // pair.
 }


### PR DESCRIPTION
## Summary

Fixes #152. Implements **Option B** from the design discussion on the issue: fresh `(op_tx, op_rx)` channel pair per process incarnation.

## Root cause

The per-node `restart_loop` in `spawn/prepared.rs` recycled the same flume `(op_tx, op_rx)` across restarts: when a process exited, `spawn_inner`'s task shipped `op_rx` back through `NodeProcessFinished`, and the restart loop passed it straight into the next `spawn_inner` invocation. The matching `op_tx` lived in `RunningNode.process` as a `ProcessHandle`.

This let a stale grace-kill task reach the replacement process:

1. `restart_single_node` calls `node.process.take()` and spawns a ~5s grace-kill task holding the old `ProcessHandle`.
2. Old process receives `Stop` and exits cleanly in, say, ~100 ms.
3. `finished_tx` fires. `restart_loop` respawns via `spawn_inner(op_rx, ...)` — the **same** `op_rx` the old task shipped back, now wired to the freshly spawned child.
4. 4.9s later the grace-kill task wakes up and calls `old_handle.submit(SoftKill)`. Operation lands on the still-alive `op_rx` and prematurely kills the **new** child.

## Fix

1. **Drop `op_rx` at end of spawn_inner.** `NodeProcessFinished` no longer carries it back. The task drops the receiver explicitly when the child exits.
2. **Fresh channel pair per restart.** `restart_loop` creates a brand-new `(op_tx_new, op_rx_new)` before each restart-spawn. The old channel is orphaned; the new process only receives operations via the new pair.
3. **New `AdoraEvent::ProcessHandleReplaced { dataflow_id, node_id, new_handle }`** emitted from `restart_loop` on successful respawn. The daemon main loop handles it by swapping `running_nodes[id].process = Some(new_handle)` so subsequent stop/kill operations from *any* daemon path target the current incarnation.
4. **`restart_single_node` comment cleanup.** The old "re-enable restart only after the process handle is taken" comment was confused — the ordering it claimed to protect never mattered. Replaced with a note explaining that the `disable_restart.store(false)` is still needed to clear prior cascading-close / stop disables, and that channel isolation makes the ordering moot.

## Why overwriting the old `ProcessHandle` is safe

`ProcessHandle::drop` still sends `Kill`. This used to be a footgun because `op_rx` stayed alive — but with the fix, by the time the daemon overwrites `running_nodes[id].process = Some(new_handle)`, the old `op_rx` has been dropped at the end of its spawn_inner task, so the Drop-fired Kill lands on a closed channel and returns false (no-op). No double kill, no cross-incarnation delivery.

## Tests

Three new unit tests in `running_dataflow::tests` — they exercise the core invariant without needing to spawn real child processes:

| Test | Scenario |
|---|---|
| `submit_to_dropped_receiver_returns_false` | Stale-kill case: old handle reports failure once its receiver is gone |
| `submit_to_live_receiver_succeeds` | Positive control |
| `two_independent_channels_do_not_cross_deliver` | Headline invariant: a `Kill` via the old handle never appears on the new receiver |

End-to-end validation via the existing `fault-tolerance-e2e` suite, which drives the real restart-loop code path through a crashing child:

- `restart_recovers_from_failure` — the exact scenario this refactor touches
- `max_restarts_limit_reached`
- `input_timeout_closes_stale_input`

All pass. The `smoke_rust_dataflow*` suite also passes to confirm no regression in the non-restart path.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-daemon -- -D warnings`
- [x] `cargo test -p adora-daemon` — 23/23 pass (20 existing + 3 new)
- [x] `cargo test --release --test fault-tolerance-e2e` — 3/3 pass
- [x] `cargo test --release --test example-smoke smoke_rust_dataflow*` — 3/3 pass

Fixes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)
