### PR TITLE
fix(ci): install MinGW C++ toolchain for windows-gnu cross-check, fix Python template version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -454,7 +454,7 @@ jobs:
             cross: true
           - runner: ubuntu-latest
             target: x86_64-pc-windows-gnu
-            gcc: gcc-mingw-w64-x86-64
+            gcc: gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64
           - runner: macos-latest
             target: aarch64-apple-darwin
           - runner: macos-latest

--- a/binaries/cli/src/template/python/__node-name__/pyproject.toml
+++ b/binaries/cli/src/template/python/__node-name__/pyproject.toml
@@ -7,7 +7,7 @@ license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.8"
 
-dependencies = ["adora-rs >= 0.3.9"]
+dependencies = ["adora-rs >= 0.2.0"]
 
 [dependency-groups]
 dev = ["pytest >=8.1.1", "ruff >=0.9.1"]


### PR DESCRIPTION
Fixes #176. Two workflow-level issues from PR #167 that left restored CI jobs red on main:

## 1. x86_64-pc-windows-gnu cross-check

Only `gcc-mingw-w64-x86-64` was installed, but `link-cplusplus` (a build dep) needs `x86_64-w64-mingw32-g++` which comes from the `g++-mingw-w64-x86-64` package.

Fix: add `g++-mingw-w64-x86-64` to the `gcc` matrix field.

## 2. Python template version

The generated `pyproject.toml` required `adora-rs >= 0.3.9` but the published package is `0.2.1`. The CLI test `Test Python template project` fails immediately because pip/uv can't satisfy the constraint.

Fix: change to `adora-rs >= 0.2.0` so the template works against the current release.

## Test plan

- [x] YAML validates
- [x] Template version matches published package
- [ ] CI will validate both fixes on this PR's run

Fixes #176