### PR TITLE
ci: upgrade actions/checkout from v3 to v4 in 4 workflows

### DIFF
--- a/.github/workflows/cargo-release.yml
+++ b/.github/workflows/cargo-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r7kamura/rust-problem-matchers@v1.1.0
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/delete-buildjet-cache.yml
+++ b/.github/workflows/delete-buildjet-cache.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - uses: buildjet/cache-delete@v1
         with:
           cache_key: ${{ inputs.cache_key }}

--- a/.github/workflows/dora-bot-assign.yml
+++ b/.github/workflows/dora-bot-assign.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.event_name == 'issue_comment'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Parses comment then assign/unassign user
         env:

--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -247,7 +247,7 @@ jobs:
           - path: binaries/cli
             name: dora-rs-cli
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build sdist
         uses: PyO3/maturin-action@v1
         with:


### PR DESCRIPTION
cargo-release.yml, pip-release.yml (sdist job), dora-bot-assign.yml, and delete-buildjet-cache.yml were still using actions/checkout@v3 while all other workflows had already migrated to v4.

Detected by scripts/qa/ci-lint.sh.