### PR TITLE
ci: add nightly regression workflow + testing matrix doc

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,177 @@
+name: Nightly Regression
+
+# Deep regression coverage that runs outside the PR cycle.
+#
+# Tier 1 gates per docs/testing-matrix.md:
+#   - Full example-smoke suite (~11 min)
+#   - Service/action/streaming communication patterns
+#   - Log-sink example dataflows
+#   - Record/replay round-trip
+#
+# Failures file issues with the `nightly-regression` label; they do not
+# block PRs. If a failure reproduces for 3 consecutive nightly runs,
+# promote it to the fast CI gate.
+#
+# Triggers:
+#   - schedule: daily at 06:00 UTC
+#   - workflow_dispatch: manual run from Actions UI
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: "1.92.0"
+
+jobs:
+  smoke-suite:
+    name: Smoke suite (tests/example-smoke.rs)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python venv
+        run: |
+          uv venv --seed -p 3.12
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          source .venv/bin/activate
+          uv pip install pyarrow
+          uv pip install -e apis/python/node
+      - name: Run smoke suite
+        id: smoke
+        continue-on-error: true
+        run: |
+          cargo test -p dora-examples --test example-smoke -- --test-threads=1 2>&1 | tee smoke-output.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+      - name: Upload smoke log
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-output
+          path: smoke-output.log
+          retention-days: 14
+      - name: Fail the job if smoke suite failed
+        if: steps.smoke.outputs.exit_code != '0'
+        run: exit 1
+
+  log-sinks:
+    name: Log-sink examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build CLI
+        run: cargo install --path binaries/cli --locked
+      - name: Build log-sink nodes
+        run: cargo build -p log-sink-file -p log-sink-alert -p log-sink-tcp
+      - name: log-sink-file
+        run: dora run examples/log-sink-file/dataflow.yml --stop-after 15s
+      - name: log-sink-alert
+        run: dora run examples/log-sink-alert/dataflow.yml --stop-after 15s
+      - name: log-sink-tcp
+        run: dora run examples/log-sink-tcp/dataflow.yml --stop-after 15s
+
+  service-action-streaming:
+    name: Service / Action / Streaming patterns
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build CLI
+        run: cargo install --path binaries/cli --locked
+      - name: Build service / action example nodes
+        run: >
+          cargo build
+          -p service-example-client
+          -p service-example-server
+          -p action-example-client
+          -p action-example-server
+      - name: service-example
+        run: dora run examples/service-example/dataflow.yml --stop-after 15s
+      - name: action-example
+        run: dora run examples/action-example/dataflow.yml --stop-after 20s
+      - name: streaming-example
+        run: dora run examples/streaming-example/dataflow.yml --stop-after 15s
+
+  record-replay:
+    name: Record/replay round-trip
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Build CLI
+        run: cargo install --path binaries/cli --locked
+      - name: Build rust-dataflow example nodes
+        run: >
+          cargo build
+          -p rust-dataflow-example-node
+          -p rust-dataflow-example-status-node
+          -p rust-dataflow-example-sink
+      - name: Record rust-dataflow
+        run: |
+          # `dora record <yaml>` instruments the dataflow and runs it;
+          # recording written to `recording_<timestamp>.adorec`.
+          timeout 20s dora record examples/rust-dataflow/dataflow.yml -o run.adorec || true
+          test -f run.adorec || { echo "record did not produce run.adorec"; exit 1; }
+          echo "recording size: $(wc -c < run.adorec) bytes"
+      - name: Replay
+        run: dora replay run.adorec
+
+  file-issue-on-failure:
+    name: File issue on nightly failure
+    runs-on: ubuntu-latest
+    needs: [smoke-suite, log-sinks, service-action-streaming, record-replay]
+    if: failure() && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create or update regression issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Nightly regression on $(date -u +%Y-%m-%d)"
+          BODY=$(cat <<EOF
+          Nightly regression suite failed.
+
+          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          Commit: ${{ github.sha }}
+
+          Jobs:
+          - smoke-suite
+          - log-sinks
+          - service-action-streaming
+          - record-replay
+
+          See the run for per-job status and logs. Reproduce locally with:
+          \`\`\`
+          cargo test -p dora-examples --test example-smoke -- --test-threads=1
+          \`\`\`
+          EOF
+          )
+          gh issue create --title "$TITLE" --body "$BODY" --label nightly-regression

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -1,0 +1,135 @@
+# Testing Matrix
+
+Where each feature is tested, and how to run the manual gates.
+
+See issue #215 for the original audit. See `CLAUDE.md` for the CI philosophy
+(remote CI is deliberately lean; deep gates run on laptops and nightly).
+
+## Tier 0 — Remote CI (every push and PR)
+
+Fast gates. Must pass for every PR.
+
+| Area | Where | How |
+|---|---|---|
+| Format | `.github/workflows/ci.yml` `fmt` | `cargo fmt --all -- --check` |
+| Clippy | `.github/workflows/ci.yml` `clippy` | `cargo clippy --all -- -D warnings` |
+| Core tests | `.github/workflows/ci.yml` `test` | `cargo test --all` (Python crates excluded) |
+| Example dataflows (Rust/C/C++/Python) | `.github/workflows/ci.yml` `examples` | `cargo run --example ...` on 3 platforms |
+| CLI template + basic Python examples | `.github/workflows/ci.yml` `cli` | `dora new` + `dora run` on 3 platforms |
+| E2E WS control plane | `.github/workflows/ci.yml` `e2e` | `cargo test --test ws-cli-e2e` |
+| Fault tolerance E2E | `.github/workflows/ci.yml` `fault-tolerance-e2e` | `cargo test --test fault-tolerance-e2e` |
+| Supply chain (cargo-audit / cargo-deny) | `.github/workflows/ci.yml` `audit` | `scripts/qa/audit.sh` |
+| Unwrap budget | `.github/workflows/ci.yml` `unwrap-budget` | `scripts/qa/unwrap-budget.sh` |
+| Benchmark regression | `.github/workflows/ci.yml` `benchmark-regression` | |
+| Typos | `.github/workflows/ci.yml` `typos` | `crate-ci/typos` |
+
+## Tier 1 — Nightly (`.github/workflows/nightly.yml`)
+
+Runs daily at 06:00 UTC and via `workflow_dispatch`. Failures file issues with
+the `nightly-regression` label but do not block PRs.
+
+| Area | Job |
+|---|---|
+| Full smoke suite (`tests/example-smoke.rs`, 44 tests) | `smoke-suite` |
+| Log-sink examples (file, alert, tcp) | `log-sinks` |
+| Service / Action / Streaming communication patterns | `service-action-streaming` |
+| Record / replay round-trip | `record-replay` |
+
+Run locally:
+```bash
+cargo test -p dora-examples --test example-smoke -- --test-threads=1
+dora run examples/service-example/dataflow.yml --stop-after 15s
+dora run examples/action-example/dataflow.yml --stop-after 20s
+dora run examples/log-sink-file/dataflow.yml --stop-after 15s
+```
+
+## Tier 2 — Laptop / manual
+
+Not automated — too heavy, platform-specific, or requires dedicated infra.
+Run before releases or when touching the relevant subsystem.
+
+### Deep QA gates
+
+Documented in `CLAUDE.md`. Invoke via `make`:
+
+| Gate | Command | When |
+|---|---|---|
+| Full QA (fast + tests + coverage) | `make qa-full` | before significant push |
+| Tier 1 (qa-full + mutants + semver) | `make qa-tier1` | before release, or crate audit |
+| Coverage (lcov report) | `make qa-coverage` | when investigating coverage |
+| Mutation testing | `make qa-mutants` | when auditing test quality |
+| Semver check | `make qa-semver` | before publishing to crates.io |
+| Adversarial LLM review | `make qa-adversarial` | before merging AI-authored code (requires codex or claude CLI) |
+
+### Cluster mode
+
+```bash
+dora cluster up --size 3
+dora cluster status
+dora start examples/multiple-daemons/dataflow.yml
+dora cluster down
+```
+
+Not automated: cluster up spawns multiple daemon processes and requires
+network orchestration that isn't stable in GitHub Actions runners.
+
+### Soft real-time
+
+```bash
+sudo dora daemon --rt       # requires CAP_SYS_NICE or root
+# With cpu_affinity + SCHED_FIFO in the dataflow YAML
+```
+
+Not automated: requires specific kernel config (`CONFIG_RT_GROUP_SCHED`)
+and privileged execution, which GHA runners do not provide reliably.
+
+### Coordinator HA / distributed
+
+```bash
+# Terminal 1
+dora coordinator --backend redb --store-path /tmp/dora-coord
+# Terminal 2
+dora daemon --machine-id A --coordinator-addr 127.0.0.1
+# Terminal 3 — kill coordinator, restart, verify daemon auto-reconnects
+pkill dora-coordinator
+dora coordinator --backend redb --store-path /tmp/dora-coord
+```
+
+Not automated: failure-injection timing is flaky on cloud runners.
+Planned: dedicated self-hosted runner for HA scenarios.
+
+### Cross-machine Zenoh data plane
+
+```bash
+# Machine A
+dora coordinator --bind 0.0.0.0
+dora daemon --machine-id A --coordinator-addr <machine-a-ip>
+# Machine B
+dora daemon --machine-id B --coordinator-addr <machine-a-ip>
+```
+
+Not automated: requires two networked hosts.
+
+## What's NOT covered anywhere yet
+
+Tracked in issue #215. Selected items:
+
+- `dora topic echo/hz/info/pub` TUI interaction
+- `dora top` (TUI)
+- `dora graph` output validation (generates Mermaid; no golden file compare)
+- `dora param get/set/delete` interactive path (covered by `ws-cli-e2e` on the wire)
+- `dora trace list/view`
+- `dora self update`
+
+Most of these are interactive TUI commands that need an expect-style harness.
+Opening separate issues as we pick them up.
+
+## Promotion policy
+
+If a nightly failure reproduces for **3 consecutive runs**, promote the
+corresponding test to the remote CI gate (move from `nightly.yml` to
+`ci.yml`). Keep lean-CI-first: only promote gates that catch real bugs,
+not flaky infra.
+
+If a remote CI gate is flaky (>10% false-positive rate over a month),
+demote it to nightly.


### PR DESCRIPTION
## Summary

Refs #215. Implements **Tier 1 (nightly)** coverage from the tiered strategy discussed in that issue.

Adds `.github/workflows/nightly.yml` plus `docs/testing-matrix.md` documenting what's covered where.

## Design

- **Never blocks PRs.** Runs on schedule (daily 06:00 UTC) and via `workflow_dispatch`.
- **Failures file issues** with the `nightly-regression` label. No email, no PR-level noise.
- **Isolated from ci.yml.** Zero risk to the per-PR critical path.

## Jobs

| Job | What it covers | Timeout |
|---|---|---|
| `smoke-suite` | Full `tests/example-smoke.rs` (44 tests) | 30 min |
| `log-sinks` | `log-sink-file`, `log-sink-alert`, `log-sink-tcp` | 20 min |
| `service-action-streaming` | 3 headline communication patterns from the README | 20 min |
| `record-replay` | `dora record` -> `.adorec` -> `dora replay` round-trip | 15 min |
| `file-issue-on-failure` | Files a `nightly-regression` issue with a run link | — |

The smoke-suite job runs with `continue-on-error: true` on the test step and only fails the job at the end, so the artifact upload always captures the log for debugging.

## `docs/testing-matrix.md`

Documents three tiers:

- **Tier 0 (remote CI):** fmt, clippy, core tests, example dataflows, CLI templates, E2E, fault tolerance, supply chain, unwrap budget, typos — the current `ci.yml` content.
- **Tier 1 (nightly):** what this PR adds.
- **Tier 2 (laptop/manual):** deep QA (`make qa-full`, `make qa-tier1`), cluster mode, soft real-time, coordinator HA, cross-machine Zenoh. With instructions for running each.

Includes a **promotion policy**: if a nightly failure reproduces for 3 consecutive runs, promote the test to remote CI. If a remote CI gate is flaky (>10% FP over a month), demote to nightly.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow
- [x] Verified all referenced example dirs and Cargo packages exist
- [x] Verified `dora record` / `dora replay` CLI signatures match the workflow usage
- [x] `nightly-regression` GitHub label exists

First run will be triggered manually via workflow_dispatch after merge to confirm the jobs actually pass before waiting for the cron.
