### PR TITLE
cli(topic): add --count/--duration to echo, --duration to hz

### DIFF
--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -49,12 +49,14 @@ pub struct Echo {
     #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 
-    /// Exit after this many messages (default: stream until interrupted)
-    #[clap(long, value_name = "N")]
-    pub count: Option<usize>,
+    /// Exit after this many messages (default: stream until interrupted).
+    /// Must be at least 1.
+    #[clap(long, value_name = "N", value_parser = clap::value_parser!(u64).range(1..))]
+    pub count: Option<u64>,
 
-    /// Exit after this many seconds (default: stream until interrupted)
-    #[clap(long, value_name = "SECONDS")]
+    /// Exit after this many seconds (default: stream until interrupted).
+    /// Must be at least 1.
+    #[clap(long, value_name = "SECONDS", value_parser = clap::value_parser!(u64).range(1..))]
     pub duration: Option<u64>,
 
     #[clap(flatten)]
@@ -79,7 +81,7 @@ fn inspect(
     coordinator: CoordinatorOptions,
     selector: TopicSelector,
     format: OutputFormat,
-    count: Option<usize>,
+    count: Option<u64>,
     duration: Option<u64>,
 ) -> eyre::Result<()> {
     let session = coordinator.connect()?;
@@ -96,7 +98,7 @@ fn inspect(
     const HINT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
     let mut hint_shown = false;
     let mut buf = Vec::with_capacity(1024);
-    let mut emitted: usize = 0;
+    let mut emitted: u64 = 0;
     let deadline = duration.map(|s| std::time::Instant::now() + std::time::Duration::from_secs(s));
     loop {
         // Stop conditions: --count reached or --duration elapsed.

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -49,6 +49,14 @@ pub struct Echo {
     #[clap(long, value_name = "FORMAT", default_value_t = OutputFormat::Table)]
     pub format: OutputFormat,
 
+    /// Exit after this many messages (default: stream until interrupted)
+    #[clap(long, value_name = "N")]
+    pub count: Option<usize>,
+
+    /// Exit after this many seconds (default: stream until interrupted)
+    #[clap(long, value_name = "SECONDS")]
+    pub duration: Option<u64>,
+
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
 }
@@ -57,7 +65,13 @@ impl Executable for Echo {
     fn execute(self) -> eyre::Result<()> {
         default_tracing()?;
 
-        inspect(self.coordinator, self.selector, self.format)
+        inspect(
+            self.coordinator,
+            self.selector,
+            self.format,
+            self.count,
+            self.duration,
+        )
     }
 }
 
@@ -65,6 +79,8 @@ fn inspect(
     coordinator: CoordinatorOptions,
     selector: TopicSelector,
     format: OutputFormat,
+    count: Option<usize>,
+    duration: Option<u64>,
 ) -> eyre::Result<()> {
     let session = coordinator.connect()?;
     let (dataflow_id, topics) = selector.resolve(&session)?;
@@ -80,10 +96,33 @@ fn inspect(
     const HINT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
     let mut hint_shown = false;
     let mut buf = Vec::with_capacity(1024);
+    let mut emitted: usize = 0;
+    let deadline = duration.map(|s| std::time::Instant::now() + std::time::Duration::from_secs(s));
     loop {
-        let result = match data_rx.recv_timeout(HINT_TIMEOUT) {
+        // Stop conditions: --count reached or --duration elapsed.
+        if let Some(max) = count
+            && emitted >= max
+        {
+            break;
+        }
+        let recv_timeout = match deadline {
+            Some(d) => {
+                let remaining = d.saturating_duration_since(std::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                remaining.min(HINT_TIMEOUT)
+            }
+            None => HINT_TIMEOUT,
+        };
+        let result = match data_rx.recv_timeout(recv_timeout) {
             Ok(result) => result,
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if let Some(d) = deadline
+                    && std::time::Instant::now() >= d
+                {
+                    break;
+                }
                 if !hint_shown {
                     eprintln!(
                         "{}: no topic data received. Ensure your dataflow was started with \
@@ -216,6 +255,7 @@ fn inspect(
                         );
                     }
                 }
+                emitted += 1;
             }
             InterDaemonEvent::OutputClosed {
                 node_id, output_id, ..

--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -67,7 +67,8 @@ pub struct Hz {
 
     /// Run for this many seconds without TUI, print final stats, and exit.
     /// Required when stdout is not a terminal (e.g. CI, scripting).
-    #[clap(long, value_name = "SECONDS")]
+    /// Must be at least 1.
+    #[clap(long, value_name = "SECONDS", value_parser = clap::value_parser!(u64).range(1..))]
     duration: Option<u64>,
 
     #[clap(flatten)]

--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -65,16 +65,17 @@ pub struct Hz {
     #[clap(long, default_value_t = 10, value_parser = parse_window)]
     window: usize,
 
+    /// Run for this many seconds without TUI, print final stats, and exit.
+    /// Required when stdout is not a terminal (e.g. CI, scripting).
+    #[clap(long, value_name = "SECONDS")]
+    duration: Option<u64>,
+
     #[clap(flatten)]
     coordinator: CoordinatorOptions,
 }
 
 impl Executable for Hz {
     fn execute(self) -> eyre::Result<()> {
-        if !io::stdout().is_terminal() {
-            eyre::bail!("`dora topic hz` requires an interactive terminal");
-        }
-
         let session = self.coordinator.connect()?;
         let (dataflow_id, topics) = self.selector.resolve(&session)?;
 
@@ -85,11 +86,85 @@ impl Executable for Hz {
 
         let (_subscription_id, data_rx) = session.subscribe_topics(dataflow_id, ws_topics)?;
 
+        // Non-interactive path: collect for `--duration`, print final stats.
+        if let Some(secs) = self.duration {
+            return run_hz_oneshot(self.window, topics, data_rx, secs);
+        }
+
+        if !io::stdout().is_terminal() {
+            eyre::bail!(
+                "`dora topic hz` requires an interactive terminal. \
+                 Pass `--duration <SECONDS>` for non-interactive use."
+            );
+        }
+
         let terminal = ratatui::init();
         let result = run_hz(terminal, self.window, topics, data_rx);
         ratatui::restore();
         result
     }
+}
+
+/// Non-interactive sampler: subscribes for `seconds`, then prints
+/// per-topic stats as a plain table and exits.
+fn run_hz_oneshot(
+    window: usize,
+    outputs: BTreeSet<TopicIdentifier>,
+    data_rx: std::sync::mpsc::Receiver<eyre::Result<Vec<u8>>>,
+    seconds: u64,
+) -> eyre::Result<()> {
+    let mut stats: Vec<(HzLabel<'_>, Arc<HzStats>)> = Vec::with_capacity(outputs.len() + 1);
+    stats.push((HzLabel::Aggregate, Arc::new(HzStats::new(window))));
+    for topic in &outputs {
+        stats.push((HzLabel::Topic(topic), Arc::new(HzStats::new(window))));
+    }
+
+    let mut topic_index: BTreeMap<(String, String), usize> = BTreeMap::new();
+    for (i, (label, _)) in stats.iter().enumerate().skip(1) {
+        if let HzLabel::Topic(topic) = label {
+            topic_index.insert((topic.node_id.to_string(), topic.data_id.to_string()), i);
+        }
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(seconds);
+    while Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        match data_rx.recv_timeout(remaining) {
+            Ok(Ok(payload)) => {
+                let event = match Timestamped::deserialize_inter_daemon_event(&payload) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                if let InterDaemonEvent::Output {
+                    node_id, output_id, ..
+                } = event.inner
+                {
+                    let now = Instant::now();
+                    stats[0].1.record(now); // aggregate
+                    let key = (node_id.to_string(), output_id.to_string());
+                    if let Some(&idx) = topic_index.get(&key) {
+                        stats[idx].1.record(now);
+                    }
+                }
+            }
+            Ok(Err(_)) => continue,
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+
+    println!("topic\tavg_ms\tavg_hz\tmin_ms\tmax_ms\tstd_ms\tsamples");
+    for (label, hz_stats) in &stats {
+        let samples = hz_stats.timestamps.lock().unwrap().len();
+        match hz_stats.calculate() {
+            Some(s) => println!(
+                "{}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{:.2}\t{}",
+                label, s.avg_ms, s.avg_hz, s.min_ms, s.max_ms, s.std_ms, samples
+            ),
+            None => println!("{}\t-\t-\t-\t-\t-\t{}", label, samples),
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

Closes #233 (CLI changes portion). Adds bounded-execution flags to `dora topic echo` and `dora topic hz`, which previously streamed forever with no built-in exit condition.

## Changes

### `dora topic echo`

```
--count <N>        Exit after this many messages (default: stream until interrupted)
--duration <SECONDS>  Exit after this many seconds (default: stream until interrupted)
```

Either fires first. Default behavior unchanged (stream forever, backward compat).

### `dora topic hz`

```
--duration <SECONDS>  Run for this many seconds without TUI, print final stats, and exit.
                      Required when stdout is not a terminal (e.g. CI, scripting).
```

When `--duration` is set, skips the ratatui TUI entirely. Collects timestamps for the given duration, then prints a plain tab-separated stats table:

```
topic               avg_ms   avg_hz   min_ms   max_ms   std_ms   samples
ALL                 100.12   9.99     99.45    101.23   0.45     30
ticker/count        100.12   9.99     99.45    101.23   0.45     30
```

When stdout is not a TTY and `--duration` is missing, the error message now points users to `--duration` (was a generic "requires interactive terminal" before).

## Why no CI smoke in this PR

Initial attempt to add a nightly smoke test exposed a separate issue: a Python-source fixture with `_unstable_debug.publish_all_messages_to_zenoh: true` doesn't actually push messages through Zenoh the way the subscribe path expects. `dora topic info` on a Running dataflow showed `Total messages: 0` after 3 seconds of collection.

This is orthogonal to the CLI flag additions. The flags are independently useful for any scripting use case right now; the smoke test will land in a follow-up once the Zenoh publish path is understood.

## Test plan

- [x] `cargo build -p dora-cli` — clean
- [x] `cargo clippy -p dora-cli -- -D warnings` — clean
- [x] `cargo fmt --all` — clean
- [x] `cargo test -p dora-cli` — passes
- [x] `dora topic echo --help` shows `--count` and `--duration`
- [x] `dora topic hz --help` shows `--duration`
- [x] Existing `hz.rs` `parse_window` tests still pass
