### PR TITLE
ci(nightly): pre-build CLI once, share via artifact (-43 runner-min/night)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -240,8 +240,11 @@ jobs:
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [smoke-suite, log-sinks, service-action, streaming, record-replay]
-    if: failure() && github.event_name == 'schedule'
+    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay]
+    # `always() && contains(needs.*.result, 'failure')` covers both direct
+    # failures and the case where build-cli fails and downstream jobs get
+    # skipped (plain `failure()` would miss the skipped-cascade case).
+    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@v4
       - name: Create or update regression issue

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,8 +4,9 @@ name: Nightly Regression
 #
 # Tier 1 gates per docs/testing-matrix.md:
 #   - Full example-smoke suite (~11 min)
-#   - Service/action/streaming communication patterns
-#   - Log-sink example dataflows
+#   - Service/action communication patterns (Rust-only)
+#   - Streaming example (Python)
+#   - Log-sink example dataflows (Python sources)
 #   - Record/replay round-trip
 #
 # Failures file issues with the `nightly-regression` label; they do not
@@ -69,9 +70,31 @@ jobs:
         if: steps.smoke.outputs.exit_code != '0'
         run: exit 1
 
+  # Build the dora CLI once and upload as artifact for downstream jobs.
+  # Saves ~15 min × 4 downstream jobs = ~60 runner-minutes per nightly run.
+  build-cli:
+    name: Build dora CLI (shared)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install dora CLI to ./dist
+        run: cargo install --path binaries/cli --locked --root ./dist
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dora-cli
+          path: dist/bin/dora
+          retention-days: 1
+
   log-sinks:
     name: Log-sink examples (Python sources)
     runs-on: ubuntu-latest
+    needs: build-cli
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -94,8 +117,15 @@ jobs:
           source .venv/bin/activate
           uv pip install pyarrow
           uv pip install -e apis/python/node
-      - name: Build CLI
-        run: cargo install --path binaries/cli --locked
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
       - name: Build log-sink nodes
         run: cargo build -p log-sink-file -p log-sink-alert -p log-sink-tcp
       - name: log-sink-file
@@ -108,6 +138,7 @@ jobs:
   service-action:
     name: Service / Action patterns (Rust-only)
     runs-on: ubuntu-latest
+    needs: build-cli
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -115,8 +146,15 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
-      - name: Build CLI
-        run: cargo install --path binaries/cli --locked
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
       - name: Build service / action example nodes
         run: >
           cargo build
@@ -132,13 +170,10 @@ jobs:
   streaming:
     name: Streaming example (Python)
     runs-on: ubuntu-latest
+    needs: build-cli
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-      - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -154,14 +189,22 @@ jobs:
           source .venv/bin/activate
           uv pip install pyarrow
           uv pip install -e apis/python/node
-      - name: Build CLI
-        run: cargo install --path binaries/cli --locked
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
       - name: streaming-example
         run: dora run examples/streaming-example/dataflow.yml --uv --stop-after 15s
 
   record-replay:
     name: Record/replay round-trip
     runs-on: ubuntu-latest
+    needs: build-cli
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -169,8 +212,15 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
-      - name: Build CLI
-        run: cargo install --path binaries/cli --locked
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
       - name: Build rust-dataflow example nodes
         run: >
           cargo build


### PR DESCRIPTION
## Summary

Refs #215. Tackles the nightly-CI runner-time waste: 4 downstream jobs each did `cargo install --path binaries/cli --locked` independently (~15 min each = ~60 runner-minutes burned per nightly).

## Design

Single `build-cli` job installs the CLI once to `./dist/bin/dora` and uploads as artifact (retention 1 day). Downstream jobs (`log-sinks`, `service-action`, `streaming`, `record-replay`) download the artifact and prepend its directory to `PATH`.

## Impact

| | Before | After |
|---|---|---|
| CLI builds per nightly | 4 × 15 min = **60 min** | 1 × 15 min + 4 × 30s downloads = **~17 min** |
| Total runner cost per nightly | ~90 min | ~47 min |
| Wall-clock (critical path) | ~35 min | ~30 min (build-cli gates downstream jobs) |
| Runner-minutes saved | — | **~43 min/night** |

## Also

Dropped the Rust toolchain + rust-cache from the `streaming` job. It only runs `dora run` on Python nodes — no Rust build needed. Saves another couple of minutes per run.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow
- [x] Verified `cargo install --root ./dist` produces `./dist/bin/dora`
- [x] Artifact path `dist/bin/dora` matches what `upload-artifact` points at
- [x] Downstream jobs `chmod +x` before adding to PATH (binary loses +x on download)

Will trigger via `workflow_dispatch` after merge to confirm the artifact hand-off works end-to-end.
