### PR TITLE
ci(test): add semantic assertions for Tier 0 CLI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,15 +110,60 @@ jobs:
         run: |
           cargo run --quiet -p dora-cli -- validate examples/rust-dataflow/dataflow.yml
           cargo run --quiet -p dora-cli -- validate examples/multiple-daemons/dataflow.yml
+      # Semantic: strict-types must accept a well-typed dataflow and reject
+      # a mismatched one. Protects against the validator silently passing
+      # both cases (e.g. strict mode accidentally becoming a no-op).
+      - name: CLI semantic — dora validate --strict-types
+        shell: bash
+        run: |
+          set -e
+          cargo run --quiet -p dora-cli -- validate --strict-types examples/typed-dataflow/dataflow.yml
+          # Negative: must exit non-zero on intentional type mismatch
+          if cargo run --quiet -p dora-cli -- validate --strict-types tests/fixtures/type-mismatch.yml; then
+            echo "ERROR: --strict-types accepted tests/fixtures/type-mismatch.yml — validator regression"
+            exit 1
+          fi
       - name: CLI smoke — dora expand
         shell: bash
         run: |
           cargo run --quiet -p dora-cli -- expand examples/module-dataflow/dataflow.yml > /dev/null
+      # Semantic: expand must flatten module references into named nodes
+      # (pipeline.doubler, pipeline.filter come from the pipeline module).
+      # If expand regresses and emits the `modules:` block without inlining,
+      # this catches it.
+      - name: CLI semantic — dora expand flattens modules
+        shell: bash
+        run: |
+          set -e
+          out=$(cargo run --quiet -p dora-cli -- expand examples/module-dataflow/dataflow.yml)
+          for id in sender pipeline.doubler pipeline.filter receiver; do
+            echo "$out" | grep -q "^- id: $id" \
+              || { echo "ERROR: expand output missing node id '$id'"; exit 1; }
+          done
+          # The flattened output must not still contain a top-level modules: block
+          if echo "$out" | grep -q '^modules:'; then
+            echo "ERROR: expand output still contains 'modules:' block — not flattened"
+            exit 1
+          fi
       - name: CLI smoke — dora graph (mermaid)
         shell: bash
         run: |
           cargo run --quiet -p dora-cli -- graph examples/rust-dataflow/dataflow.yml --mermaid > /dev/null
           cargo run --quiet -p dora-cli -- graph examples/multiple-daemons/dataflow.yml --mermaid > /dev/null
+      # Semantic: graph output must contain the dataflow's actual node IDs
+      # and mermaid flowchart syntax. Catches renderer regressions that
+      # silently produce empty or malformed diagrams.
+      - name: CLI semantic — dora graph contains expected nodes
+        shell: bash
+        run: |
+          set -e
+          out=$(cargo run --quiet -p dora-cli -- graph examples/rust-dataflow/dataflow.yml --mermaid)
+          echo "$out" | grep -q '^flowchart ' \
+            || { echo "ERROR: graph output missing 'flowchart' header"; exit 1; }
+          for id in rust-node rust-sink rust-status-node; do
+            echo "$out" | grep -q "$id" \
+              || { echo "ERROR: graph output missing node '$id'"; exit 1; }
+          done
 
   # ===== Examples (cross-platform) =====
   # Restored from upstream dora CI — runs actual dataflows end-to-end.

--- a/tests/fixtures/type-mismatch.yml
+++ b/tests/fixtures/type-mismatch.yml
@@ -1,0 +1,19 @@
+# Intentional type-mismatch fixture for testing `dora validate --strict-types`.
+# The sink declares `reading: std/core/v1/String` but the sensor outputs
+# `std/core/v1/Float64`. strict-types validation must reject this dataflow.
+#
+# Used by the Tier 0 CLI smoke gates in .github/workflows/ci.yml.
+nodes:
+  - id: sensor
+    path: sensor.py
+    outputs:
+      - reading
+    output_types:
+      reading: std/core/v1/Float64
+
+  - id: sink
+    path: sink.py
+    inputs:
+      reading: sensor/reading
+    input_types:
+      reading: std/core/v1/String  # intentionally wrong: sensor emits Float64


### PR DESCRIPTION
## Summary

Closes #226. Addresses the strongest critique of #223 (Tier 0 CLI smoke): invocation succeeded but output content was never checked.

## What's added

Three new semantic assertion steps in the `test` job, running on all 3 platforms. Each piggybacks on the already-compiled workspace.

### `dora validate --strict-types` (positive + negative)

| Case | Fixture | Expected |
|---|---|---|
| Positive | `examples/typed-dataflow/dataflow.yml` | exit 0 |
| Negative | `tests/fixtures/type-mismatch.yml` (new) | exit != 0 |

The negative fixture declares `input_types: String` on a `Float64` output. If strict mode ever regresses to a no-op, the negative case will pass and CI will fail correctly.

### `dora expand` — must flatten modules

```bash
out=$(dora expand examples/module-dataflow/dataflow.yml)
# All 4 node IDs present
grep -q '^- id: sender' <<<"$out"
grep -q '^- id: pipeline.doubler' <<<"$out"
grep -q '^- id: pipeline.filter' <<<"$out"
grep -q '^- id: receiver' <<<"$out"
# modules: block is gone
! grep -q '^modules:' <<<"$out"
```

### `dora graph --mermaid` — contains expected nodes + flowchart header

```bash
out=$(dora graph examples/rust-dataflow/dataflow.yml --mermaid)
grep -q '^flowchart ' <<<"$out"
grep -q 'rust-node'         <<<"$out"
grep -q 'rust-sink'         <<<"$out"
grep -q 'rust-status-node'  <<<"$out"
```

## What regressions this catches

- Strict-types silently becoming a no-op (e.g. a refactor that forgets the `--strict` flag handling)
- `expand` regressing to pass-through or stopping at the module boundary
- `graph` renderer producing empty/malformed output with no error

## Test plan

- [x] All 11 assertions pass locally
- [x] Negative strict-types case exits non-zero with a clear error
- [x] YAML validates
- [x] No changes to existing assertions; only additions

## Not in this PR

- Other Tier 0 commands (`trace list/view`, etc.) — tracked in #226 follow-ups
- TUI command coverage — #227
- Cluster commands — #228
