### PR TITLE
ci: upstream parity — workflow_dispatch, check+build, rust-dataflow-git, divergence docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,16 @@
+# CI workflow — superset of upstream dora-rs/dora CI (issue #180).
+#
+# Intentional divergences from upstream:
+# - No Windows in examples/CLI jobs (upstream has it; deferred until
+#   Windows-specific bugs are triaged — tracked in issue #180)
+# - Bench is Ubuntu-only (criterion regression, not cross-platform example)
+# - ROS2 bridge Python test skipped (pyo3 0.28 auto-initialize removed)
+# - No cargo-release/pip-release/docker-image workflows (not publishing yet)
+# - No labeler/bot workflows (not needed for this fork)
+#
+# Matches upstream on: test (3 platforms), fmt, clippy, typos,
+# cross-check (8 targets), examples, CLI, ROS2 bridge examples,
+# MSRV, license check, workflow_dispatch support.
 name: CI
 
 on:
@@ -5,6 +18,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -57,7 +71,16 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
-      - run: >
+      - name: Check
+        run: cargo check --all
+      - name: Build (excluding Python packages)
+        run: >
+          cargo build --all
+          --exclude dora-node-api-python
+          --exclude dora-operator-api-python
+          --exclude dora-ros2-bridge-python
+      - name: Test
+        run: >
           cargo test --all
           --exclude dora-node-api-python
           --exclude dora-operator-api-python
@@ -105,6 +128,9 @@ jobs:
       - name: Rust Dataflow example
         timeout-minutes: 30
         run: cargo run --example rust-dataflow
+      - name: Rust Git Dataflow example
+        timeout-minutes: 30
+        run: cargo run --example rust-dataflow-git
       - name: Multiple Daemons example
         timeout-minutes: 30
         run: cargo run --example multiple-daemons
@@ -339,6 +365,11 @@ jobs:
           cargo test --test fault-tolerance-e2e -- --test-threads=1
         timeout-minutes: 15
 
+  # Benchmark regression check — Ubuntu only (intentional).
+  # Upstream dora runs bench on 3 platforms but only for the benchmark
+  # example (not criterion regression). Our `examples` job already runs
+  # the benchmark example on ubuntu + macos. This job runs criterion
+  # crate-level benchmarks with baseline caching, which is OS-specific.
   bench:
     name: Benchmark regression check
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4301,9 +4301,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -6878,9 +6878,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -6895,15 +6895,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
Partially fixes #180.

## Changes

1. **`workflow_dispatch`** — can now trigger CI manually from GitHub UI (matches upstream)
2. **`cargo check` + `cargo build`** added to test job (upstream does check/build/test; we only did test)
3. **`rust-dataflow-git` example** added to examples job (existed in repo, wasn't tested)
4. **Divergence documentation** — header comment in ci.yml explicitly lists what differs from upstream and why

## Intentional divergences (documented)

| Gap | Reason |
|---|---|
| No Windows in examples/CLI | Deferred until Windows-specific bugs triaged |
| Bench is Ubuntu-only | Criterion regression check, not cross-platform example run |
| ROS2 Python test skipped | pyo3 0.28 removed auto-initialize |
| No release/bot workflows | Not publishing to crates.io/PyPI/Docker yet |

## Test plan

- [x] YAML validates
- [ ] CI will validate the new steps

Partially fixes #180