### PR TITLE
fix(message): allow '/' in DataId for operator-namespaced outputs

### DIFF
--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -3,8 +3,11 @@ use std::{borrow::Borrow, convert::Infallible, str::FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Validate that an identifier contains only safe characters: `[a-zA-Z0-9_.-]`.
-fn validate_id(id: &str) -> Result<(), InvalidId> {
+/// Validate that a node identifier contains only safe characters: `[a-zA-Z0-9_.-]`.
+///
+/// NodeIds must NOT contain `/` because `/` is the separator between
+/// `<node_id>/<output_id>` in input mapping syntax.
+fn validate_node_id(id: &str) -> Result<(), InvalidId> {
     if id.is_empty() {
         return Err(InvalidId("identifier must not be empty".into()));
     }
@@ -14,6 +17,27 @@ fn validate_id(id: &str) -> Result<(), InvalidId> {
     {
         return Err(InvalidId(format!(
             "identifier contains invalid character '{ch}' -- only [a-zA-Z0-9_.-] are allowed"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate that a data identifier contains only safe characters: `[a-zA-Z0-9_./-]`.
+///
+/// DataIds allow `/` because runtime-node operator outputs are
+/// namespaced as `<operator-id>/<output-name>` (e.g. `rust-operator/status`).
+/// The input mapping syntax `<node-id>/<output-id>` splits on the
+/// FIRST `/`, so subsequent slashes are part of the DataId.
+fn validate_data_id(id: &str) -> Result<(), InvalidId> {
+    if id.is_empty() {
+        return Err(InvalidId("identifier must not be empty".into()));
+    }
+    if let Some(ch) = id
+        .chars()
+        .find(|c| !c.is_ascii_alphanumeric() && *c != '_' && *c != '-' && *c != '.' && *c != '/')
+    {
+        return Err(InvalidId(format!(
+            "identifier contains invalid character '{ch}' -- only [a-zA-Z0-9_./-] are allowed"
         )));
     }
     Ok(())
@@ -39,7 +63,7 @@ impl<'de> Deserialize<'de> for NodeId {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        validate_id(&s).map_err(serde::de::Error::custom)?;
+        validate_node_id(&s).map_err(serde::de::Error::custom)?;
         Ok(NodeId(s))
     }
 }
@@ -48,7 +72,7 @@ impl FromStr for NodeId {
     type Err = InvalidId;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        validate_id(s)?;
+        validate_node_id(s)?;
         Ok(Self(s.to_owned()))
     }
 }
@@ -66,7 +90,7 @@ impl FromStr for NodeId {
 /// is fallible.
 impl From<String> for NodeId {
     fn from(id: String) -> Self {
-        if let Err(e) = validate_id(&id) {
+        if let Err(e) = validate_node_id(&id) {
             panic!("invalid NodeId '{id}': {e}");
         }
         Self(id)
@@ -125,7 +149,7 @@ impl<'de> Deserialize<'de> for DataId {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        validate_id(&s).map_err(serde::de::Error::custom)?;
+        validate_data_id(&s).map_err(serde::de::Error::custom)?;
         Ok(DataId(s))
     }
 }
@@ -134,7 +158,7 @@ impl FromStr for DataId {
     type Err = InvalidId;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        validate_id(s)?;
+        validate_data_id(s)?;
         Ok(Self(s.to_owned()))
     }
 }
@@ -151,7 +175,7 @@ impl From<DataId> for String {
 /// or `DataId::try_from(s)` when handling untrusted input.
 impl From<String> for DataId {
     fn from(id: String) -> Self {
-        if let Err(e) = validate_id(&id) {
+        if let Err(e) = validate_data_id(&id) {
             panic!("invalid DataId '{id}': {e}");
         }
         Self(id)
@@ -173,21 +197,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn valid_ids() {
-        assert!(validate_id("my-node").is_ok());
-        assert!(validate_id("my_node").is_ok());
-        assert!(validate_id("MyNode123").is_ok());
-        assert!(validate_id("node.v2").is_ok());
-        assert!(validate_id("a").is_ok());
+    fn valid_node_ids() {
+        assert!(validate_node_id("my-node").is_ok());
+        assert!(validate_node_id("my_node").is_ok());
+        assert!(validate_node_id("MyNode123").is_ok());
+        assert!(validate_node_id("node.v2").is_ok());
+        assert!(validate_node_id("a").is_ok());
     }
 
     #[test]
-    fn invalid_ids() {
-        assert!(validate_id("").is_err());
-        assert!(validate_id("node/output").is_err());
-        assert!(validate_id("node name").is_err());
-        assert!(validate_id("node;rm").is_err());
-        assert!(validate_id("node\0").is_err());
+    fn invalid_node_ids() {
+        assert!(validate_node_id("").is_err());
+        assert!(validate_node_id("node/output").is_err());
+        assert!(validate_node_id("node name").is_err());
+        assert!(validate_node_id("node;rm").is_err());
+        assert!(validate_node_id("node\0").is_err());
+    }
+
+    #[test]
+    fn data_id_allows_slash_for_operators() {
+        // Operator outputs are namespaced: `operator-id/output-name`
+        assert!(validate_data_id("rust-operator/status").is_ok());
+        assert!(validate_data_id("op/output").is_ok());
+        assert!(validate_data_id("simple").is_ok());
+    }
+
+    #[test]
+    fn data_id_rejects_other_specials() {
+        assert!(validate_data_id("").is_err());
+        assert!(validate_data_id("has space").is_err());
+        assert!(validate_data_id("semi;colon").is_err());
     }
 
     #[test]

--- a/libraries/message/src/id.rs
+++ b/libraries/message/src/id.rs
@@ -40,6 +40,16 @@ fn validate_data_id(id: &str) -> Result<(), InvalidId> {
             "identifier contains invalid character '{ch}' -- only [a-zA-Z0-9_./-] are allowed"
         )));
     }
+    // Reject malformed slash patterns that would produce empty segments
+    // when split (e.g. "op/", "/out", "a//b"). These would cause panics
+    // in downstream code that does DataId::from(segment) on the split
+    // result (e.g. descriptor/validate.rs:379).
+    if id.starts_with('/') || id.ends_with('/') || id.contains("//") {
+        return Err(InvalidId(format!(
+            "identifier '{id}' has empty path segment -- \
+             leading, trailing, or consecutive '/' are not allowed"
+        )));
+    }
     Ok(())
 }
 
@@ -227,6 +237,14 @@ mod tests {
         assert!(validate_data_id("").is_err());
         assert!(validate_data_id("has space").is_err());
         assert!(validate_data_id("semi;colon").is_err());
+    }
+
+    #[test]
+    fn data_id_rejects_malformed_slash_patterns() {
+        assert!(validate_data_id("op/").is_err(), "trailing slash");
+        assert!(validate_data_id("/out").is_err(), "leading slash");
+        assert!(validate_data_id("a//b").is_err(), "double slash");
+        assert!(validate_data_id("/").is_err(), "bare slash");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #168. Runtime-node operator outputs use `<operator-id>/<output-name>` (e.g. `rust-operator/status`). The DataId validator rejected `/` because it shared the same validator with NodeId.

## Fix

Split `validate_id` into two:
- `validate_node_id`: rejects `/` (unchanged — NodeIds can't have `/` since it's the node/output separator)
- `validate_data_id`: allows `/` for operator-namespaced outputs

## Verification

`adora validate examples/multiple-daemons/dataflow.yml` now passes (was crashing with `invalid DataId 'rust-operator/status'`).

## Tests

- `data_id_allows_slash_for_operators` — `rust-operator/status`, `op/output` both valid
- `data_id_rejects_other_specials` — spaces, semicolons still rejected
- All 10 id tests pass

Fixes #168