### PR TITLE
fix(state): enforce strict runtime param delivery for running nodes

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1167,72 +1167,60 @@ async fn start_inner(
                             key,
                             value,
                         } => {
-                            let reply = match resolve_param_target(
-                                &running_dataflows,
-                                store.as_ref(),
-                                &dataflow_id,
-                                &node_id,
-                            ) {
-                                Ok(target) => match serde_json::to_vec(&value) {
-                                    Ok(bytes) => {
-                                        match store.put_node_param(
-                                            &dataflow_id,
-                                            &node_id,
-                                            &key,
-                                            &bytes,
-                                        ) {
-                                            Ok(()) => {
-                                                if let ParamTarget::Running { daemon_id } = target {
-                                                    if let Some(df) =
-                                                        running_dataflows.get_mut(&dataflow_id)
-                                                    {
-                                                        df.append_state_log(
-                                                            StateCatchUpOperation::SetParam {
-                                                                node_id: node_id.clone(),
-                                                                key: key.clone(),
-                                                                value: value.clone(),
-                                                            },
-                                                        );
+                            let reply: eyre::Result<ControlRequestReply> = async {
+                                let target = resolve_param_target(
+                                    &running_dataflows,
+                                    store.as_ref(),
+                                    &dataflow_id,
+                                    &node_id,
+                                )?;
+                                let bytes = serde_json::to_vec(&value)
+                                    .map_err(|e| eyre!("failed to serialize param value: {e}"))?;
+                                store.put_node_param(&dataflow_id, &node_id, &key, &bytes)?;
 
-                                                        if let Ok(msg) =
-                                                            serde_json::to_vec(&Timestamped {
-                                                                inner: DaemonCoordinatorEvent::SetParam {
-                                                                    dataflow_id,
-                                                                    node_id: node_id.clone(),
-                                                                    key: key.clone(),
-                                                                    value: value.clone(),
-                                                                },
-                                                                timestamp: clock.new_timestamp(),
-                                                            })
-                                                            && let Some(conn) =
-                                                                daemon_connections.get_mut(&daemon_id)
-                                                                && let Err(e) =
-                                                                    conn.send_and_receive(&msg).await
-                                                                {
-                                                                    tracing::warn!(
-                                                                        %node_id,
-                                                                        %daemon_id,
-                                                                        "param persisted in store; runtime forwarding is best-effort and failed: {e}"
-                                                                    );
-                                                                }
-                                                    } else {
-                                                        // Dataflow may have been removed after target resolution.
-                                                        tracing::warn!(
-                                                            %dataflow_id,
-                                                            %node_id,
-                                                            "param persisted in store; running dataflow disappeared before runtime forwarding"
-                                                        );
-                                                    }
-                                                }
-                                                Ok(ControlRequestReply::ParamSet)
-                                            }
-                                            Err(e) => Err(e),
-                                        }
-                                    }
-                                    Err(e) => Err(eyre!("failed to serialize param value: {e}")),
-                                },
-                                Err(e) => Err(e),
-                            };
+                                if let ParamTarget::Running { daemon_id } = target {
+                                    let df = running_dataflows.get_mut(&dataflow_id).ok_or_else(
+                                        || {
+                                            eyre!(
+                                                "param persisted in store but running dataflow `{dataflow_id}` disappeared before runtime forwarding for node `{node_id}`"
+                                            )
+                                        },
+                                    )?;
+                                    df.append_state_log(StateCatchUpOperation::SetParam {
+                                        node_id: node_id.clone(),
+                                        key: key.clone(),
+                                        value: value.clone(),
+                                    });
+
+                                    let msg = serde_json::to_vec(&Timestamped {
+                                        inner: DaemonCoordinatorEvent::SetParam {
+                                            dataflow_id,
+                                            node_id: node_id.clone(),
+                                            key: key.clone(),
+                                            value: value.clone(),
+                                        },
+                                        timestamp: clock.new_timestamp(),
+                                    })
+                                    .map_err(|e| {
+                                        eyre!("failed to serialize SetParam event for node `{node_id}`: {e}")
+                                    })?;
+
+                                    let conn =
+                                        daemon_connections.get_mut(&daemon_id).ok_or_else(|| {
+                                            eyre!(
+                                                "param persisted in store but daemon `{daemon_id}` is not connected"
+                                            )
+                                        })?;
+                                    let reply_raw = conn.send_and_receive(&msg).await.map_err(|e| {
+                                        eyre!(
+                                            "failed to forward SetParam to daemon `{daemon_id}` for node `{node_id}`: {e}"
+                                        )
+                                    })?;
+                                    ensure_set_param_forward_applied(&reply_raw, &node_id)?;
+                                }
+                                Ok(ControlRequestReply::ParamSet)
+                            }
+                            .await;
                             let _ = reply_sender.send(reply);
                         }
                         ControlRequest::DeleteParam {
@@ -1240,62 +1228,58 @@ async fn start_inner(
                             node_id,
                             key,
                         } => {
-                            let reply = match resolve_param_target(
-                                &running_dataflows,
-                                store.as_ref(),
-                                &dataflow_id,
-                                &node_id,
-                            ) {
-                                Ok(target) => {
-                                    match store.delete_node_param(&dataflow_id, &node_id, &key) {
-                                        Ok(()) => {
-                                            if let ParamTarget::Running { daemon_id } = target {
-                                                if let Some(df) =
-                                                    running_dataflows.get_mut(&dataflow_id)
-                                                {
-                                                    df.append_state_log(
-                                                        StateCatchUpOperation::DeleteParam {
-                                                            node_id: node_id.clone(),
-                                                            key: key.clone(),
-                                                        },
-                                                    );
+                            let reply: eyre::Result<ControlRequestReply> = async {
+                                let target = resolve_param_target(
+                                    &running_dataflows,
+                                    store.as_ref(),
+                                    &dataflow_id,
+                                    &node_id,
+                                )?;
+                                store.delete_node_param(&dataflow_id, &node_id, &key)?;
 
-                                                    if let Ok(msg) =
-                                                        serde_json::to_vec(&Timestamped {
-                                                            inner: DaemonCoordinatorEvent::DeleteParam {
-                                                                dataflow_id,
-                                                                node_id: node_id.clone(),
-                                                                key: key.clone(),
-                                                            },
-                                                            timestamp: clock.new_timestamp(),
-                                                        })
-                                                        && let Some(conn) =
-                                                            daemon_connections.get_mut(&daemon_id)
-                                                            && let Err(e) =
-                                                                conn.send_and_receive(&msg).await
-                                                            {
-                                                                tracing::warn!(
-                                                                    %node_id,
-                                                                    %daemon_id,
-                                                                    "param deleted in store; runtime forwarding is best-effort and failed: {e}"
-                                                                );
-                                                            }
-                                                } else {
-                                                    // Dataflow may have been removed after target resolution.
-                                                    tracing::warn!(
-                                                        %dataflow_id,
-                                                        %node_id,
-                                                        "param deleted in store; running dataflow disappeared before runtime forwarding"
-                                                    );
-                                                }
-                                            }
-                                            Ok(ControlRequestReply::ParamDeleted)
-                                        }
-                                        Err(e) => Err(e),
-                                    }
+                                if let ParamTarget::Running { daemon_id } = target {
+                                    let df = running_dataflows.get_mut(&dataflow_id).ok_or_else(
+                                        || {
+                                            eyre!(
+                                                "param deleted in store but running dataflow `{dataflow_id}` disappeared before runtime forwarding for node `{node_id}`"
+                                            )
+                                        },
+                                    )?;
+                                    df.append_state_log(StateCatchUpOperation::DeleteParam {
+                                        node_id: node_id.clone(),
+                                        key: key.clone(),
+                                    });
+
+                                    let msg = serde_json::to_vec(&Timestamped {
+                                        inner: DaemonCoordinatorEvent::DeleteParam {
+                                            dataflow_id,
+                                            node_id: node_id.clone(),
+                                            key: key.clone(),
+                                        },
+                                        timestamp: clock.new_timestamp(),
+                                    })
+                                    .map_err(|e| {
+                                        eyre!(
+                                            "failed to serialize DeleteParam event for node `{node_id}`: {e}"
+                                        )
+                                    })?;
+
+                                    let conn =
+                                        daemon_connections.get_mut(&daemon_id).ok_or_else(|| {
+                                            eyre!(
+                                                "param deleted in store but daemon `{daemon_id}` is not connected"
+                                            )
+                                        })?;
+                                    let reply_raw = conn.send_and_receive(&msg).await.map_err(|e| {
+                                        eyre!(
+                                            "failed to forward DeleteParam to daemon `{daemon_id}` for node `{node_id}`: {e}"
+                                        )
+                                    })?;
+                                    ensure_delete_param_forward_applied(&reply_raw, &node_id)?;
                                 }
-                                Err(e) => Err(e),
-                            };
+                                Ok(ControlRequestReply::ParamDeleted)
+                            }
+                            .await;
                             let _ = reply_sender.send(reply);
                         }
                         // --- Dynamic Topology ---
@@ -2280,6 +2264,36 @@ fn build_set_param_message_from_raw_json(
     .map_err(Into::into)
 }
 
+fn ensure_set_param_forward_applied(
+    reply_raw: &[u8],
+    node_id: &dora_core::config::NodeId,
+) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::SetParamResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::SetParamResult(Err(err)) => Err(eyre!(
+            "daemon failed to apply SetParam for node `{node_id}`: {err}"
+        )),
+        other => Err(eyre!(
+            "unexpected daemon reply for SetParam on node `{node_id}`: {other:?}"
+        )),
+    }
+}
+
+fn ensure_delete_param_forward_applied(
+    reply_raw: &[u8],
+    node_id: &dora_core::config::NodeId,
+) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::DeleteParamResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::DeleteParamResult(Err(err)) => Err(eyre!(
+            "daemon failed to apply DeleteParam for node `{node_id}`: {err}"
+        )),
+        other => Err(eyre!(
+            "unexpected daemon reply for DeleteParam on node `{node_id}`: {other:?}"
+        )),
+    }
+}
+
 fn schedule_param_replay_for_ready_dataflow(
     dataflow_id: DataflowId,
     dataflow: &RunningDataflow,
@@ -2958,6 +2972,29 @@ mod tests {
         // But a daemon at seq 7 can
         let delta = df.state_log_delta(7).expect("should succeed");
         assert_eq!(delta.len(), 3); // entries 8, 9, 10
+    }
+
+    #[test]
+    fn set_param_forward_reply_reports_daemon_rejection() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Err(
+            "node `camera` channel full".to_string(),
+        )))
+        .unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let err = ensure_set_param_forward_applied(&reply, &node_id)
+            .expect_err("daemon rejection should fail strict forwarding");
+        assert!(err.to_string().contains("failed to apply SetParam"));
+    }
+
+    #[test]
+    fn delete_param_forward_reply_rejects_unexpected_reply_variant() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Ok(()))).unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let err = ensure_delete_param_forward_applied(&reply, &node_id)
+            .expect_err("unexpected reply variant should fail strict forwarding");
+        assert!(err.to_string().contains("unexpected daemon reply"));
     }
 }
 

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1176,6 +1176,9 @@ async fn start_inner(
                                 )?;
                                 let bytes = serde_json::to_vec(&value)
                                     .map_err(|e| eyre!("failed to serialize param value: {e}"))?;
+                                // Persist first (source of truth), then attempt synchronous
+                                // runtime forwarding. If forwarding fails, caller gets Error(...)
+                                // but persisted value will be replayed on catch-up/reconnect.
                                 store.put_node_param(&dataflow_id, &node_id, &key, &bytes)?;
 
                                 if let ParamTarget::Running { daemon_id } = target {
@@ -1235,6 +1238,9 @@ async fn start_inner(
                                     &dataflow_id,
                                     &node_id,
                                 )?;
+                                // Persist first (source of truth), then attempt synchronous
+                                // runtime forwarding. If forwarding fails, caller gets Error(...)
+                                // but delete is still reflected in persisted state/catch-up log.
                                 store.delete_node_param(&dataflow_id, &node_id, &key)?;
 
                                 if let ParamTarget::Running { daemon_id } = target {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -197,6 +197,47 @@ const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// patterns; messages are dropped with a warning when full.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
 
+fn deliver_param_update_strict(
+    dataflow: &RunningDataflow,
+    node_id: &NodeId,
+    key: String,
+    value: serde_json::Value,
+    clock: &HLC,
+) -> eyre::Result<()> {
+    let channel = dataflow
+        .subscribe_channels
+        .get(node_id)
+        .ok_or_else(|| eyre!("node `{node_id}` not connected"))?;
+    match send_with_timestamp(channel, NodeEvent::ParamUpdate { key, value }, clock) {
+        Ok(true) => {
+            dataflow.inc_pending(node_id);
+            Ok(())
+        }
+        Ok(false) => Err(eyre!("node `{node_id}` channel full")),
+        Err(_) => Err(eyre!("node `{node_id}` channel closed")),
+    }
+}
+
+fn deliver_param_delete_strict(
+    dataflow: &RunningDataflow,
+    node_id: &NodeId,
+    key: String,
+    clock: &HLC,
+) -> eyre::Result<()> {
+    let channel = dataflow
+        .subscribe_channels
+        .get(node_id)
+        .ok_or_else(|| eyre!("node `{node_id}` not connected"))?;
+    match send_with_timestamp(channel, NodeEvent::ParamDeleted { key }, clock) {
+        Ok(true) => {
+            dataflow.inc_pending(node_id);
+            Ok(())
+        }
+        Ok(false) => Err(eyre!("node `{node_id}` channel full")),
+        Err(_) => Err(eyre!("node `{node_id}` channel closed")),
+    }
+}
+
 /// The Daemon manages running dataflows, node communication, and inter-daemon
 /// message routing. Fields are `pub(crate)` to enable `impl Daemon` blocks in
 /// submodules (e.g., `node_events.rs`, `dataflow_lifecycle.rs`) as part of the
@@ -1397,26 +1438,7 @@ impl Daemon {
             } => {
                 let result = match self.running.get(&dataflow_id) {
                     Some(dataflow) => {
-                        if let Some(channel) = dataflow.subscribe_channels.get(&node_id) {
-                            match send_with_timestamp(
-                                channel,
-                                NodeEvent::ParamUpdate { key, value },
-                                &self.clock,
-                            ) {
-                                Ok(true) => {
-                                    dataflow.inc_pending(&node_id);
-                                    Ok(())
-                                }
-                                Ok(false) => Ok(()), // event dropped (channel full)
-                                Err(_) => Err(eyre::eyre!("node `{node_id}` channel closed")),
-                            }
-                        } else {
-                            tracing::debug!(
-                                %node_id,
-                                "param update not deliverable: node not yet connected"
-                            );
-                            Ok(())
-                        }
+                        deliver_param_update_strict(dataflow, &node_id, key, value, &self.clock)
                     }
                     None => Err(eyre::eyre!("no running dataflow with ID `{dataflow_id}`")),
                 };
@@ -1435,26 +1457,7 @@ impl Daemon {
             } => {
                 let result = match self.running.get(&dataflow_id) {
                     Some(dataflow) => {
-                        if let Some(channel) = dataflow.subscribe_channels.get(&node_id) {
-                            match send_with_timestamp(
-                                channel,
-                                NodeEvent::ParamDeleted { key },
-                                &self.clock,
-                            ) {
-                                Ok(true) => {
-                                    dataflow.inc_pending(&node_id);
-                                    Ok(())
-                                }
-                                Ok(false) => Ok(()), // event dropped (channel full)
-                                Err(_) => Err(eyre::eyre!("node `{node_id}` channel closed")),
-                            }
-                        } else {
-                            tracing::debug!(
-                                %node_id,
-                                "param delete not deliverable: node not yet connected"
-                            );
-                            Ok(())
-                        }
+                        deliver_param_delete_strict(dataflow, &node_id, key, &self.clock)
                     }
                     None => Err(eyre::eyre!("no running dataflow with ID `{dataflow_id}`")),
                 };
@@ -4683,6 +4686,23 @@ mod fault_tolerance_tests {
     }
 
     #[test]
+    fn strict_param_update_fails_when_node_not_connected() {
+        let df = test_dataflow();
+        let clock = test_clock();
+        let node_id: NodeId = "node_missing".to_string().into();
+
+        let err = deliver_param_update_strict(
+            &df,
+            &node_id,
+            "threshold".into(),
+            serde_json::json!(1),
+            &clock,
+        )
+        .expect_err("strict delivery should fail when node channel is missing");
+        assert!(err.to_string().contains("not connected"));
+    }
+
+    #[test]
     fn param_delete_delivered_to_node() {
         let clock = test_clock();
         let (tx, mut rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
@@ -4715,6 +4735,32 @@ mod fault_tolerance_tests {
         let result =
             send_with_timestamp(&tx, NodeEvent::ParamDeleted { key: "rate".into() }, &clock);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn strict_param_delete_fails_when_channel_full() {
+        let mut df = test_dataflow();
+        let clock = test_clock();
+        let node_id: NodeId = "node_a".to_string().into();
+        let (tx, _rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
+        df.subscribe_channels.insert(node_id.clone(), tx.clone());
+
+        // Saturate channel so strict delivery observes a dropped send.
+        for _ in 0..NODE_EVENT_CHANNEL_CAPACITY {
+            let sent = send_with_timestamp(
+                &tx,
+                NodeEvent::ParamDeleted {
+                    key: "prefill".into(),
+                },
+                &clock,
+            )
+            .unwrap();
+            assert!(sent);
+        }
+
+        let err = deliver_param_delete_strict(&df, &node_id, "threshold".into(), &clock)
+            .expect_err("strict delivery should fail when node channel is full");
+        assert!(err.to_string().contains("channel full"));
     }
 }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1849,6 +1849,8 @@ impl Daemon {
                                     &self.clock,
                                 ) {
                                     Ok(true) => dataflow.inc_pending(node_id),
+                                    // Catch-up is recovery/best-effort: keep applying remaining
+                                    // entries and let future catch-up cycles reconcile again.
                                     Ok(false) => {} // dropped (channel full)
                                     Err(_) => {
                                         tracing::warn!("catch-up: node `{node_id}` channel closed")
@@ -1866,6 +1868,8 @@ impl Daemon {
                                     &self.clock,
                                 ) {
                                     Ok(true) => dataflow.inc_pending(node_id),
+                                    // Catch-up is recovery/best-effort: keep applying remaining
+                                    // entries and let future catch-up cycles reconcile again.
                                     Ok(false) => {}
                                     Err(_) => {
                                         tracing::warn!("catch-up: node `{node_id}` channel closed")

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -555,6 +555,43 @@ mod real_dataflow {
         }
     }
 
+    fn set_param_with_retry(
+        session: &WsSession,
+        dataflow_id: Uuid,
+        node_id: dora_message::id::NodeId,
+        key: String,
+        value: serde_json::Value,
+    ) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        loop {
+            let reply = super::send_request(
+                session,
+                &ControlRequest::SetParam {
+                    dataflow_id,
+                    node_id: node_id.clone(),
+                    key: key.clone(),
+                    value: value.clone(),
+                },
+            )
+            .unwrap();
+            match reply {
+                ControlRequestReply::ParamSet => return,
+                ControlRequestReply::Error(msg)
+                    if msg.contains("not connected")
+                        || msg.contains("channel full")
+                        || msg.contains("failed to apply SetParam") =>
+                {
+                    assert!(
+                        std::time::Instant::now() <= deadline,
+                        "set failed after retries for key `{key}`: {msg}"
+                    );
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                other => panic!("set failed for key `{key}`: {other:?}"),
+            }
+        }
+    }
+
     /// Full lifecycle: start -> list (shows dataflow) -> stop -> destroy
     #[test]
     fn e2e_start_list_stop() {
@@ -666,19 +703,12 @@ mod real_dataflow {
         let node_id: dora_message::id::NodeId = "rust-node".to_string().into();
         let session = connect_session();
 
-        let reply = super::send_request(
+        set_param_with_retry(
             &session,
-            &ControlRequest::SetParam {
-                dataflow_id,
-                node_id: node_id.clone(),
-                key: "rate".into(),
-                value: serde_json::json!(100),
-            },
-        )
-        .unwrap();
-        assert!(
-            matches!(reply, ControlRequestReply::ParamSet),
-            "set failed: {reply:?}"
+            dataflow_id,
+            node_id.clone(),
+            "rate".into(),
+            serde_json::json!(100),
         );
 
         let reply = super::send_request(
@@ -762,19 +792,12 @@ mod real_dataflow {
         ];
 
         for (key, value) in &test_cases {
-            let reply = super::send_request(
+            set_param_with_retry(
                 &session,
-                &ControlRequest::SetParam {
-                    dataflow_id,
-                    node_id: node_id.clone(),
-                    key: key.to_string(),
-                    value: value.clone(),
-                },
-            )
-            .unwrap();
-            assert!(
-                matches!(reply, ControlRequestReply::ParamSet),
-                "set failed for {key}"
+                dataflow_id,
+                node_id.clone(),
+                key.to_string(),
+                value.clone(),
             );
         }
 


### PR DESCRIPTION
## Summary
  This PR makes runtime parameter mutation delivery strict for **running** targets.

  For `SetParam` / `DeleteParam`, success now requires daemon-confirmed runtime delivery to the target running node. Non-delivery paths now return errors instead of silently succeeding.

  ## Problem / Impact
  Previously, param mutations could report success even when runtime delivery did not happen (e.g. node not connected or channel full). That created control-plane/data-plane inconsistency:

  - CLI/API saw success
  - runtime node did not receive/apply the mutation
  - coordinator/store state suggested mutation succeeded

  This is a correctness issue across CLI → coordinator → daemon → node boundaries.

  ## What Changed

  ### 1) Daemon: strict delivery semantics for running nodes
  In `binaries/daemon/src/lib.rs`:

  - `SetParam` and `DeleteParam` now return daemon errors when delivery is not possible:
    - node not connected
    - node channel full
    - node channel closed
  - Added strict helpers:
    - `deliver_param_update_strict(...)`
    - `deliver_param_delete_strict(...)`

  ### 2) Coordinator: strict reply validation for running-target forwarding
  In `binaries/coordinator/src/lib.rs`:

  - Added reply validators:
    - `ensure_set_param_forward_applied(...)`
    - `ensure_delete_param_forward_applied(...)`
  - Running-target mutation path now requires:
    - `DaemonCoordinatorReply::SetParamResult(Ok(()))` for `SetParam`
    - `DaemonCoordinatorReply::DeleteParamResult(Ok(()))` for `DeleteParam`
  - Daemon rejection / unexpected reply now returns `ControlRequestReply::Error(...)` to caller.

  ### 3) E2E stability under strict startup timing
  In `tests/ws-cli-e2e.rs`:

  - Added bounded retry helper `set_param_with_retry(...)` for transient startup windows where node channels are not yet connected.
  - Updated param running-dataflow E2E tests to use retry helper.

  ## Why This Is High-Leverage
  This is a focused contract fix across system boundaries that improves correctness without new subsystem complexity:

  - aligns API success semantics with runtime application semantics
  - removes silent non-delivery success cases
  - improves reliability/debuggability in distributed state mutation flows

  ## Files Changed
  - `binaries/coordinator/src/lib.rs`
  - `binaries/daemon/src/lib.rs`
  - `tests/ws-cli-e2e.rs`

  ## Tests Added / Updated

  ### New targeted tests
  - Daemon:
    - strict update fails when node not connected
    - strict delete fails when channel full
  - Coordinator:
    - rejects daemon SetParam error reply
    - rejects unexpected reply variant for delete-forward validation

  ### Existing tests rerun
  - Full daemon suite
  - Full coordinator suite
  - Param-focused ws-cli E2E (`e2e_param_*`)

  ## Validation
  Ran following checks (all pass):

  - `cargo fmt --all -- --check`
  - `cargo clippy -p dora-daemon -p dora-coordinator -- -D warnings`
  - `cargo test -p dora-daemon -- --nocapture`
  - `cargo test -p dora-coordinator -- --nocapture`
  - `cargo test --test ws-cli-e2e e2e_param_ -- --nocapture --test-threads=1`
