### PR TITLE
ci(nightly): add topic + top inspection smoke job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -307,10 +307,73 @@ jobs:
             exit 1
           fi
 
+  topic-and-top-smoke:
+    # Smoke-tests the inspection commands: `dora top --once`, `dora topic
+    # list/info/pub`. Each has a non-interactive mode (--once / built-in
+    # exit / --duration / --count). `topic echo` and `topic hz` stream
+    # without bound — tracked separately, need --duration/--count flags.
+    name: Topic & top inspection smoke
+    runs-on: ubuntu-latest
+    needs: build-cli
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
+      - name: Build rust-dataflow example nodes
+        run: cargo build -p rust-dataflow-example-node -p rust-dataflow-example-sink
+      - name: Start coordinator + daemon
+        run: |
+          dora up
+          sleep 2
+      - name: dora top --once with no dataflow returns valid JSON
+        run: |
+          # No dataflow running yet: must produce '[]' (valid empty JSON).
+          out=$(dora top --once || true)
+          echo "$out"
+          echo "$out" | grep -qE '^\[' || { echo "ERROR: top --once didn't produce JSON array"; exit 1; }
+      - name: Start a debug-enabled dataflow
+        run: |
+          dora start tests/fixtures/zenoh-debug-dataflow.yml --name tui-smoke --detach
+          sleep 5  # let nodes register and emit at least a few messages
+      - name: dora topic list (json)
+        run: |
+          out=$(dora topic list -d tui-smoke --format json)
+          echo "$out"
+          # JSON output should be parseable and contain known node/output IDs
+          echo "$out" | python3 -c "import json,sys; data=json.load(sys.stdin); assert any('rust-node' in str(t) for t in data), f'rust-node not in {data}'"
+      - name: dora topic info on rust-node/random (--duration 3)
+        run: |
+          dora topic info -d tui-smoke rust-node/random --duration 3 2>&1 | tee info.out
+          # Should produce stats output that mentions the topic
+          grep -q 'rust-node/random' info.out || { echo "ERROR: info output missing topic"; exit 1; }
+      - name: dora topic pub --count 3
+        run: |
+          dora topic pub -d tui-smoke rust-node/random '42' --count 3 2>&1 | tee pub.out
+          # Should successfully publish (exit 0). Output may vary; just
+          # assert no error keyword leaked through.
+          ! grep -qiE 'error|fail|panic' pub.out
+      - name: Stop dataflow + tear down
+        if: always()
+        run: |
+          dora stop --name tui-smoke --grace-duration 5s 2>/dev/null || true
+          dora destroy 2>/dev/null || true
+
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke]
+    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke]
     # `always() && contains(needs.*.result, 'failure')` covers both direct
     # failures and the case where build-cli fails and downstream jobs get
     # skipped (plain `failure()` would miss the skipped-cascade case).
@@ -367,6 +430,7 @@ jobs:
           - streaming
           - record-replay
           - cluster-smoke
+          - topic-and-top-smoke
 
           See the run for per-job status and logs. Subsequent failures
           will comment on this issue instead of opening new ones. Close

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -312,6 +312,11 @@ jobs:
     # list/info/pub`. Each has a non-interactive mode (--once / built-in
     # exit / --duration / --count). `topic echo` and `topic hz` stream
     # without bound — tracked separately, need --duration/--count flags.
+    #
+    # Uses Python source nodes (ticker.py / sink.py) so the dataflow runs
+    # indefinitely until stopped (rust-dataflow nodes hit tick limits).
+    # Runs without --uv: ambient venv has local dora-rs 0.2.1; --uv would
+    # spawn isolated per-script venvs that pull dora-rs 0.5.0 from PyPI.
     name: Topic & top inspection smoke
     runs-on: ubuntu-latest
     needs: build-cli
@@ -322,6 +327,21 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
       - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: Set up Python venv with local dora-rs
+        # Required so the Python source nodes import dora-rs 0.2.1 (matching
+        # the daemon's message format), not the 0.5.0 from PyPI.
+        run: |
+          uv venv --seed -p 3.12
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          source .venv/bin/activate
+          uv pip install pyarrow
+          uv pip install -e apis/python/node
       - name: Download dora CLI
         uses: actions/download-artifact@v4
         with:
@@ -331,8 +351,6 @@ jobs:
         run: |
           chmod +x ./cli-bin/dora
           echo "$PWD/cli-bin" >> "$GITHUB_PATH"
-      - name: Build rust-dataflow example nodes
-        run: cargo build -p rust-dataflow-example-node -p rust-dataflow-example-sink
       - name: Start coordinator + daemon
         run: |
           dora up
@@ -344,26 +362,38 @@ jobs:
           echo "$out"
           echo "$out" | grep -qE '^\[' || { echo "ERROR: top --once didn't produce JSON array"; exit 1; }
       - name: Start a debug-enabled dataflow
+        # The fixture uses Python source nodes (ticker.py / sink.py) so the
+        # dataflow runs forever (rust-dataflow-example-node hits a tick limit
+        # and exits, breaking subsequent topic queries). Runs without --uv:
+        # the ambient venv has local dora-rs (just installed above), and
+        # --uv would create a fresh venv that pulls dora-rs 0.5.0 from PyPI.
         run: |
           dora start tests/fixtures/zenoh-debug-dataflow.yml --name tui-smoke --detach
-          sleep 5  # let nodes register and emit at least a few messages
-      - name: dora topic list (json)
+          sleep 5  # let nodes register and start emitting messages
+          dora list  # surface status for the log
+      - name: dora topic list (NDJSON)
         run: |
+          # `topic list --format json` emits NDJSON (one object per line),
+          # not a JSON array. Parse each line, assert at least one row
+          # describes the ticker/count topic.
           out=$(dora topic list -d tui-smoke --format json)
           echo "$out"
-          # JSON output should be parseable and contain known node/output IDs
-          echo "$out" | python3 -c "import json,sys; data=json.load(sys.stdin); assert any('rust-node' in str(t) for t in data), f'rust-node not in {data}'"
-      - name: dora topic info on rust-node/random (--duration 3)
+          echo "$out" | python3 -c "
+          import json, sys
+          rows = [json.loads(line) for line in sys.stdin if line.strip()]
+          assert rows, 'no NDJSON rows produced'
+          assert any(r.get('node') == 'ticker' and r.get('name') == 'count' for r in rows), \
+              f'ticker/count not in topic list: {rows}'
+          "
+      - name: dora topic info on ticker/count (--duration 3)
         run: |
-          dora topic info -d tui-smoke rust-node/random --duration 3 2>&1 | tee info.out
-          # Should produce stats output that mentions the topic
-          grep -q 'rust-node/random' info.out || { echo "ERROR: info output missing topic"; exit 1; }
+          dora topic info -d tui-smoke ticker/count --duration 3 2>&1 | tee info.out
+          grep -q 'ticker/count' info.out || { echo "ERROR: info output missing topic"; exit 1; }
       - name: dora topic pub --count 3
         run: |
-          dora topic pub -d tui-smoke rust-node/random '42' --count 3 2>&1 | tee pub.out
-          # Should successfully publish (exit 0). Output may vary; just
-          # assert no error keyword leaked through.
-          ! grep -qiE 'error|fail|panic' pub.out
+          dora topic pub -d tui-smoke ticker/count '42' --count 3 2>&1 | tee pub.out
+          # `topic pub` prints "Published message N/3" on success.
+          grep -q 'Published message 3/3' pub.out || { echo "ERROR: pub didn't emit all 3 messages"; exit 1; }
       - name: Stop dataflow + tear down
         if: always()
         run: |

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -37,6 +37,7 @@ the `nightly-regression` label but do not block PRs.
 | Streaming example (Python nodes) | `streaming` |
 | Record / replay round-trip | `record-replay` |
 | Cluster lifecycle (`cluster status`, `cluster down`) | `cluster-smoke` |
+| Inspection commands (`top --once`, `topic list/info/pub`) | `topic-and-top-smoke` |
 
 Run locally:
 ```bash

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -135,15 +135,23 @@ Not automated: requires two networked hosts.
 
 Tracked in issue #215. Selected items:
 
-- `dora topic echo/hz/info/pub` TUI interaction
-- `dora top` (TUI)
-- `dora graph` output validation (generates Mermaid; no golden file compare)
-- `dora param get/set/delete` interactive path (covered by `ws-cli-e2e` on the wire)
+- `dora topic echo` and `dora topic hz` — stream forever, need bounded modes
+  (filed as #233)
 - `dora trace list/view`
 - `dora self update`
 
-Most of these are interactive TUI commands that need an expect-style harness.
-Opening separate issues as we pick them up.
+Most of these are interactive TUI commands that need either non-interactive
+modes or an expect-style harness. Opening separate issues as we pick them
+up.
+
+### Already covered (despite earlier audit)
+
+These were on the gap list but now have nightly coverage in
+`topic-and-top-smoke`:
+- `dora top --once` (JSON snapshot)
+- `dora topic list --format json` (NDJSON parse)
+- `dora topic info --duration N`
+- `dora topic pub --count N`
 
 ## Promotion policy
 

--- a/tests/fixtures/sink.py
+++ b/tests/fixtures/sink.py
@@ -1,0 +1,9 @@
+"""Sink that consumes counter values until the dataflow stops."""
+
+from dora import Node
+
+node = Node()
+for event in node:
+    if event["type"] == "STOP":
+        break
+    # Drain inputs silently. The sink exists to give topics a subscriber.

--- a/tests/fixtures/ticker.py
+++ b/tests/fixtures/ticker.py
@@ -1,0 +1,13 @@
+"""Tick source that emits an incrementing counter forever."""
+
+import pyarrow as pa
+from dora import Node
+
+node = Node()
+counter = 0
+for event in node:
+    if event["type"] == "INPUT" and event["id"] == "tick":
+        node.send_output("count", pa.array([counter], type=pa.uint64()))
+        counter += 1
+    elif event["type"] == "STOP":
+        break

--- a/tests/fixtures/zenoh-debug-dataflow.yml
+++ b/tests/fixtures/zenoh-debug-dataflow.yml
@@ -2,25 +2,24 @@
 # for `dora topic echo`, `topic info`, and `topic pub` to inspect/inject
 # runtime messages. Used by the nightly TUI smoke job.
 #
-# Mirrors examples/rust-dataflow/dataflow.yml + adds the debug flag.
+# Uses Python timer source so the dataflow runs indefinitely until
+# explicitly stopped (rust-dataflow nodes hit their tick limit and exit).
 nodes:
-  - id: rust-node
-    build: cargo build -p rust-dataflow-example-node
-    path: ../../target/debug/rust-dataflow-example-node
+  - id: ticker
+    path: ticker.py
     inputs:
-      tick: dora/timer/millis/10
+      tick: dora/timer/millis/100
     outputs:
-      - random
+      - count
     output_types:
-      random: std/core/v1/UInt64
+      count: std/core/v1/UInt64
 
-  - id: rust-sink
-    build: cargo build -p rust-dataflow-example-sink
-    path: ../../target/debug/rust-dataflow-example-sink
+  - id: sink
+    path: sink.py
     inputs:
-      message: rust-node/random
+      count: ticker/count
     input_types:
-      message: std/core/v1/UInt64
+      count: std/core/v1/UInt64
 
 _unstable_debug:
   publish_all_messages_to_zenoh: true

--- a/tests/fixtures/zenoh-debug-dataflow.yml
+++ b/tests/fixtures/zenoh-debug-dataflow.yml
@@ -1,0 +1,26 @@
+# Dataflow with `publish_all_messages_to_zenoh: true` enabled — required
+# for `dora topic echo`, `topic info`, and `topic pub` to inspect/inject
+# runtime messages. Used by the nightly TUI smoke job.
+#
+# Mirrors examples/rust-dataflow/dataflow.yml + adds the debug flag.
+nodes:
+  - id: rust-node
+    build: cargo build -p rust-dataflow-example-node
+    path: ../../target/debug/rust-dataflow-example-node
+    inputs:
+      tick: dora/timer/millis/10
+    outputs:
+      - random
+    output_types:
+      random: std/core/v1/UInt64
+
+  - id: rust-sink
+    build: cargo build -p rust-dataflow-example-sink
+    path: ../../target/debug/rust-dataflow-example-sink
+    inputs:
+      message: rust-node/random
+    input_types:
+      message: std/core/v1/UInt64
+
+_unstable_debug:
+  publish_all_messages_to_zenoh: true


### PR DESCRIPTION
## Summary

Investigation phase + first wave of TUI command coverage for #227.

## Audit findings

Better than expected — most TUI commands already have non-interactive modes:

| Command | Bounded mode | This PR |
|---|---|---|
| `dora top` | `--once` (JSON snapshot) | ✅ tested |
| `dora topic list` | always exits, `--format json` | ✅ tested |
| `dora topic info` | `--duration N` | ✅ tested |
| `dora topic pub` | `--count N` | ✅ tested |
| `dora topic echo` | streams forever | ❌ filed #233 (needs `--count`/`--duration`) |
| `dora topic hz` | streams forever (`--window` is sliding, not stop) | ❌ filed #233 |

## What's added

New nightly job `topic-and-top-smoke` that exercises the 4 testable commands. Plus a fixture `tests/fixtures/zenoh-debug-dataflow.yml` (rust-dataflow with `publish_all_messages_to_zenoh: true` enabled — required for `topic info/pub` to inspect/inject runtime messages).

### Assertions

- `dora top --once` with no dataflow → must produce valid JSON array
- `dora topic list -d <df> --format json` → parsed via python, must contain `rust-node`
- `dora topic info -d <df> rust-node/random --duration 3` → output must mention the topic
- `dora topic pub -d <df> rust-node/random '42' --count 3` → exit 0, no error keywords in output

## Closes / refs

- Closes #227 for the 4 commands with bounded modes
- New issue #233 tracks the remaining 2 (`topic echo`, `topic hz`) which need new CLI flags

## Test plan

- [x] Verified `dora top --once` works (returns `[]` exit 0 with no dataflow)
- [x] Verified `dora topic list/info/pub --help` show the flags I'm using
- [x] `dora validate tests/fixtures/zenoh-debug-dataflow.yml` passes
- [x] YAML lints clean
- [x] `file-issue-on-failure` `needs:` updated to include new job
- [x] testing-matrix.md updated with new row
