### PR TITLE
ci: re-enable 2 test crates + promote benchmark to a real gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,6 @@ jobs:
           --exclude dora-ros2-bridge-python
           --exclude dora-cli-api-python
           --exclude dora-examples
-          --exclude rust-dataflow-example-node
-          --exclude multiple-daemons-example-operator
 
       # ===== Tier 0 CLI smoke gates =====
       # Fast per-platform checks against the 80% CLI coverage gap in #215.
@@ -205,10 +203,8 @@ jobs:
         if: runner.os == 'Linux'
         timeout-minutes: 30
         run: cargo run --example cmake-dataflow
-      - name: Benchmark example
-        continue-on-error: true
-        timeout-minutes: 30
-        run: cargo run --example benchmark --release
+      # Benchmark example runs in the dedicated `bench-example` job below
+      # across all 3 platforms — no duplication here.
 
   # ===== CLI integration tests (cross-platform) =====
   # Restored from upstream dora CI — tests template creation, Python examples,
@@ -423,7 +419,6 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
       - name: Benchmark example
-        continue-on-error: true
         timeout-minutes: 45
         run: cargo run --example benchmark --release
 


### PR DESCRIPTION
## Summary

Refs #215. Closes two audit items in a single small PR.

## 1. Re-enable 2 test crates in `cargo test --all`

`rust-dataflow-example-node` and `multiple-daemons-example-operator` were previously excluded. Verified locally that their tests pass:

```
$ cargo test -p rust-dataflow-example-node -p multiple-daemons-example-operator
test result: ok. 3 passed; 0 failed; 0 ignored
```

The exclusions were historical (Windows `file!()` path length issue) and no longer apply.

## 2. Promote benchmark to a real gate

- Dropped `continue-on-error: true` from the dedicated `bench-example` job — a regression will now fail CI instead of being silently hidden. This was called out as "a regression would not fail CI" in #215.
- Removed the **duplicate** `Benchmark example` step from the `examples` job — the dedicated `bench-example` job already runs the same command on the same 3 platforms. No coverage loss.

## Risk

Low. If the benchmark example turns out to be flaky in CI (despite being stable locally), we revert the `continue-on-error` change with a specific explanation in the commit message. Not a one-way door.

The test-crate re-enable is a strict increase in coverage with 3 passing tests added to the matrix — no risk.

## Test plan

- [x] `cargo test -p rust-dataflow-example-node -p multiple-daemons-example-operator` → 3 passed
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on ci.yml
- [x] Confirmed `continue-on-error` now appears 0 times in `.github/workflows/ci.yml`
