### PR TITLE
feat(cli): typed control request layer with expect_reply! macro

### DIFF
--- a/binaries/cli/src/command/list.rs
+++ b/binaries/cli/src/command/list.rs
@@ -2,16 +2,12 @@ use std::io::Write;
 
 use super::{Executable, default_tracing};
 use crate::{
-    common::{CoordinatorOptions, query_running_dataflows},
+    common::{CoordinatorOptions, expect_reply, query_running_dataflows, send_control_request},
     formatting::OutputFormat,
     ws_client::WsSession,
 };
-use adora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, DataflowStatus},
-};
+use adora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::DataflowStatus};
 use clap::Args;
-use eyre::{Context, bail};
 use serde::Serialize;
 use tabwriter::TabWriter;
 use uuid::Uuid;
@@ -96,18 +92,8 @@ fn list(
     let list = query_running_dataflows(session)?;
 
     // Get node information
-    let node_info_reply = session
-        .request(&serde_json::to_vec(&ControlRequest::GetNodeInfo).unwrap())
-        .wrap_err("failed to send GetNodeInfo request")?;
-
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&node_info_reply).wrap_err("failed to parse node info reply")?;
-
-    let node_infos = match reply {
-        ControlRequestReply::NodeInfoList(infos) => infos,
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected node info reply: {other:?}"),
-    };
+    let reply = send_control_request(session, &ControlRequest::GetNodeInfo)?;
+    let node_infos = expect_reply!(reply, NodeInfoList(infos))?;
 
     // Aggregate metrics by dataflow UUID
     let mut dataflow_metrics: std::collections::BTreeMap<Uuid, DataflowMetrics> =

--- a/binaries/cli/src/command/stop.rs
+++ b/binaries/cli/src/command/stop.rs
@@ -1,8 +1,10 @@
 use super::{Executable, default_tracing};
-use crate::common::{CoordinatorOptions, handle_dataflow_result, query_running_dataflows};
+use crate::common::{
+    CoordinatorOptions, expect_reply, handle_dataflow_result, query_running_dataflows,
+    send_control_request,
+};
 use crate::ws_client::WsSession;
 use adora_message::cli_to_coordinator::ControlRequest;
-use adora_message::coordinator_to_cli::ControlRequestReply;
 use duration_str::parse;
 use eyre::{Context, bail};
 use std::io::IsTerminal;
@@ -83,25 +85,16 @@ fn stop_dataflow(
     force: bool,
     session: &WsSession,
 ) -> Result<(), eyre::ErrReport> {
-    let reply_raw = session
-        .request(
-            &serde_json::to_vec(&ControlRequest::Stop {
-                dataflow_uuid: uuid,
-                grace_duration,
-                force,
-            })
-            .unwrap(),
-        )
-        .wrap_err("failed to send dataflow stop message")?;
-    let result: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match result {
-        ControlRequestReply::DataflowStopped { uuid, result } => {
-            handle_dataflow_result(result, Some(uuid))
-        }
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected stop dataflow reply: {other:?}"),
-    }
+    let reply = send_control_request(
+        session,
+        &ControlRequest::Stop {
+            dataflow_uuid: uuid,
+            grace_duration,
+            force,
+        },
+    )?;
+    let (uuid, result) = expect_reply!(reply, DataflowStopped { uuid, result })?;
+    handle_dataflow_result(result, Some(uuid))
 }
 
 fn stop_dataflow_by_name(
@@ -110,23 +103,14 @@ fn stop_dataflow_by_name(
     force: bool,
     session: &WsSession,
 ) -> Result<(), eyre::ErrReport> {
-    let reply_raw = session
-        .request(
-            &serde_json::to_vec(&ControlRequest::StopByName {
-                name,
-                grace_duration,
-                force,
-            })
-            .unwrap(),
-        )
-        .wrap_err("failed to send dataflow stop_by_name message")?;
-    let result: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match result {
-        ControlRequestReply::DataflowStopped { uuid, result } => {
-            handle_dataflow_result(result, Some(uuid))
-        }
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected stop dataflow reply: {other:?}"),
-    }
+    let reply = send_control_request(
+        session,
+        &ControlRequest::StopByName {
+            name,
+            grace_duration,
+            force,
+        },
+    )?;
+    let (uuid, result) = expect_reply!(reply, DataflowStopped { uuid, result })?;
+    handle_dataflow_result(result, Some(uuid))
 }

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -37,6 +37,10 @@ pub(crate) fn handle_dataflow_result(
 }
 
 /// Send a control request and deserialize the reply.
+///
+/// Returns `Err` if the coordinator replies with
+/// [`ControlRequestReply::Error`], so callers don't need to match
+/// on the error variant themselves (dora-rs/adora#153).
 pub(crate) fn send_control_request(
     session: &WsSession,
     request: &ControlRequest,
@@ -44,22 +48,50 @@ pub(crate) fn send_control_request(
     let reply_raw = session
         .request(&serde_json::to_vec(request).unwrap())
         .wrap_err("failed to send control request")?;
-    serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")
-}
-
-pub(crate) fn query_running_dataflows(session: &WsSession) -> eyre::Result<DataflowList> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::List).unwrap())
-        .wrap_err("failed to send list message")?;
     let reply: ControlRequestReply =
         serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    let ids = match reply {
-        ControlRequestReply::DataflowList(list) => list,
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected list dataflow reply: {other:?}"),
-    };
+    match reply {
+        ControlRequestReply::Error(err) => Err(eyre::eyre!("{err}")),
+        other => Ok(other),
+    }
+}
 
-    Ok(ids)
+/// Extract a specific reply variant, returning an error for mismatches.
+///
+/// Eliminates the repetitive
+/// `match reply { Variant(x) => x, other => bail!("unexpected: {other:?}") }`
+/// at every CLI call site (dora-rs/adora#153).
+macro_rules! expect_reply {
+    // Tuple variant: ControlRequestReply::Foo(inner)
+    ($reply:expr, $variant:ident ($inner:ident)) => {
+        match $reply {
+            adora_message::coordinator_to_cli::ControlRequestReply::$variant($inner) => {
+                Ok($inner)
+            }
+            other => Err(eyre::eyre!(
+                "unexpected reply (expected {}): {other:?}",
+                stringify!($variant)
+            )),
+        }
+    };
+    // Struct variant: ControlRequestReply::Foo { a, b }
+    ($reply:expr, $variant:ident { $($field:ident),+ $(,)? }) => {
+        match $reply {
+            adora_message::coordinator_to_cli::ControlRequestReply::$variant { $($field),+ } => {
+                Ok(($($field),+))
+            }
+            other => Err(eyre::eyre!(
+                "unexpected reply (expected {}): {other:?}",
+                stringify!($variant)
+            )),
+        }
+    };
+}
+pub(crate) use expect_reply;
+
+pub(crate) fn query_running_dataflows(session: &WsSession) -> eyre::Result<DataflowList> {
+    let reply = send_control_request(session, &ControlRequest::List)?;
+    expect_reply!(reply, DataflowList(list))
 }
 
 pub(crate) fn resolve_dataflow_identifier_interactive(


### PR DESCRIPTION
Addresses #153 (Option 2 from the [design comment](https://github.com/dora-rs/adora/issues/153#issuecomment-4218281557): typed trait layer as a cheap first step).

## Problem

34 CLI call sites repeat the same 4-line boilerplate:

```rust
let reply_raw = session.request(&serde_json::to_vec(&req).unwrap())?;
let reply: ControlRequestReply = serde_json::from_slice(&reply_raw)?;
match reply {
    ControlRequestReply::Foo(x) => x,
    ControlRequestReply::Error(err) => bail!("{err}"),
    other => bail!("unexpected: {other:?}"),
}
```

## Fix

Two improvements:

### 1. `send_control_request` handles Error internally

Returns `Err` for `ControlRequestReply::Error` so callers never match on it.

### 2. `expect_reply!` macro

Extracts a specific reply variant in one line:

```rust
// Tuple variant
let reply = send_control_request(session, &ControlRequest::List)?;
let list = expect_reply!(reply, DataflowList(list))?;

// Struct variant
let reply = send_control_request(session, &ControlRequest::Stop { ... })?;
let (uuid, result) = expect_reply!(reply, DataflowStopped { uuid, result })?;
```

Converted `list.rs` and `stop.rs` as proof of pattern. The remaining ~30 call sites can be converted incrementally — fully additive, no breaking changes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-cli -- -D warnings`
- [x] `cargo build -p adora-cli`

Addresses #153