### PR TITLE
fix(runtime): use multi-thread tokio scheduler for Zenoh compatibility

### DIFF
--- a/binaries/runtime/src/lib.rs
+++ b/binaries/runtime/src/lib.rs
@@ -62,7 +62,11 @@ pub fn main() -> eyre::Result<()> {
         event,
     });
 
-    let tokio_runtime = Builder::new_current_thread()
+    // Use multi-thread scheduler (with 1 worker) because Zenoh requires it
+    // for distributed cross-daemon communication. current_thread panics when
+    // Zenoh tries to spawn background tasks during session init.
+    let tokio_runtime = Builder::new_multi_thread()
+        .worker_threads(1)
         .enable_all()
         .build()
         .wrap_err("Could not build a tokio runtime.")?;


### PR DESCRIPTION
## Summary

Fixes #202.

The operator runtime (`binaries/runtime`) used `tokio::runtime::Builder::new_current_thread()` for its main event loop. Zenoh 1.8+ requires a multi-thread scheduler to spawn its background tasks, causing a panic during session init in distributed (multi-daemon) dataflows.

### Root cause

When `runtime-node` starts on daemon A and needs to publish to daemon B via Zenoh, the node API calls `open_zenoh_session()`. Zenoh's internal async tasks need `tokio::spawn()`, which panics on a current-thread runtime:

```
thread '<unnamed>' panicked at zenoh-runtime-1.8.0/src/lib.rs:149:21:
Zenoh runtime doesn't support Tokio's current thread scheduler.
```

### Fix

One line change: `Builder::new_current_thread()` -> `Builder::new_multi_thread().worker_threads(1)` in `binaries/runtime/src/lib.rs:65`. The `worker_threads(1)` keeps overhead minimal since operators typically run in a single thread.

The download-only runtimes in `shared_lib.rs` and `python.rs` are left as `current_thread` since they don't initialize Zenoh.

## Test plan

- [x] `cargo run --example multiple-daemons` completes successfully (sink receives data, no panics)
- [x] `cargo clippy -p dora-runtime -- -D warnings`
- [x] `cargo fmt --all -- --check`