### PR TITLE
qa: wire adversarial LLM review into QA pipeline (optional)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 .PHONY: qa qa-fast qa-full qa-tier1 \
         qa-fmt qa-audit qa-unwrap qa-clippy qa-test qa-coverage qa-mutants qa-semver \
-        qa-install
+        qa-adversarial qa-install
 
 qa: qa-fast
 
@@ -52,6 +52,10 @@ qa-mutants:
 
 qa-semver:
 	@scripts/qa/semver.sh
+
+# Adversarial LLM review of current diff (requires codex or claude CLI)
+qa-adversarial:
+	@scripts/qa/adversarial.sh
 
 # One-shot tool installation
 

--- a/scripts/qa/adversarial.sh
+++ b/scripts/qa/adversarial.sh
@@ -17,11 +17,13 @@
 #   scripts/qa/adversarial.sh --base HEAD~3        # diff vs HEAD~3
 #   scripts/qa/adversarial.sh --diff mypatch.diff  # diff from a file
 #   scripts/qa/adversarial.sh --backend claude     # force claude CLI
+#   scripts/qa/adversarial.sh --optional           # skip cleanly if no CLI
 #
 # Environment overrides:
 #   ADVERSARIAL_BACKEND=codex|claude  — skip auto-detect
 #   ADVERSARIAL_BASE=<ref>            — base for diff (default: origin/main)
 #   ADVERSARIAL_MAX_DIFF_KB=200       — skip review if diff is larger
+#   ADVERSARIAL_OPTIONAL=1            — skip cleanly when no CLI available
 
 set -euo pipefail
 
@@ -32,14 +34,16 @@ BASE="${ADVERSARIAL_BASE:-origin/main}"
 DIFF_FILE=""
 BACKEND="${ADVERSARIAL_BACKEND:-}"
 MAX_DIFF_KB="${ADVERSARIAL_MAX_DIFF_KB:-200}"
+OPTIONAL="${ADVERSARIAL_OPTIONAL:-0}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --base) BASE="$2"; shift 2 ;;
     --diff) DIFF_FILE="$2"; shift 2 ;;
     --backend) BACKEND="$2"; shift 2 ;;
+    --optional) OPTIONAL=1; shift ;;
     --help|-h)
-      sed -n '2,25p' "$0"
+      sed -n '2,27p' "$0"
       exit 0
       ;;
     *) echo "Unknown arg: $1" >&2; exit 2 ;;
@@ -53,7 +57,13 @@ if [[ -z "$BACKEND" ]]; then
   elif command -v claude >/dev/null 2>&1; then
     BACKEND=claude
   else
+    if [[ "$OPTIONAL" == "1" ]]; then
+      echo "adversarial: neither 'codex' nor 'claude' CLI installed, skipping (optional)" >&2
+      exit 0
+    fi
     echo "error: neither 'codex' nor 'claude' CLI is installed." >&2
+    echo "  Install codex: https://github.com/openai/codex" >&2
+    echo "  Or run with --optional to skip cleanly when unavailable." >&2
     exit 2
   fi
 fi

--- a/scripts/qa/all.sh
+++ b/scripts/qa/all.sh
@@ -50,6 +50,8 @@ elif [[ "$MODE" == "--full" || "$MODE" == "--tier1" ]]; then
     --exclude dora-cli-api-python \
     --exclude dora-examples
   run "coverage" scripts/qa/coverage.sh
+  # Adversarial LLM review skips cleanly on machines without codex/claude.
+  run "adversarial" scripts/qa/adversarial.sh --optional
 
   if [[ "$MODE" == "--tier1" ]]; then
     run "mutants" scripts/qa/mutants.sh


### PR DESCRIPTION
## Summary

Fixes #217. Wires the existing `scripts/qa/adversarial.sh` (added in 63f6e91) into the QA pipeline as an optional step.

## Changes

### 1. `scripts/qa/adversarial.sh` — add `--optional` flag

When `--optional` (or `ADVERSARIAL_OPTIONAL=1`) is passed and neither `codex` nor `claude` CLI is installed, the script skips cleanly with exit 0 instead of failing. Without the flag, the hard-fail behavior is preserved — plus an installation hint is printed.

### 2. `Makefile` — add `qa-adversarial` target

Explicit invocation. Fails hard if no CLI available, matching the rest of the `qa-*` targets: if you asked for it, you expect it.

### 3. `scripts/qa/all.sh` — call in `--full` and `--tier1`

Called as `scripts/qa/adversarial.sh --optional`, so `make qa-full` on any machine works — users with CLIs get the benefit, users without get a clean skip. Not included in `--fast` (LLM review too slow for the pre-commit budget).

## Behavior matrix

| Command | codex/claude installed | neither installed |
|---------|------------------------|-------------------|
| `make qa-adversarial` | runs review | hard-fail with install hint |
| `make qa-full` | runs adversarial as part of the suite | adversarial step skips cleanly |
| `make qa-tier1` | runs adversarial as part of the suite | adversarial step skips cleanly |
| `make qa-fast` | unchanged (not included) | unchanged |

## Test plan

- [x] `bash -n scripts/qa/adversarial.sh && bash -n scripts/qa/all.sh` — syntax OK
- [x] `env PATH=/usr/bin:/bin bash scripts/qa/adversarial.sh --optional` → skips with exit 0
- [x] `env PATH=/usr/bin:/bin bash scripts/qa/adversarial.sh` → hard-fails with exit 2 and install hint
- [x] `make qa-adversarial` with codex installed → runs (no diff message when branch matches main)

## Non-goals

- Not published to CI (`.github/workflows/ci.yml` unchanged). Remote CI stays lean per project policy (see `CLAUDE.md` "Do NOT run the full QA suite on every commit/push"). Users opt in locally via `make qa-full`.
