### PR TITLE
fix(node-api): apply pattern type-check exemption on Stream::poll_next path

### DIFF
--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -1047,19 +1047,37 @@ impl Stream for EventStream {
             .map(|item| item.map(Self::convert_event_item));
 
         // Run first-message type check on the Stream path too.
+        //
+        // Mirror the recv_async() logic: skip the check (and keep it
+        // armed) when the message carries pattern metadata, so a later
+        // non-pattern message can still validate (dora-rs/adora#174).
         if let std::task::Poll::Ready(Some(Event::Input {
-            ref id, ref data, ..
+            ref id,
+            ref metadata,
+            ref data,
         })) = poll
-            && let Some(expected) = self.input_type_checks.remove(id)
+            && let Some(expected) = self.input_type_checks.get(id).cloned()
         {
-            let actual = data.data_type();
-            if *actual != arrow_schema::DataType::Null && *actual != expected {
-                tracing::warn!(
-                    input = %id,
-                    expected = ?expected,
-                    actual = ?actual,
-                    "input type mismatch on first message (Stream path)"
-                );
+            let is_pattern_message = metadata
+                .parameters
+                .contains_key(adora_message::metadata::REQUEST_ID)
+                || metadata
+                    .parameters
+                    .contains_key(adora_message::metadata::GOAL_ID)
+                || metadata
+                    .parameters
+                    .contains_key(adora_message::metadata::GOAL_STATUS);
+            if !is_pattern_message {
+                self.input_type_checks.remove(id);
+                let actual = data.data_type();
+                if *actual != arrow_schema::DataType::Null && *actual != expected {
+                    tracing::warn!(
+                        input = %id,
+                        expected = ?expected,
+                        actual = ?actual,
+                        "input type mismatch on first message (Stream path)"
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #174. PR #164 fixed polymorphic pattern type checking for `recv_async()` but the `Stream::poll_next` path still used the old unconditional `input_type_checks.remove(id)`. If a pattern message arrived first via `StreamExt::next()`, the check was consumed and a later non-pattern message on the same input would never validate.

## Fix

Mirror the `recv_async()` logic in `poll_next`:
- Use `get(id).cloned()` instead of `remove(id)`
- Only consume the check for non-pattern messages (those without `request_id`, `goal_id`, or `goal_status` metadata)
- Pattern messages leave the check armed for the next non-pattern message

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-node-api -- -D warnings`
- [x] `cargo test -p adora-node-api --lib` — 72/72 pass

Fixes #174