### PR TITLE
ci(nightly): fix Python setup + dedup issue filing (follow-up to #219)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,7 +70,7 @@ jobs:
         run: exit 1
 
   log-sinks:
-    name: Log-sink examples
+    name: Log-sink examples (Python sources)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -79,19 +79,34 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python venv
+        # Required because every log-sink example has Python source nodes
+        # (sensor.py / source.py). Mirrors the ci.yml Python setup.
+        run: |
+          uv venv --seed -p 3.12
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          source .venv/bin/activate
+          uv pip install pyarrow
+          uv pip install -e apis/python/node
       - name: Build CLI
         run: cargo install --path binaries/cli --locked
       - name: Build log-sink nodes
         run: cargo build -p log-sink-file -p log-sink-alert -p log-sink-tcp
       - name: log-sink-file
-        run: dora run examples/log-sink-file/dataflow.yml --stop-after 15s
+        run: dora run examples/log-sink-file/dataflow.yml --uv --stop-after 15s
       - name: log-sink-alert
-        run: dora run examples/log-sink-alert/dataflow.yml --stop-after 15s
+        run: dora run examples/log-sink-alert/dataflow.yml --uv --stop-after 15s
       - name: log-sink-tcp
-        run: dora run examples/log-sink-tcp/dataflow.yml --stop-after 15s
+        run: dora run examples/log-sink-tcp/dataflow.yml --uv --stop-after 15s
 
-  service-action-streaming:
-    name: Service / Action / Streaming patterns
+  service-action:
+    name: Service / Action patterns (Rust-only)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -113,8 +128,36 @@ jobs:
         run: dora run examples/service-example/dataflow.yml --stop-after 15s
       - name: action-example
         run: dora run examples/action-example/dataflow.yml --stop-after 20s
+
+  streaming:
+    name: Streaming example (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python venv
+        # Required because prompt_source.py / generator.py / sink.py are
+        # Python nodes. Mirrors the ci.yml Python setup.
+        run: |
+          uv venv --seed -p 3.12
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          source .venv/bin/activate
+          uv pip install pyarrow
+          uv pip install -e apis/python/node
+      - name: Build CLI
+        run: cargo install --path binaries/cli --locked
       - name: streaming-example
-        run: dora run examples/streaming-example/dataflow.yml --stop-after 15s
+        run: dora run examples/streaming-example/dataflow.yml --uv --stop-after 15s
 
   record-replay:
     name: Record/replay round-trip
@@ -147,31 +190,73 @@ jobs:
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [smoke-suite, log-sinks, service-action-streaming, record-replay]
+    needs: [smoke-suite, log-sinks, service-action, streaming, record-replay]
     if: failure() && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
       - name: Create or update regression issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          TITLE="Nightly regression on $(date -u +%Y-%m-%d)"
-          BODY=$(cat <<EOF
-          Nightly regression suite failed.
+          # Find any open nightly-regression issue. If one exists, append
+          # a comment with today's failure. Otherwise open a fresh issue.
+          # Prevents issue spam when nightly is red for multiple days.
+          DATE=$(date -u +%Y-%m-%d)
+          EXISTING=$(gh issue list \
+            --repo "$REPO" \
+            --state open \
+            --label nightly-regression \
+            --limit 1 \
+            --json number \
+            --jq '.[0].number // empty')
 
-          Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          Commit: ${{ github.sha }}
+          COMMENT_BODY=$(cat <<EOF
+          Another failure on $DATE.
 
-          Jobs:
-          - smoke-suite
-          - log-sinks
-          - service-action-streaming
-          - record-replay
+          Run: $RUN_URL
+          Commit: $COMMIT_SHA
 
-          See the run for per-job status and logs. Reproduce locally with:
+          Reproduce locally:
           \`\`\`
           cargo test -p dora-examples --test example-smoke -- --test-threads=1
           \`\`\`
           EOF
           )
-          gh issue create --title "$TITLE" --body "$BODY" --label nightly-regression
+
+          if [ -n "$EXISTING" ]; then
+            echo "Updating existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --repo "$REPO" --body "$COMMENT_BODY"
+          else
+            echo "Opening new nightly-regression issue"
+            ISSUE_BODY=$(cat <<EOF
+          Nightly regression suite failed on $DATE.
+
+          Run: $RUN_URL
+          Commit: $COMMIT_SHA
+
+          Jobs:
+          - smoke-suite
+          - log-sinks
+          - service-action
+          - streaming
+          - record-replay
+
+          See the run for per-job status and logs. Subsequent failures
+          will comment on this issue instead of opening new ones. Close
+          this issue when the regression is fixed.
+
+          Reproduce locally:
+          \`\`\`
+          cargo test -p dora-examples --test example-smoke -- --test-threads=1
+          \`\`\`
+          EOF
+            )
+            gh issue create \
+              --repo "$REPO" \
+              --title "Nightly regression since $DATE" \
+              --body "$ISSUE_BODY" \
+              --label nightly-regression
+          fi

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -32,15 +32,26 @@ the `nightly-regression` label but do not block PRs.
 |---|---|
 | Full smoke suite (`tests/example-smoke.rs`, 44 tests) | `smoke-suite` |
 | Log-sink examples (file, alert, tcp) | `log-sinks` |
-| Service / Action / Streaming communication patterns | `service-action-streaming` |
+| Service / Action patterns (Rust-only) | `service-action` |
+| Streaming example (Python nodes) | `streaming` |
 | Record / replay round-trip | `record-replay` |
 
 Run locally:
 ```bash
+# Smoke suite
 cargo test -p dora-examples --test example-smoke -- --test-threads=1
+
+# Rust-only examples (no Python setup needed)
 dora run examples/service-example/dataflow.yml --stop-after 15s
 dora run examples/action-example/dataflow.yml --stop-after 20s
-dora run examples/log-sink-file/dataflow.yml --stop-after 15s
+
+# Python-backed examples — need uv venv + local dora install first:
+#   uv venv --seed -p 3.12
+#   source .venv/bin/activate
+#   uv pip install pyarrow
+#   uv pip install -e apis/python/node
+dora run examples/log-sink-file/dataflow.yml --uv --stop-after 15s
+dora run examples/streaming-example/dataflow.yml --uv --stop-after 15s
 ```
 
 ## Tier 2 — Laptop / manual


### PR DESCRIPTION
## Summary

Follow-up to #219 addressing three review findings. All valid.

## Fixes

### 1. `log-sinks` job missing Python setup (would fail false-positive)

All three log-sink dataflows have Python source nodes:
- `examples/log-sink-file/dataflow.yml` → `sensor.py`, `processor.py`
- `examples/log-sink-alert/dataflow.yml` → `source.py`
- `examples/log-sink-tcp/dataflow.yml` → `source.py`

The nightly job ran `dora run <yaml> --stop-after 15s` with no `uv venv`, no `apis/python/node` install, and no `--uv` flag. As the reviewer noted, this would fail on environment setup, not real regressions.

**Fix:** added `setup-python` + `setup-uv` + venv bootstrap (mirrors `ci.yml`). Passes `--uv` to each `dora run`.

### 2. Split `service-action-streaming` into two jobs

Same issue as #1 but only for the `streaming-example` step. `service-example` and `action-example` are Rust-only; `streaming-example` has three Python nodes (`prompt_source.py`, `generator.py`, `sink.py`).

**Fix:** split into two jobs. `service-action` stays lean (no Python). New `streaming` job has the Python setup.

### 3. `file-issue-on-failure` would spam issues

Original: `gh issue create ...` runs on every scheduled failure. N-day outage → N new issues.

**Fix:** check for an existing open issue with the `nightly-regression` label. If one exists, comment on it (dated). If not, create a new one. PR description noted "no PR-level noise" — this now matches that intent.

```bash
EXISTING=$(gh issue list --state open --label nightly-regression --limit 1 --json number --jq '.[0].number // empty')
if [ -n "$EXISTING" ]; then
  gh issue comment "$EXISTING" --body "$COMMENT_BODY"
else
  gh issue create --title "..." --body "$ISSUE_BODY" --label nightly-regression
fi
```

### 4. `docs/testing-matrix.md` reproducer mismatched requirements

Same issue as #1: the local-reproducer block included `dora run examples/log-sink-file/dataflow.yml --stop-after 15s` with no setup note and no `--uv`.

**Fix:** split Rust-only vs Python-backed commands, added the venv setup incantation as a comment block above the Python commands.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow
- [x] Verified each `examples/log-sink-*` and `streaming-example` has `.py` files
- [x] Verified `service-example` and `action-example` are Rust-only (no `.py`)
- [x] `gh issue list --state open --label nightly-regression` works on this repo (label exists, created in PR #219 prep)

Will trigger via `workflow_dispatch` after merge to confirm the Python-setup jobs actually pass.
