### PR TITLE
fix: rename remaining ADORA_ refs in guide, cmake templates, smoke script

### DIFF
--- a/binaries/cli/src/template/c/cmake-template.txt
+++ b/binaries/cli/src/template/c/cmake-template.txt
@@ -4,13 +4,13 @@ project(cxx-dataflow LANGUAGES C)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_FLAGS "-fPIC")
 
-set(ADORA_ROOT_DIR "__ADORA_PATH__" CACHE FILEPATH "Path to the root of dora")
+set(DORA_ROOT_DIR "__DORA_PATH__" CACHE FILEPATH "Path to the root of dora")
 
 set(dora_c_include_dir "${CMAKE_CURRENT_BINARY_DIR}/include/c")
-if(ADORA_ROOT_DIR)
+if(DORA_ROOT_DIR)
     include(ExternalProject)
     ExternalProject_Add(Dora
-        SOURCE_DIR ${ADORA_ROOT_DIR}
+        SOURCE_DIR ${DORA_ROOT_DIR}
         BUILD_IN_SOURCE True
         CONFIGURE_COMMAND ""
         BUILD_COMMAND
@@ -20,7 +20,7 @@ if(ADORA_ROOT_DIR)
     )
 
     add_custom_command(OUTPUT ${dora_c_include_dir}
-        WORKING_DIRECTORY ${ADORA_ROOT_DIR}
+        WORKING_DIRECTORY ${DORA_ROOT_DIR}
         DEPENDS Dora
         COMMAND
             mkdir ${CMAKE_CURRENT_BINARY_DIR}/include/c -p
@@ -29,7 +29,7 @@ if(ADORA_ROOT_DIR)
     )
 
     add_custom_target(Dora_c DEPENDS ${dora_c_include_dir})
-    set(dora_link_dirs ${ADORA_ROOT_DIR}/target/debug)
+    set(dora_link_dirs ${DORA_ROOT_DIR}/target/debug)
 else()
     include(ExternalProject)
     ExternalProject_Add(Dora

--- a/binaries/cli/src/template/cxx/cmake-template.txt
+++ b/binaries/cli/src/template/cxx/cmake-template.txt
@@ -4,15 +4,15 @@ project(cxx-dataflow LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS "-fPIC")
 
-set(ADORA_ROOT_DIR "__ADORA_PATH__" CACHE FILEPATH "Path to the root of dora")
+set(DORA_ROOT_DIR "__DORA_PATH__" CACHE FILEPATH "Path to the root of dora")
 
 set(dora_cxx_include_dir "${CMAKE_CURRENT_BINARY_DIR}/include/cxx")
 set(node_bridge "${CMAKE_CURRENT_BINARY_DIR}/node_bridge.cc")
 
-if(ADORA_ROOT_DIR)
+if(DORA_ROOT_DIR)
     include(ExternalProject)
     ExternalProject_Add(Dora
-        SOURCE_DIR ${ADORA_ROOT_DIR}
+        SOURCE_DIR ${DORA_ROOT_DIR}
         BUILD_IN_SOURCE True
         CONFIGURE_COMMAND ""
         BUILD_COMMAND
@@ -22,7 +22,7 @@ if(ADORA_ROOT_DIR)
     )
 
     add_custom_command(OUTPUT ${node_bridge} ${dora_cxx_include_dir} ${operator_bridge} ${dora_c_include_dir}
-        WORKING_DIRECTORY ${ADORA_ROOT_DIR}
+        WORKING_DIRECTORY ${DORA_ROOT_DIR}
         DEPENDS Dora
         COMMAND
             mkdir ${dora_cxx_include_dir} -p
@@ -33,7 +33,7 @@ if(ADORA_ROOT_DIR)
     )
     
     add_custom_target(Dora_cxx DEPENDS ${node_bridge} ${dora_cxx_include_dir})
-    set(dora_link_dirs ${ADORA_ROOT_DIR}/target/debug)
+    set(dora_link_dirs ${DORA_ROOT_DIR}/target/debug)
 else()
     include(ExternalProject)
     ExternalProject_Add(Dora

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -692,7 +692,7 @@ _unstable_deploy:
 
 ```
 [HEADER]
-├─ MAGIC: 8 bytes ("ADORAREC")
+├─ MAGIC: 8 bytes ("DORAREC")
 ├─ version: u16 LE (currently 1)
 ├─ start_nanos: u64 LE (Unix epoch nanoseconds)
 ├─ dataflow_id: 16 bytes (UUID)
@@ -710,7 +710,7 @@ _unstable_deploy:
 └─ event_bytes: [u8; event_bytes_len]    (bincode InterDaemonEvent)
 
 [FOOTER] (optional, written on clean finish)
-├─ FOOTER_MAGIC: 8 bytes ("ADORAEND")
+├─ FOOTER_MAGIC: 8 bytes ("DORAEND")
 ├─ total_messages: u64 LE
 └─ total_bytes: u64 LE
 ```

--- a/docs/octos-adora-integration-report.md
+++ b/docs/octos-adora-integration-report.md
@@ -147,7 +147,7 @@ dora param set $UUID node_name param_key value
                                │ ShellTool / Dora skill
                                ▼
                     ┌─────────────────────────────┐
-                    │      ADORA CLI (Executor)    │
+                    │      DORA CLI (Executor)    │
                     │  dora run/start/stop        │
                     │  dora node add/remove       │
                     │  dora param set/get         │

--- a/guide/po/messages.pot
+++ b/guide/po/messages.pot
@@ -3286,7 +3286,7 @@ msgstr ""
 msgid ""
 "```\n"
 "[HEADER]\n"
-"├─ MAGIC: 8 bytes (\"ADORAREC\")\n"
+"├─ MAGIC: 8 bytes (\"DORAREC\")\n"
 "├─ version: u16 LE (currently 1)\n"
 "├─ start_nanos: u64 LE (Unix epoch nanoseconds)\n"
 "├─ dataflow_id: 16 bytes (UUID)\n"
@@ -3304,7 +3304,7 @@ msgid ""
 "└─ event_bytes: [u8; event_bytes_len]    (bincode InterDaemonEvent)\n"
 "\n"
 "[FOOTER] (optional, written on clean finish)\n"
-"├─ FOOTER_MAGIC: 8 bytes (\"ADORAEND\")\n"
+"├─ FOOTER_MAGIC: 8 bytes (\"DORAEND\")\n"
 "├─ total_messages: u64 LE\n"
 "└─ total_bytes: u64 LE\n"
 "```"
@@ -3496,7 +3496,7 @@ msgid "Location"
 msgstr ""
 
 #: src/concepts/architecture.md:788
-msgid "`ADORA_COORDINATOR_PORT_WS_DEFAULT`"
+msgid "`DORA_COORDINATOR_PORT_WS_DEFAULT`"
 msgstr ""
 
 #: src/concepts/architecture.md:788 src/operations/cli.md:1056
@@ -3505,7 +3505,7 @@ msgid "Coordinator WebSocket port"
 msgstr ""
 
 #: src/concepts/architecture.md:789
-msgid "`ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT`"
+msgid "`DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT`"
 msgstr ""
 
 #: src/concepts/architecture.md:789
@@ -4585,7 +4585,7 @@ msgstr ""
 #: src/concepts/dataflow-yaml.md:185
 msgid ""
 "Run `dora validate <file>` to check type annotations statically. For "
-"runtime checking, set `ADORA_RUNTIME_TYPE_CHECK=warn` or `error`:"
+"runtime checking, set `DORA_RUNTIME_TYPE_CHECK=warn` or `error`:"
 msgstr ""
 
 #: src/concepts/dataflow-yaml.md:189 src/concepts/types.md:266
@@ -7356,12 +7356,12 @@ msgid "Thread-local testing state set by `setup_integration_testing`"
 msgstr ""
 
 #: src/languages/rust.md:52
-msgid "`ADORA_NODE_CONFIG` environment variable (set by the daemon)"
+msgid "`DORA_NODE_CONFIG` environment variable (set by the daemon)"
 msgstr ""
 
 #: src/languages/rust.md:53
 msgid ""
-"`ADORA_TEST_WITH_INPUTS` environment variable (file-based integration "
+"`DORA_TEST_WITH_INPUTS` environment variable (file-based integration "
 "testing)"
 msgstr ""
 
@@ -8116,7 +8116,7 @@ msgid "Variable"
 msgstr ""
 
 #: src/languages/rust.md:554
-msgid "`ADORA_TEST_WITH_INPUTS`"
+msgid "`DORA_TEST_WITH_INPUTS`"
 msgstr ""
 
 #: src/languages/rust.md:554
@@ -8124,7 +8124,7 @@ msgid "Path to a JSON input file (`IntegrationTestInput` format)"
 msgstr ""
 
 #: src/languages/rust.md:555
-msgid "`ADORA_TEST_WRITE_OUTPUTS_TO`"
+msgid "`DORA_TEST_WRITE_OUTPUTS_TO`"
 msgstr ""
 
 #: src/languages/rust.md:555
@@ -8132,7 +8132,7 @@ msgid "Path for the output JSONL file (default: `outputs.jsonl` next to inputs)"
 msgstr ""
 
 #: src/languages/rust.md:556
-msgid "`ADORA_TEST_NO_OUTPUT_TIME_OFFSET`"
+msgid "`DORA_TEST_NO_OUTPUT_TIME_OFFSET`"
 msgstr ""
 
 #: src/languages/rust.md:556
@@ -13535,7 +13535,7 @@ msgid "Commands"
 msgstr ""
 
 #: src/operations/cli.md:1055
-msgid "`ADORA_COORDINATOR_ADDR`"
+msgid "`DORA_COORDINATOR_ADDR`"
 msgstr ""
 
 #: src/operations/cli.md:1055 src/operations/cli.md:1056
@@ -13547,12 +13547,12 @@ msgid "Coordinator IP address"
 msgstr ""
 
 #: src/operations/cli.md:1056
-msgid "`ADORA_COORDINATOR_PORT`"
+msgid "`DORA_COORDINATOR_PORT`"
 msgstr ""
 
 #: src/operations/cli.md:1057 src/operations/logging.md:156
 #: src/operations/logging.md:330
-msgid "`ADORA_LOG_LEVEL`"
+msgid "`DORA_LOG_LEVEL`"
 msgstr ""
 
 #: src/operations/cli.md:1057 src/operations/cli.md:1058
@@ -13566,7 +13566,7 @@ msgstr ""
 
 #: src/operations/cli.md:1058 src/operations/logging.md:157
 #: src/operations/logging.md:331
-msgid "`ADORA_LOG_FORMAT`"
+msgid "`DORA_LOG_FORMAT`"
 msgstr ""
 
 #: src/operations/cli.md:1058 src/operations/logging.md:331
@@ -13575,7 +13575,7 @@ msgstr ""
 
 #: src/operations/cli.md:1059 src/operations/logging.md:158
 #: src/operations/logging.md:332
-msgid "`ADORA_LOG_FILTER`"
+msgid "`DORA_LOG_FILTER`"
 msgstr ""
 
 #: src/operations/cli.md:1059
@@ -13583,7 +13583,7 @@ msgid "Default per-node level overrides"
 msgstr ""
 
 #: src/operations/cli.md:1060
-msgid "`ADORA_ALLOW_SHELL_NODES`"
+msgid "`DORA_ALLOW_SHELL_NODES`"
 msgstr ""
 
 #: src/operations/cli.md:1060
@@ -13595,7 +13595,7 @@ msgid "Enable shell node execution"
 msgstr ""
 
 #: src/operations/cli.md:1061
-msgid "`ADORA_RUNTIME_TYPE_CHECK`"
+msgid "`DORA_RUNTIME_TYPE_CHECK`"
 msgstr ""
 
 #: src/operations/cli.md:1061
@@ -14128,7 +14128,7 @@ msgstr ""
 #: src/operations/cli.md:1507
 msgid ""
 "Run `dora up` first, or check "
-"`ADORA_COORDINATOR_ADDR`/`ADORA_COORDINATOR_PORT`"
+"`DORA_COORDINATOR_ADDR`/`DORA_COORDINATOR_PORT`"
 msgstr ""
 
 #: src/operations/cli.md:1508
@@ -14515,7 +14515,7 @@ msgid "CLI display"
 msgstr ""
 
 #: src/operations/logging.md:88
-msgid "`--log-level`, `ADORA_LOG_LEVEL`"
+msgid "`--log-level`, `DORA_LOG_LEVEL`"
 msgstr ""
 
 #: src/operations/logging.md:89
@@ -14523,11 +14523,11 @@ msgid "Output formats"
 msgstr ""
 
 #: src/operations/logging.md:89
-msgid "`--log-format`, `ADORA_LOG_FORMAT`"
+msgid "`--log-format`, `DORA_LOG_FORMAT`"
 msgstr ""
 
 #: src/operations/logging.md:90
-msgid "`--log-filter`, `ADORA_LOG_FILTER`"
+msgid "`--log-filter`, `DORA_LOG_FILTER`"
 msgstr ""
 
 #: src/operations/logging.md:91
@@ -15028,7 +15028,7 @@ msgid "`--level LEVEL`"
 msgstr ""
 
 #: src/operations/logging.md:263
-msgid "Minimum log level (env: `ADORA_LOG_LEVEL`)"
+msgid "Minimum log level (env: `DORA_LOG_LEVEL`)"
 msgstr ""
 
 #: src/operations/logging.md:264
@@ -15192,7 +15192,7 @@ msgid "Default per-node overrides"
 msgstr ""
 
 #: src/operations/logging.md:333
-msgid "`ADORA_QUIET`"
+msgid "`DORA_QUIET`"
 msgstr ""
 
 #: src/operations/logging.md:333
@@ -15220,7 +15220,7 @@ msgid "# CLI flag overrides env var:\n"
 msgstr ""
 
 #: src/operations/logging.md:348
-msgid "# overrides ADORA_LOG_LEVEL=info\n"
+msgid "# overrides DORA_LOG_LEVEL=info\n"
 msgstr ""
 
 #: src/operations/logging.md:353
@@ -16805,8 +16805,8 @@ msgstr ""
 
 #: src/operations/logging.md:1264
 msgid ""
-"**Use environment variables for team defaults.** Set `ADORA_LOG_LEVEL` and "
-"`ADORA_LOG_FORMAT` in your shell profile or CI configuration. Individual "
+"**Use environment variables for team defaults.** Set `DORA_LOG_LEVEL` and "
+"`DORA_LOG_FORMAT` in your shell profile or CI configuration. Individual "
 "developers can override with CLI flags."
 msgstr ""
 
@@ -17704,7 +17704,7 @@ msgstr ""
 #: src/operations/debugging.md:498
 msgid ""
 "For full distributed tracing across daemons and nodes, set "
-"`ADORA_OTLP_ENDPOINT` and use an OTLP-compatible backend."
+"`DORA_OTLP_ENDPOINT` and use an OTLP-compatible backend."
 msgstr ""
 
 #: src/operations/debugging.md:502
@@ -17896,15 +17896,15 @@ msgid "Environment variables:"
 msgstr ""
 
 #: src/operations/debugging.md:589
-msgid "`ADORA_LOG_LEVEL` -- default log level"
+msgid "`DORA_LOG_LEVEL` -- default log level"
 msgstr ""
 
 #: src/operations/debugging.md:590
-msgid "`ADORA_LOG_FORMAT` -- default log format"
+msgid "`DORA_LOG_FORMAT` -- default log format"
 msgstr ""
 
 #: src/operations/debugging.md:591
-msgid "`ADORA_LOG_FILTER` -- default per-node filter"
+msgid "`DORA_LOG_FILTER` -- default per-node filter"
 msgstr ""
 
 #: src/operations/debugging.md:595
@@ -21989,7 +21989,7 @@ msgid ""
 "When the Dora descriptor resolver encounters a `ros2:` key on a node, it "
 "converts it into a `Custom` node pointing to the `dora-ros2-bridge-node` "
 "binary. The bridge config is serialized as JSON into the "
-"`ADORA_ROS2_BRIDGE_CONFIG` environment variable."
+"`DORA_ROS2_BRIDGE_CONFIG` environment variable."
 msgstr ""
 
 #: src/advanced/ros2-bridge.md:29
@@ -25587,11 +25587,11 @@ msgid "Builds and runs a node crate (e.g., `rust-dataflow-example-node`)"
 msgstr ""
 
 #: src/development/testing.md:104
-msgid "Sets `ADORA_TEST_WITH_INPUTS` to a JSON file with timed events"
+msgid "Sets `DORA_TEST_WITH_INPUTS` to a JSON file with timed events"
 msgstr ""
 
 #: src/development/testing.md:105
-msgid "Sets `ADORA_TEST_NO_OUTPUT_TIME_OFFSET=1` for deterministic output"
+msgid "Sets `DORA_TEST_NO_OUTPUT_TIME_OFFSET=1` for deterministic output"
 msgstr ""
 
 #: src/development/testing.md:106
@@ -26106,7 +26106,7 @@ msgid "Generating test input files"
 msgstr ""
 
 #: src/development/testing.md:329
-msgid "Record real dataflow events by setting `ADORA_WRITE_EVENTS_TO`:"
+msgid "Record real dataflow events by setting `DORA_WRITE_EVENTS_TO`:"
 msgstr ""
 
 #: src/development/testing.md:332
@@ -26116,7 +26116,7 @@ msgstr ""
 #: src/development/testing.md:335
 msgid ""
 "This writes `inputs-{node_id}.json` files that can be used directly with "
-"`ADORA_TEST_WITH_INPUTS`."
+"`DORA_TEST_WITH_INPUTS`."
 msgstr ""
 
 #: src/development/testing.md:337
@@ -26257,7 +26257,7 @@ msgstr ""
 
 #: src/development/testing.md:407
 msgid ""
-"Check that `ADORA_TEST_NO_OUTPUT_TIME_OFFSET=1` is set (time offsets vary "
+"Check that `DORA_TEST_NO_OUTPUT_TIME_OFFSET=1` is set (time offsets vary "
 "per machine)"
 msgstr ""
 

--- a/guide/po/zh-CN.po
+++ b/guide/po/zh-CN.po
@@ -3418,7 +3418,7 @@ msgstr ""
 msgid ""
 "```\n"
 "[HEADER]\n"
-"├─ MAGIC: 8 bytes (\"ADORAREC\")\n"
+"├─ MAGIC: 8 bytes (\"DORAREC\")\n"
 "├─ version: u16 LE (currently 1)\n"
 "├─ start_nanos: u64 LE (Unix epoch nanoseconds)\n"
 "├─ dataflow_id: 16 bytes (UUID)\n"
@@ -3436,7 +3436,7 @@ msgid ""
 "└─ event_bytes: [u8; event_bytes_len]    (bincode InterDaemonEvent)\n"
 "\n"
 "[FOOTER] (optional, written on clean finish)\n"
-"├─ FOOTER_MAGIC: 8 bytes (\"ADORAEND\")\n"
+"├─ FOOTER_MAGIC: 8 bytes (\"DORAEND\")\n"
 "├─ total_messages: u64 LE\n"
 "└─ total_bytes: u64 LE\n"
 "```"
@@ -3634,7 +3634,7 @@ msgid "Location"
 msgstr ""
 
 #: src/concepts/architecture.md:788
-msgid "`ADORA_COORDINATOR_PORT_WS_DEFAULT`"
+msgid "`DORA_COORDINATOR_PORT_WS_DEFAULT`"
 msgstr ""
 
 #: src/concepts/architecture.md:788 src/operations/cli.md:1056
@@ -3643,7 +3643,7 @@ msgid "Coordinator WebSocket port"
 msgstr ""
 
 #: src/concepts/architecture.md:789
-msgid "`ADORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT`"
+msgid "`DORA_DAEMON_LOCAL_LISTEN_PORT_DEFAULT`"
 msgstr ""
 
 #: src/concepts/architecture.md:789
@@ -4804,7 +4804,7 @@ msgstr ""
 #: src/concepts/dataflow-yaml.md:185
 msgid ""
 "Run `dora validate <file>` to check type annotations statically. For "
-"runtime checking, set `ADORA_RUNTIME_TYPE_CHECK=warn` or `error`:"
+"runtime checking, set `DORA_RUNTIME_TYPE_CHECK=warn` or `error`:"
 msgstr ""
 
 #: src/concepts/dataflow-yaml.md:189 src/concepts/types.md:266
@@ -7694,12 +7694,12 @@ msgid "Thread-local testing state set by `setup_integration_testing`"
 msgstr ""
 
 #: src/languages/rust.md:52
-msgid "`ADORA_NODE_CONFIG` environment variable (set by the daemon)"
+msgid "`DORA_NODE_CONFIG` environment variable (set by the daemon)"
 msgstr ""
 
 #: src/languages/rust.md:53
 msgid ""
-"`ADORA_TEST_WITH_INPUTS` environment variable (file-based integration "
+"`DORA_TEST_WITH_INPUTS` environment variable (file-based integration "
 "testing)"
 msgstr ""
 
@@ -8475,7 +8475,7 @@ msgid "Variable"
 msgstr "变量"
 
 #: src/languages/rust.md:554
-msgid "`ADORA_TEST_WITH_INPUTS`"
+msgid "`DORA_TEST_WITH_INPUTS`"
 msgstr ""
 
 #: src/languages/rust.md:554
@@ -8483,7 +8483,7 @@ msgid "Path to a JSON input file (`IntegrationTestInput` format)"
 msgstr ""
 
 #: src/languages/rust.md:555
-msgid "`ADORA_TEST_WRITE_OUTPUTS_TO`"
+msgid "`DORA_TEST_WRITE_OUTPUTS_TO`"
 msgstr ""
 
 #: src/languages/rust.md:555
@@ -8492,7 +8492,7 @@ msgid ""
 msgstr ""
 
 #: src/languages/rust.md:556
-msgid "`ADORA_TEST_NO_OUTPUT_TIME_OFFSET`"
+msgid "`DORA_TEST_NO_OUTPUT_TIME_OFFSET`"
 msgstr ""
 
 #: src/languages/rust.md:556
@@ -14017,7 +14017,7 @@ msgid "Commands"
 msgstr "命令"
 
 #: src/operations/cli.md:1055
-msgid "`ADORA_COORDINATOR_ADDR`"
+msgid "`DORA_COORDINATOR_ADDR`"
 msgstr ""
 
 #: src/operations/cli.md:1055 src/operations/cli.md:1056
@@ -14029,12 +14029,12 @@ msgid "Coordinator IP address"
 msgstr ""
 
 #: src/operations/cli.md:1056
-msgid "`ADORA_COORDINATOR_PORT`"
+msgid "`DORA_COORDINATOR_PORT`"
 msgstr ""
 
 #: src/operations/cli.md:1057 src/operations/logging.md:156
 #: src/operations/logging.md:330
-msgid "`ADORA_LOG_LEVEL`"
+msgid "`DORA_LOG_LEVEL`"
 msgstr ""
 
 #: src/operations/cli.md:1057 src/operations/cli.md:1058
@@ -14048,7 +14048,7 @@ msgstr ""
 
 #: src/operations/cli.md:1058 src/operations/logging.md:157
 #: src/operations/logging.md:331
-msgid "`ADORA_LOG_FORMAT`"
+msgid "`DORA_LOG_FORMAT`"
 msgstr ""
 
 #: src/operations/cli.md:1058 src/operations/logging.md:331
@@ -14057,7 +14057,7 @@ msgstr ""
 
 #: src/operations/cli.md:1059 src/operations/logging.md:158
 #: src/operations/logging.md:332
-msgid "`ADORA_LOG_FILTER`"
+msgid "`DORA_LOG_FILTER`"
 msgstr ""
 
 #: src/operations/cli.md:1059
@@ -14065,7 +14065,7 @@ msgid "Default per-node level overrides"
 msgstr ""
 
 #: src/operations/cli.md:1060
-msgid "`ADORA_ALLOW_SHELL_NODES`"
+msgid "`DORA_ALLOW_SHELL_NODES`"
 msgstr ""
 
 #: src/operations/cli.md:1060
@@ -14077,7 +14077,7 @@ msgid "Enable shell node execution"
 msgstr ""
 
 #: src/operations/cli.md:1061
-msgid "`ADORA_RUNTIME_TYPE_CHECK`"
+msgid "`DORA_RUNTIME_TYPE_CHECK`"
 msgstr ""
 
 #: src/operations/cli.md:1061
@@ -14611,8 +14611,8 @@ msgstr ""
 
 #: src/operations/cli.md:1507
 msgid ""
-"Run `dora up` first, or check `ADORA_COORDINATOR_ADDR`/"
-"`ADORA_COORDINATOR_PORT`"
+"Run `dora up` first, or check `DORA_COORDINATOR_ADDR`/"
+"`DORA_COORDINATOR_PORT`"
 msgstr ""
 
 #: src/operations/cli.md:1508
@@ -15011,7 +15011,7 @@ msgid "CLI display"
 msgstr ""
 
 #: src/operations/logging.md:88
-msgid "`--log-level`, `ADORA_LOG_LEVEL`"
+msgid "`--log-level`, `DORA_LOG_LEVEL`"
 msgstr ""
 
 #: src/operations/logging.md:89
@@ -15019,11 +15019,11 @@ msgid "Output formats"
 msgstr ""
 
 #: src/operations/logging.md:89
-msgid "`--log-format`, `ADORA_LOG_FORMAT`"
+msgid "`--log-format`, `DORA_LOG_FORMAT`"
 msgstr ""
 
 #: src/operations/logging.md:90
-msgid "`--log-filter`, `ADORA_LOG_FILTER`"
+msgid "`--log-filter`, `DORA_LOG_FILTER`"
 msgstr ""
 
 #: src/operations/logging.md:91
@@ -15526,7 +15526,7 @@ msgid "`--level LEVEL`"
 msgstr ""
 
 #: src/operations/logging.md:263
-msgid "Minimum log level (env: `ADORA_LOG_LEVEL`)"
+msgid "Minimum log level (env: `DORA_LOG_LEVEL`)"
 msgstr ""
 
 #: src/operations/logging.md:264
@@ -15690,7 +15690,7 @@ msgid "Default per-node overrides"
 msgstr ""
 
 #: src/operations/logging.md:333
-msgid "`ADORA_QUIET`"
+msgid "`DORA_QUIET`"
 msgstr ""
 
 #: src/operations/logging.md:333
@@ -15718,7 +15718,7 @@ msgid "# CLI flag overrides env var:\n"
 msgstr ""
 
 #: src/operations/logging.md:348
-msgid "# overrides ADORA_LOG_LEVEL=info\n"
+msgid "# overrides DORA_LOG_LEVEL=info\n"
 msgstr ""
 
 #: src/operations/logging.md:353
@@ -17356,8 +17356,8 @@ msgstr ""
 
 #: src/operations/logging.md:1264
 msgid ""
-"**Use environment variables for team defaults.** Set `ADORA_LOG_LEVEL` and "
-"`ADORA_LOG_FORMAT` in your shell profile or CI configuration. Individual "
+"**Use environment variables for team defaults.** Set `DORA_LOG_LEVEL` and "
+"`DORA_LOG_FORMAT` in your shell profile or CI configuration. Individual "
 "developers can override with CLI flags."
 msgstr ""
 
@@ -18281,7 +18281,7 @@ msgstr ""
 #: src/operations/debugging.md:498
 msgid ""
 "For full distributed tracing across daemons and nodes, set "
-"`ADORA_OTLP_ENDPOINT` and use an OTLP-compatible backend."
+"`DORA_OTLP_ENDPOINT` and use an OTLP-compatible backend."
 msgstr ""
 
 #: src/operations/debugging.md:502
@@ -18473,15 +18473,15 @@ msgid "Environment variables:"
 msgstr ""
 
 #: src/operations/debugging.md:589
-msgid "`ADORA_LOG_LEVEL` -- default log level"
+msgid "`DORA_LOG_LEVEL` -- default log level"
 msgstr ""
 
 #: src/operations/debugging.md:590
-msgid "`ADORA_LOG_FORMAT` -- default log format"
+msgid "`DORA_LOG_FORMAT` -- default log format"
 msgstr ""
 
 #: src/operations/debugging.md:591
-msgid "`ADORA_LOG_FILTER` -- default per-node filter"
+msgid "`DORA_LOG_FILTER` -- default per-node filter"
 msgstr ""
 
 #: src/operations/debugging.md:595
@@ -22673,7 +22673,7 @@ msgid ""
 "When the Dora descriptor resolver encounters a `ros2:` key on a node, it "
 "converts it into a `Custom` node pointing to the `dora-ros2-bridge-node` "
 "binary. The bridge config is serialized as JSON into the "
-"`ADORA_ROS2_BRIDGE_CONFIG` environment variable."
+"`DORA_ROS2_BRIDGE_CONFIG` environment variable."
 msgstr ""
 
 #: src/advanced/ros2-bridge.md:29
@@ -26323,11 +26323,11 @@ msgid "Builds and runs a node crate (e.g., `rust-dataflow-example-node`)"
 msgstr ""
 
 #: src/development/testing.md:104
-msgid "Sets `ADORA_TEST_WITH_INPUTS` to a JSON file with timed events"
+msgid "Sets `DORA_TEST_WITH_INPUTS` to a JSON file with timed events"
 msgstr ""
 
 #: src/development/testing.md:105
-msgid "Sets `ADORA_TEST_NO_OUTPUT_TIME_OFFSET=1` for deterministic output"
+msgid "Sets `DORA_TEST_NO_OUTPUT_TIME_OFFSET=1` for deterministic output"
 msgstr ""
 
 #: src/development/testing.md:106
@@ -26842,7 +26842,7 @@ msgid "Generating test input files"
 msgstr ""
 
 #: src/development/testing.md:329
-msgid "Record real dataflow events by setting `ADORA_WRITE_EVENTS_TO`:"
+msgid "Record real dataflow events by setting `DORA_WRITE_EVENTS_TO`:"
 msgstr ""
 
 #: src/development/testing.md:332
@@ -26852,7 +26852,7 @@ msgstr ""
 #: src/development/testing.md:335
 msgid ""
 "This writes `inputs-{node_id}.json` files that can be used directly with "
-"`ADORA_TEST_WITH_INPUTS`."
+"`DORA_TEST_WITH_INPUTS`."
 msgstr ""
 
 #: src/development/testing.md:337
@@ -26993,7 +26993,7 @@ msgstr ""
 
 #: src/development/testing.md:407
 msgid ""
-"Check that `ADORA_TEST_NO_OUTPUT_TIME_OFFSET=1` is set (time offsets vary "
+"Check that `DORA_TEST_NO_OUTPUT_TIME_OFFSET=1` is set (time offsets vary "
 "per machine)"
 msgstr ""
 

--- a/guide/src/concepts/architecture.md
+++ b/guide/src/concepts/architecture.md
@@ -681,7 +681,7 @@ _unstable_deploy:
 
 ```
 [HEADER]
-├─ MAGIC: 8 bytes ("ADORAREC")
+├─ MAGIC: 8 bytes ("DORAREC")
 ├─ version: u16 LE (currently 1)
 ├─ start_nanos: u64 LE (Unix epoch nanoseconds)
 ├─ dataflow_id: 16 bytes (UUID)
@@ -699,7 +699,7 @@ _unstable_deploy:
 └─ event_bytes: [u8; event_bytes_len]    (bincode InterDaemonEvent)
 
 [FOOTER] (optional, written on clean finish)
-├─ FOOTER_MAGIC: 8 bytes ("ADORAEND")
+├─ FOOTER_MAGIC: 8 bytes ("DORAEND")
 ├─ total_messages: u64 LE
 └─ total_bytes: u64 LE
 ```

--- a/scripts/smoke-all.sh
+++ b/scripts/smoke-all.sh
@@ -36,7 +36,7 @@ for arg in "$@"; do
     esac
 done
 
-ADORA="${ADORA_BIN:-$ROOT/target/debug/dora}"
+DORA="${DORA_BIN:-$ROOT/target/debug/dora}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -52,17 +52,17 @@ run_networked() {
     echo "=> $name (networked, ${timeout}s)"
 
     # Clean up any stale processes
-    "$ADORA" down > /dev/null 2>&1 || true
+    "$DORA" down > /dev/null 2>&1 || true
     sleep 0.5
 
-    if ! "$ADORA" up > /dev/null 2>&1; then
+    if ! "$DORA" up > /dev/null 2>&1; then
         log_fail "$name (dora up failed)"
         return
     fi
 
-    if ! "$ADORA" start "$ROOT/$yaml" --detach > /dev/null 2>&1; then
+    if ! "$DORA" start "$ROOT/$yaml" --detach > /dev/null 2>&1; then
         log_fail "$name (dora start failed)"
-        "$ADORA" down > /dev/null 2>&1 || true
+        "$DORA" down > /dev/null 2>&1 || true
         return
     fi
 
@@ -74,7 +74,7 @@ run_networked() {
         sleep 2
         elapsed=$((elapsed + 2))
         local list_out
-        list_out=$("$ADORA" list --json 2>/dev/null || echo "")
+        list_out=$("$DORA" list --json 2>/dev/null || echo "")
         if [ -z "$list_out" ]; then
             break
         fi
@@ -88,9 +88,9 @@ run_networked() {
     done
 
     # Cleanup
-    "$ADORA" stop --all > /dev/null 2>&1 || true
+    "$DORA" stop --all > /dev/null 2>&1 || true
     sleep 0.5
-    "$ADORA" down > /dev/null 2>&1 || true
+    "$DORA" down > /dev/null 2>&1 || true
 
     if [ "$failed" = true ]; then
         log_fail "$name"
@@ -105,7 +105,7 @@ run_local() {
     local name="$1" yaml="$2" timeout="${3:-15}"
     local hard_timeout=$((timeout * 2 + 5))
     echo "=> $name (local, ${timeout}s, hard-kill ${hard_timeout}s)"
-    "$ADORA" run "$ROOT/$yaml" --stop-after "${timeout}s" \
+    "$DORA" run "$ROOT/$yaml" --stop-after "${timeout}s" \
         > /dev/null 2>&1 &
     local pid=$!
     local elapsed=0


### PR DESCRIPTION
Follow-up to #186. Missed by the broad sed:

- `guide/po/messages.pot` + `zh-CN.po`: `ADORA_*` env vars, `ADORAREC`/`ADORAEND`
- `guide/src` + `docs` architecture diagrams: `ADORAREC`/`ADORAEND` in format diagrams
- C/C++ cmake templates: `ADORA_ROOT_DIR`, `__ADORA_PATH__`
- `scripts/smoke-all.sh`: `ADORA_BIN`, `$ADORA` variable
- `docs/octos-adora-integration-report.md`: `ADORA CLI`

Only the consolidation plan's compat table intentionally references `ADORA_*` (documenting what was changed).