### PR TITLE
docs: clarify platform parity for C/C++ templates (#230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,10 +419,10 @@ examples/               # Example dataflows
 | WSL (x86_64) | Best effort | Best effort (not CI-gated) |
 
 C/C++ template tests (`dora new --lang c/cxx` + CMake build) run in CI on Linux only.
-The `dora new` scaffolding itself is smoke-tested on all three platforms. macOS and
-Windows C/C++ regressions are caught by users rather than CI; report them via GitHub
-issues and we will promote the gate. See [`docs/testing-matrix.md`](docs/testing-matrix.md#platform-parity)
-for the full rationale.
+`dora new --lang rust/python` is smoke-tested on all three platforms, but the C/C++
+variants are not. macOS and Windows C/C++ regressions are caught by users rather
+than CI; report them via GitHub issues and we will promote the gate. See
+[`docs/testing-matrix.md`](docs/testing-matrix.md#platform-parity) for the full rationale.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -411,12 +411,18 @@ examples/               # Example dataflows
 
 ### Platform support
 
-| Platform | Status |
-|----------|--------|
-| Linux (x86_64, ARM64, ARM32) | First-class |
-| macOS (ARM64) | First-class |
-| Windows (x86_64) | Best effort |
-| WSL (x86_64) | Best effort |
+| Platform | Rust / Python | C / C++ templates |
+|----------|---------------|-------------------|
+| Linux (x86_64, ARM64, ARM32) | First-class | First-class (CI-gated) |
+| macOS (ARM64) | First-class | Best effort (not CI-gated) |
+| Windows (x86_64) | Best effort | Best effort (not CI-gated) |
+| WSL (x86_64) | Best effort | Best effort (not CI-gated) |
+
+C/C++ template tests (`dora new --lang c/cxx` + CMake build) run in CI on Linux only.
+The `dora new` scaffolding itself is smoke-tested on all three platforms. macOS and
+Windows C/C++ regressions are caught by users rather than CI; report them via GitHub
+issues and we will promote the gate. See [`docs/testing-matrix.md`](docs/testing-matrix.md#platform-parity)
+for the full rationale.
 
 ## Examples
 

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -153,6 +153,26 @@ These were on the gap list but now have nightly coverage in
 - `dora topic info --duration N`
 - `dora topic pub --count N`
 
+## Platform parity
+
+C/C++ template CI coverage is intentionally scoped to Linux (see issue #230):
+
+| Test | Linux | macOS | Windows |
+|---|---|---|---|
+| `dora new --lang c/cxx` scaffolding | Tier 0 (`cli` job) | Tier 0 (`cli` job) | Tier 0 (`cli` job) |
+| `cxx-dataflow`, `c-dataflow` examples | Tier 0 (`examples` job) | Tier 0 | Tier 0 |
+| `cxx-arrow-dataflow` (needs Arrow C++ lib) | Tier 0 | Tier 0 (homebrew `apache-arrow`) | not covered |
+| `cmake-dataflow` example | Tier 0 | not covered | not covered |
+| C/C++ template CMake build + `dora run` | Tier 0 (`cli` job) | not covered | not covered |
+
+**Rationale.** Production C/C++ node users are Linux-heavy. macOS/Windows C/C++ CI
+would need vcpkg or homebrew-formula pinning per runner, and the cost/benefit is
+poor for the number of real-world users on those paths. Rust/Python coverage stays
+cross-platform because those are the primary audience. If a macOS or Windows C/C++
+regression is reported, the fix is to lift the `if: runner.os == 'Linux'` gate on
+the relevant step and add platform-specific install logic — not to keep shipping
+broken.
+
 ## Promotion policy
 
 If a nightly failure reproduces for **3 consecutive runs**, promote the

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -159,11 +159,11 @@ C/C++ template CI coverage is intentionally scoped to Linux (see issue #230):
 
 | Test | Linux | macOS | Windows |
 |---|---|---|---|
-| `dora new --lang c/cxx` scaffolding | Tier 0 (`cli` job) | Tier 0 (`cli` job) | Tier 0 (`cli` job) |
+| `dora new --lang rust/python` scaffolding | Tier 0 (`cli` job) | Tier 0 (`cli` job) | Tier 0 (`cli` job) |
+| `dora new --lang c/cxx` scaffolding + CMake build + `dora run` | Tier 0 (`cli` job) | not covered | not covered |
 | `cxx-dataflow`, `c-dataflow` examples | Tier 0 (`examples` job) | Tier 0 | Tier 0 |
 | `cxx-arrow-dataflow` (needs Arrow C++ lib) | Tier 0 | Tier 0 (homebrew `apache-arrow`) | not covered |
 | `cmake-dataflow` example | Tier 0 | not covered | not covered |
-| C/C++ template CMake build + `dora run` | Tier 0 (`cli` job) | not covered | not covered |
 
 **Rationale.** Production C/C++ node users are Linux-heavy. macOS/Windows C/C++ CI
 would need vcpkg or homebrew-formula pinning per runner, and the cost/benefit is


### PR DESCRIPTION
## Summary

Closes #230. Doc-only change. README claimed first-class macOS/ARM64 and best-effort Windows across the board, but C/C++ template tests (`dora new --lang c/cxx` + CMake build) have always been gated to `if: runner.os == 'Linux'` in CI. Document reality instead of aspiration.

## Changes

- **README.md** — Platform support table now splits Rust/Python (cross-platform) from C/C++ templates (Linux-only CI). Footnote explains where `dora new` scaffolding is smoke-tested on all platforms vs. where the full CMake build is only exercised on Linux.
- **docs/testing-matrix.md** — New \"Platform parity\" section enumerating which C/C++ tests run on which OS, with rationale for scoping (production C/C++ users are Linux-heavy; cost/benefit of maintaining Windows/macOS vcpkg setup is poor).

## Why Option 3 (document scope) over lifting the gate

Three options were considered in #230:

1. Lift the Linux gate for macOS (partially free — `Install Arrow C++ Library` already handles brew). Risk: flaky homebrew version pinning.
2. Lift for macOS + Windows via vcpkg. ~30 min install per run, significant complexity.
3. Document reality and promote gates when users report regressions.

Going with 3. Remote CI philosophy (see CLAUDE.md) is deliberately lean — promoting gates only when they catch real bugs. If a macOS/Windows C/C++ regression is reported, we lift the gate then.

## Test plan

- [x] `cargo fmt --all -- --check` — not applicable (docs only)
- [x] Rendered README platform table — reads correctly, footnote links resolve
- [x] testing-matrix anchor \`#platform-parity\` matches heading