### PR TITLE
test(smoke): fix smoke test infrastructure, 44/45 now pass

### DIFF
--- a/examples/log-aggregator/log_viewer.py
+++ b/examples/log-aggregator/log_viewer.py
@@ -14,7 +14,17 @@ print("=== Log Viewer Started (receiving all dataflow logs) ===")
 
 for event in node:
     if event["type"] == "INPUT" and event["id"] == "logs":
-        raw = bytes(event["value"]).decode("utf-8")
+        value = event["value"]
+        # `dora/logs` may deliver a StringScalar, an Array, or raw bytes
+        # depending on the emitter; handle all three.
+        if hasattr(value, "as_py"):
+            raw = value.as_py()
+            if isinstance(raw, list) and raw:
+                raw = raw[0]
+        elif isinstance(value, (bytes, bytearray)):
+            raw = value.decode("utf-8")
+        else:
+            raw = str(value)
         try:
             log = json.loads(raw)
             level = log.get("level", "?").upper()

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -133,11 +133,29 @@ fn ensure_action_nodes_built() {
 /// Ensure no leftover coordinator/daemon from a previous test or manual run.
 fn cleanup_stale(dora: &str) {
     let _ = Command::new(dora)
+        .args(["stop", "--all"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = Command::new(dora)
+        .arg("destroy")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    let _ = Command::new(dora)
         .arg("down")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
-    std::thread::sleep(Duration::from_millis(500));
+    // Wait for port 6013 to be fully released (TCP TIME_WAIT)
+    std::thread::sleep(Duration::from_secs(1));
+}
+
+/// Detect whether a dataflow YAML uses Python nodes (needs --uv).
+fn needs_uv(yaml_path: &Path) -> bool {
+    std::fs::read_to_string(yaml_path)
+        .map(|content| content.contains(".py") || content.contains("pip install"))
+        .unwrap_or(false)
 }
 
 /// Run an example dataflow through the full WS control plane lifecycle.
@@ -159,6 +177,8 @@ fn run_smoke_test(name: &str, yaml_path: &str, timeout: Duration) {
 
     cleanup_stale(&dora);
 
+    let uv = needs_uv(&full_yaml);
+
     // `dora up` starts coordinator + daemon and returns when both are ready.
     // Use Stdio::null() for all streams to prevent child processes from
     // keeping inherited pipe fds open.
@@ -171,9 +191,26 @@ fn run_smoke_test(name: &str, yaml_path: &str, timeout: Duration) {
 
     assert!(up_status.success(), "{name}: dora up failed");
 
+    // Build first so start has resolved artifacts (required for Python/git/etc.)
+    let mut build_cmd = Command::new(&dora);
+    build_cmd.args(["build", full_yaml.to_str().unwrap()]);
+    if uv {
+        build_cmd.arg("--uv");
+    }
+    let build_status = build_cmd
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .unwrap_or_else(|e| panic!("{name}: failed to run dora build: {e}"));
+    assert!(build_status.success(), "{name}: dora build failed");
+
     // Start dataflow (detach so we get control back immediately)
-    let start_status = Command::new(&dora)
-        .args(["start", full_yaml.to_str().unwrap(), "--detach"])
+    let mut start_cmd = Command::new(&dora);
+    start_cmd.args(["start", full_yaml.to_str().unwrap(), "--detach"]);
+    if uv {
+        start_cmd.arg("--uv");
+    }
+    let start_status = start_cmd
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -216,17 +253,7 @@ fn run_smoke_test(name: &str, yaml_path: &str, timeout: Duration) {
     }
 
     // Clean up: stop all dataflows and destroy coordinator+daemon
-    let _ = Command::new(&dora)
-        .args(["stop", "--all"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-    std::thread::sleep(Duration::from_millis(500));
-    let _ = Command::new(&dora)
-        .arg("down")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
+    cleanup_stale(&dora);
 }
 
 /// Run an example dataflow locally with `dora run --stop-after`.
@@ -245,13 +272,17 @@ fn run_smoke_test_local(name: &str, yaml_path: &str, stop_after_secs: u64) {
     );
 
     let stop_after = format!("{stop_after_secs}s");
-    let output = Command::new(&dora)
-        .args([
-            "run",
-            full_yaml.to_str().unwrap(),
-            "--stop-after",
-            &stop_after,
-        ])
+    let mut cmd = Command::new(&dora);
+    cmd.args([
+        "run",
+        full_yaml.to_str().unwrap(),
+        "--stop-after",
+        &stop_after,
+    ]);
+    if needs_uv(&full_yaml) {
+        cmd.arg("--uv");
+    }
+    let output = cmd
         .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .output()


### PR DESCRIPTION
## Summary

Refs #206. The `dora-examples` smoke test suite was completely broken (42 of 45 tests failing). This PR fixes the test infrastructure and one genuine bug in an example node, bringing the pass rate to 44/45.

## Before / after

| | Before | After |
|---|---|---|
| Passing | 3 | **44** |
| Failing | 42 | 1 |

## Root causes fixed

### 1. Missing `--uv` flag for Python dataflows

Python examples need `uv` to resolve dependencies. The harness never passed `--uv`, so every Python test failed.

**Fix:** Added `needs_uv()` detection based on YAML content (`.py` or `pip install`), and pass `--uv` to `dora build`, `dora start`, and `dora run` when appropriate.

### 2. Missing `dora build` step in networked tests

Networked tests went straight to `dora start`, skipping the build step. This broke anything needing artifact resolution.

**Fix:** Added `dora build` before `dora start` in `run_smoke_test`.

### 3. Weak cleanup between tests

Old cleanup was just `dora down` + 500ms sleep. Port 6013 was often still in TIME_WAIT when the next test ran `dora up`, causing "Address already in use" failures.

**Fix:** `cleanup_stale` now runs `stop --all` + `destroy` + `down` + 1s sleep. Also used at end of each test.

### 4. `log_viewer.py` pyarrow bug

`bytes(event["value"])` fails with pyarrow's current API: `StringScalar` is not indexable as int.

**Fix:** Use `.as_py()` when available, fall back to `bytes()` for legacy emitters, `str()` for everything else.

## Remaining failure

`smoke_local_python_concurrent_rw` fails in the full suite but **passes when run standalone**. Root cause: an earlier test installs `dora-rs==0.5.0` from PyPI (via dora-hub packages) into the shared Python env, overriding our local `0.2.1`. Fixing this requires per-test venv isolation, out of scope for this PR.

## Test plan

- [x] Full suite locally: `cargo test -p dora-examples --test example-smoke -- --test-threads=1` passes 44/45
- [x] `cargo fmt --all -- --check`

Note: smoke tests are still excluded from CI `cargo test --all` (they require manual `--test-threads=1` and take ~11 min). Re-enabling them in CI is a separate decision.
