### PR TITLE
fix(cli): use zeroed sched_param for musl cross-compilation

### DIFF
--- a/binaries/cli/src/command/daemon.rs
+++ b/binaries/cli/src/command/daemon.rs
@@ -98,7 +98,12 @@ impl Executable for Daemon {
                 // Set SCHED_FIFO priority 50 (Linux only).
                 #[cfg(target_os = "linux")]
                 {
-                    let param = libc::sched_param { sched_priority: 50 };
+                    // Use zeroed() + field set instead of struct literal
+                    // because musl libc's sched_param has extra POSIX
+                    // fields (sched_ss_*) that glibc doesn't expose
+                    // (dora-rs/adora#170).
+                    let mut param: libc::sched_param = unsafe { std::mem::zeroed() };
+                    param.sched_priority = 50;
                     let sched_result =
                         unsafe { libc::sched_setscheduler(0, libc::SCHED_FIFO, &param) };
                     if sched_result == 0 {


### PR DESCRIPTION
Fixes #170. One-line fix: replace `libc::sched_param { sched_priority: 50 }` with `std::mem::zeroed()` + field set.

musl libc's `sched_param` has extra POSIX fields (`sched_ss_*`) that glibc doesn't expose. The struct literal syntax fails on musl targets because the extra fields are missing. `zeroed()` is the standard pattern for libc structs with platform-varying fields.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p adora-cli -- -D warnings`
- [ ] CI cross-check for `aarch64-unknown-linux-musl` and `armv7-unknown-linux-musleabihf` will validate

Fixes #170