### PR TITLE
fix: stream CLI topic inspection over coordinator websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tracing",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ futures = { workspace = true }
 tokio-stream = "0.1.11"
 tempfile = { workspace = true }
 assert2 = "0.3.16"
+tokio-tungstenite = "0.28"
 
 [[example]]
 name = "c-dataflow"

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -32,13 +32,6 @@ use crate::{
 /// Emit JSON lines:
 ///   dora topic echo -d my-dataflow robot1/pose --format json
 ///
-/// Note: The dataflow descriptor must include the following snippet so that
-/// runtime messages can be inspected:
-///
-/// ```yaml
-/// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
-/// ```
 #[derive(Debug, Args)]
 #[clap(verbatim_doc_comment)]
 pub struct Echo {
@@ -127,9 +120,7 @@ fn inspect(
                 }
                 if !hint_shown {
                     eprintln!(
-                        "{}: no topic data received. Ensure your dataflow was started with \
-                         `--debug` or add the following to your dataflow YAML:\n\n  \
-                         _unstable_debug:\n    publish_all_messages_to_zenoh: true\n",
+                        "{}: no topic data received during the wait window.",
                         "hint".yellow().bold(),
                     );
                     hint_shown = true;

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -21,6 +21,13 @@ use crate::{
 /// If no `DATA` is provided, all outputs from the selected dataflow will be
 /// echoed.
 ///
+/// Topic inspection requires debug mode on the dataflow:
+///
+/// ```yaml
+/// _unstable_debug:
+///   publish_all_messages_to_zenoh: true
+/// ```
+///
 /// Examples:
 ///
 /// Echo a single topic:
@@ -120,7 +127,7 @@ fn inspect(
                 }
                 if !hint_shown {
                     eprintln!(
-                        "{}: no topic data received during the wait window.",
+                        "{}: no topic data received during the wait window. Ensure `_unstable_debug.publish_all_messages_to_zenoh: true` is enabled on the dataflow.",
                         "hint".yellow().bold(),
                     );
                     hint_shown = true;

--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -40,13 +40,6 @@ use crate::{
 /// Measure all topics:
 ///   dora topic hz -d my-dataflow --window 10
 ///
-/// Note: The dataflow descriptor must include the following snippet so that
-/// runtime messages can be inspected:
-///
-/// ```yaml
-/// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
-/// ```
 fn parse_window(s: &str) -> Result<usize, String> {
     let val: usize = s.parse().map_err(|e| format!("{e}"))?;
     if val == 0 {

--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -26,6 +26,13 @@ use crate::{
 /// (average, min, max, stddev) over a sliding window. Average frequency (Hz)
 /// is derived from the average interval.
 ///
+/// Topic inspection requires debug mode on the dataflow:
+///
+/// ```yaml
+/// _unstable_debug:
+///   publish_all_messages_to_zenoh: true
+/// ```
+///
 /// If no `DATA` is provided, all outputs from the selected dataflow will be
 /// echoed.
 ///

--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -25,14 +25,6 @@ use crate::{
 /// Get info for a single topic:
 ///   dora topic info -d my-dataflow camera_node/image
 ///
-/// Note: The dataflow descriptor must include the following snippet so that
-/// runtime messages can be inspected (or messages must cross machine
-/// boundaries so they are forwarded through zenoh):
-///
-/// ```yaml
-/// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
-/// ```
 #[derive(Debug, Args)]
 #[clap(verbatim_doc_comment)]
 pub struct Info {

--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -20,6 +20,13 @@ use crate::{
 /// Shows topic type, publisher, subscribers, and statistics (message count,
 /// bandwidth, publishing frequency).
 ///
+/// Topic inspection requires debug mode on the dataflow:
+///
+/// ```yaml
+/// _unstable_debug:
+///   publish_all_messages_to_zenoh: true
+/// ```
+///
 /// Examples:
 ///
 /// Get info for a single topic:

--- a/binaries/cli/src/ws_client.rs
+++ b/binaries/cli/src/ws_client.rs
@@ -61,7 +61,8 @@ impl WsSession {
     /// Connect to the coordinator via WebSocket.
     ///
     /// If called from within an existing tokio runtime, uses that runtime.
-    /// Otherwise creates a new single-threaded runtime.
+    /// Otherwise creates a dedicated runtime with one worker thread so the WS
+    /// receive loop keeps running after synchronous API calls return.
     pub fn connect(addr: SocketAddr) -> eyre::Result<Self> {
         if tokio::runtime::Handle::try_current().is_ok() {
             eyre::bail!(
@@ -69,7 +70,8 @@ impl WsSession {
                  use an async-native client instead"
             );
         }
-        let rt = tokio::runtime::Builder::new_current_thread()
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
             .enable_all()
             .build()
             .context("failed to create tokio runtime for WS session")?;
@@ -188,7 +190,7 @@ impl WsSession {
             .map_err(|_| eyre!("WS session dropped reply"))?
     }
 
-    /// Subscribe to topic data via the coordinator's Zenoh proxy.
+    /// Subscribe to topic data via the coordinator's topic inspection stream.
     ///
     /// Sends a `TopicSubscribe` request, waits for the ack, then returns
     /// a `(subscription_id, receiver)` pair. Binary WS frames with matching

--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -30,8 +30,17 @@ pub enum ControlEvent {
     TopicSubscribe {
         dataflow_id: Uuid,
         topics: Vec<(NodeId, DataId)>,
-        /// Sends `true` if the dataflow exists and has publish_all_messages_to_zenoh enabled.
+        sender: mpsc::Sender<Vec<u8>>,
+        done_tx: oneshot::Sender<Result<Uuid, String>>,
+    },
+    TopicCheck {
+        dataflow_id: Uuid,
+        topics: Vec<(NodeId, DataId)>,
         found_tx: oneshot::Sender<bool>,
+    },
+    TopicUnsubscribe {
+        subscription_id: Uuid,
+        done_tx: oneshot::Sender<()>,
     },
     Error(eyre::Report),
 }

--- a/binaries/coordinator/src/control.rs
+++ b/binaries/coordinator/src/control.rs
@@ -30,7 +30,7 @@ pub enum ControlEvent {
     TopicSubscribe {
         dataflow_id: Uuid,
         topics: Vec<(NodeId, DataId)>,
-        sender: mpsc::Sender<Vec<u8>>,
+        sender: mpsc::Sender<crate::topic_subscriber::TopicFrame>,
         done_tx: oneshot::Sender<Result<Uuid, String>>,
     },
     TopicCheck {

--- a/binaries/coordinator/src/events.rs
+++ b/binaries/coordinator/src/events.rs
@@ -51,7 +51,7 @@ pub enum Event {
     },
     TopicDebugData {
         dataflow_id: Uuid,
-        subscription_id: Uuid,
+        subscription_ids: Vec<Uuid>,
         payload: Vec<u8>,
     },
     DaemonStatusReport {

--- a/binaries/coordinator/src/events.rs
+++ b/binaries/coordinator/src/events.rs
@@ -49,6 +49,11 @@ pub enum Event {
         metrics: BTreeMap<NodeId, NodeMetrics>,
         network: Option<NetworkMetrics>,
     },
+    TopicDebugData {
+        dataflow_id: Uuid,
+        subscription_id: Uuid,
+        payload: Vec<u8>,
+    },
     DaemonStatusReport {
         daemon_id: DaemonId,
         running_dataflows: Vec<dora_message::daemon_to_coordinator::DataflowStatusEntry>,
@@ -83,6 +88,7 @@ impl Event {
             Event::DataflowBuildResult { .. } => "DataflowBuildResult",
             Event::DataflowSpawnResult { .. } => "DataflowSpawnResult",
             Event::NodeMetrics { .. } => "NodeMetrics",
+            Event::TopicDebugData { .. } => "TopicDebugData",
             Event::DaemonStatusReport { .. } => "DaemonStatusReport",
             Event::DaemonStateCatchUpAck { .. } => "DaemonStateCatchUpAck",
         }

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -95,24 +95,40 @@ pub(crate) async fn send_topic_frames(
         );
         return;
     }
+    let shared_payload: std::sync::Arc<[u8]> = payload.into();
+    const MAX_CONSECUTIVE_TOPIC_SEND_TIMEOUTS: usize = 100;
     for subscription_id in subscription_ids {
         if let Some(subscriber) = topic_subscribers.get_mut(&subscription_id) {
-            let mut frame = Vec::with_capacity(16 + payload.len());
-            frame.extend_from_slice(&subscription_id.into_bytes());
-            frame.extend_from_slice(&payload);
+            let frame = crate::topic_subscriber::TopicFrame {
+                subscription_id,
+                payload: shared_payload.clone(),
+            };
             let send_result =
                 tokio::time::timeout(Duration::from_millis(100), subscriber.send_frame(frame))
                     .await;
             match send_result {
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => {
+                    subscriber.reset_timeout_streak();
+                }
                 Ok(Err(_)) => {
                     subscriber.close();
                 }
                 Err(_) => {
-                    tracing::warn!(
-                        %subscription_id,
-                        "timed out sending topic debug frame to CLI subscriber; keeping subscription active"
-                    );
+                    let timeouts = subscriber.record_timeout();
+                    if timeouts >= MAX_CONSECUTIVE_TOPIC_SEND_TIMEOUTS {
+                        tracing::warn!(
+                            %subscription_id,
+                            timeouts,
+                            "closing slow topic debug subscriber after repeated send timeouts"
+                        );
+                        subscriber.close();
+                    } else {
+                        tracing::warn!(
+                            %subscription_id,
+                            timeouts,
+                            "timed out sending topic debug frame to CLI subscriber; keeping subscription active"
+                        );
+                    }
                 }
             }
         }

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -5,6 +5,7 @@ use crate::{
         self, ArchivedDataflow, CachedResult, DaemonConnection, DaemonConnections, RunningBuild,
         RunningDataflow,
     },
+    topic_subscriber::TopicSubscriber,
 };
 use dora_core::{
     config::{NodeId, OperatorId},
@@ -27,6 +28,8 @@ use std::{
     time::Duration,
 };
 use uuid::Uuid;
+
+const MAX_TOPIC_DEBUG_PAYLOAD_BYTES: usize = 64 * 1024 * 1024;
 
 // Resolve the dataflow name.
 pub(crate) fn resolve_name(
@@ -77,6 +80,31 @@ pub(crate) async fn send_log_message(
         }
     }
     log_subscribers.retain(|s| !s.is_closed());
+}
+
+pub(crate) async fn send_topic_frame(
+    topic_subscribers: &mut BTreeMap<Uuid, TopicSubscriber>,
+    subscription_id: Uuid,
+    payload: Vec<u8>,
+) {
+    if payload.len() > MAX_TOPIC_DEBUG_PAYLOAD_BYTES {
+        tracing::warn!(
+            "dropping oversized topic debug payload ({} bytes) for subscription {subscription_id}",
+            payload.len()
+        );
+        return;
+    }
+    if let Some(subscriber) = topic_subscribers.get_mut(&subscription_id) {
+        let mut frame = Vec::with_capacity(16 + payload.len());
+        frame.extend_from_slice(&subscription_id.into_bytes());
+        frame.extend_from_slice(&payload);
+        let send_result =
+            tokio::time::timeout(Duration::from_millis(100), subscriber.send_frame(frame)).await;
+        if send_result.is_err() {
+            subscriber.close();
+        }
+    }
+    topic_subscribers.retain(|_, s| !s.is_closed());
 }
 
 pub(crate) fn dataflow_result(
@@ -551,6 +579,7 @@ pub(crate) async fn start_dataflow(
         stop_reply_senders: Vec::new(),
         buffered_log_messages: Vec::new(),
         log_subscribers: Vec::new(),
+        topic_subscribers: BTreeMap::new(),
         daemon_ack_sequence: daemons.iter().map(|d| (d.clone(), 0)).collect(),
         pending_spawn_results: daemons,
         created_at: state::now_millis(),

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -103,8 +103,17 @@ pub(crate) async fn send_topic_frames(
             let send_result =
                 tokio::time::timeout(Duration::from_millis(100), subscriber.send_frame(frame))
                     .await;
-            if send_result.is_err() {
-                subscriber.close();
+            match send_result {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) => {
+                    subscriber.close();
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        %subscription_id,
+                        "timed out sending topic debug frame to CLI subscriber; keeping subscription active"
+                    );
+                }
             }
         }
     }

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -82,26 +82,30 @@ pub(crate) async fn send_log_message(
     log_subscribers.retain(|s| !s.is_closed());
 }
 
-pub(crate) async fn send_topic_frame(
+pub(crate) async fn send_topic_frames(
     topic_subscribers: &mut BTreeMap<Uuid, TopicSubscriber>,
-    subscription_id: Uuid,
+    subscription_ids: Vec<Uuid>,
     payload: Vec<u8>,
 ) {
     if payload.len() > MAX_TOPIC_DEBUG_PAYLOAD_BYTES {
         tracing::warn!(
-            "dropping oversized topic debug payload ({} bytes) for subscription {subscription_id}",
-            payload.len()
+            "dropping oversized topic debug payload ({} bytes) for {} subscription(s)",
+            payload.len(),
+            subscription_ids.len()
         );
         return;
     }
-    if let Some(subscriber) = topic_subscribers.get_mut(&subscription_id) {
-        let mut frame = Vec::with_capacity(16 + payload.len());
-        frame.extend_from_slice(&subscription_id.into_bytes());
-        frame.extend_from_slice(&payload);
-        let send_result =
-            tokio::time::timeout(Duration::from_millis(100), subscriber.send_frame(frame)).await;
-        if send_result.is_err() {
-            subscriber.close();
+    for subscription_id in subscription_ids {
+        if let Some(subscriber) = topic_subscribers.get_mut(&subscription_id) {
+            let mut frame = Vec::with_capacity(16 + payload.len());
+            frame.extend_from_slice(&subscription_id.into_bytes());
+            frame.extend_from_slice(&payload);
+            let send_result =
+                tokio::time::timeout(Duration::from_millis(100), subscriber.send_frame(frame))
+                    .await;
+            if send_result.is_err() {
+                subscriber.close();
+            }
         }
     }
     topic_subscribers.retain(|_, s| !s.is_closed());

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1629,8 +1629,9 @@ async fn start_inner(
                     topics,
                     found_tx,
                 } => {
-                    let found =
-                        topic_outputs_by_daemon(&running_dataflows, dataflow_id, &topics).is_ok();
+                    let found = topic_outputs_by_daemon(&running_dataflows, dataflow_id, &topics)
+                        .is_ok()
+                        && topic_debug_enabled(&running_dataflows, dataflow_id).unwrap_or(false);
                     let _ = found_tx.send(found);
                 }
                 ControlEvent::TopicUnsubscribe {
@@ -1811,7 +1812,7 @@ async fn start_inner(
                 subscription_id,
                 payload,
             } => {
-                tracing::info!(
+                tracing::trace!(
                     %dataflow_id,
                     %subscription_id,
                     bytes = payload.len(),
@@ -2218,6 +2219,16 @@ fn topic_outputs_by_daemon(
     Ok(outputs_by_daemon)
 }
 
+fn topic_debug_enabled(
+    running_dataflows: &HashMap<DataflowId, RunningDataflow>,
+    dataflow_id: DataflowId,
+) -> eyre::Result<bool> {
+    let dataflow = running_dataflows
+        .get(&dataflow_id)
+        .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
+    Ok(dataflow.descriptor.debug.publish_all_messages_to_zenoh)
+}
+
 async fn start_topic_debug_stream(
     running_dataflows: &mut HashMap<DataflowId, RunningDataflow>,
     daemon_connections: &mut DaemonConnections,
@@ -2227,8 +2238,22 @@ async fn start_topic_debug_stream(
     clock: &HLC,
 ) -> eyre::Result<Uuid> {
     let outputs_by_daemon = topic_outputs_by_daemon(running_dataflows, dataflow_id, &topics)?;
-    let outputs_by_daemon_for_state = outputs_by_daemon.clone();
+    if !topic_debug_enabled(running_dataflows, dataflow_id)? {
+        eyre::bail!(
+            "topic inspection requires `_unstable_debug.publish_all_messages_to_zenoh: true`"
+        );
+    }
     let subscription_id = Uuid::new_v4();
+    running_dataflows
+        .get_mut(&dataflow_id)
+        .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?
+        .topic_subscribers
+        .insert(
+            subscription_id,
+            topic_subscriber::TopicSubscriber::new(outputs_by_daemon.clone(), sender),
+        );
+
+    let mut started_daemons = Vec::new();
     for (daemon_id, outputs) in outputs_by_daemon {
         let connection = daemon_connections
             .get_mut(&daemon_id)
@@ -2249,23 +2274,83 @@ async fn start_topic_debug_stream(
         let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
             .wrap_err("failed to deserialize start-topic-debug-stream reply")?;
         match reply {
-            DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())) => {}
+            DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())) => {
+                started_daemons.push(daemon_id);
+            }
             DaemonCoordinatorReply::StartTopicDebugStreamResult(Err(err)) => {
+                rollback_topic_debug_stream(
+                    running_dataflows,
+                    daemon_connections,
+                    dataflow_id,
+                    subscription_id,
+                    &started_daemons,
+                    clock,
+                )
+                .await?;
                 eyre::bail!("{err}");
             }
-            other => eyre::bail!("unexpected start-topic-debug-stream reply: {other:?}"),
+            other => {
+                rollback_topic_debug_stream(
+                    running_dataflows,
+                    daemon_connections,
+                    dataflow_id,
+                    subscription_id,
+                    &started_daemons,
+                    clock,
+                )
+                .await?;
+                eyre::bail!("unexpected start-topic-debug-stream reply: {other:?}");
+            }
         }
     }
 
-    let dataflow = running_dataflows
-        .get_mut(&dataflow_id)
-        .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
-    dataflow.topic_subscribers.insert(
-        subscription_id,
-        topic_subscriber::TopicSubscriber::new(outputs_by_daemon_for_state, sender),
-    );
-
     Ok(subscription_id)
+}
+
+async fn rollback_topic_debug_stream(
+    running_dataflows: &mut HashMap<DataflowId, RunningDataflow>,
+    daemon_connections: &mut DaemonConnections,
+    dataflow_id: DataflowId,
+    subscription_id: Uuid,
+    started_daemons: &[DaemonId],
+    clock: &HLC,
+) -> eyre::Result<()> {
+    let Some(subscriber) = running_dataflows
+        .get_mut(&dataflow_id)
+        .and_then(|dataflow| dataflow.topic_subscribers.remove(&subscription_id))
+    else {
+        return Ok(());
+    };
+    let _outputs_by_daemon = subscriber.outputs_by_daemon().clone();
+
+    for daemon_id in started_daemons {
+        let Some(connection) = daemon_connections.get_mut(daemon_id).cloned() else {
+            continue;
+        };
+        let message = serde_json::to_vec(&Timestamped {
+            inner: DaemonCoordinatorEvent::StopTopicDebugStream {
+                dataflow_id,
+                subscription_id,
+            },
+            timestamp: clock.new_timestamp(),
+        })?;
+        let reply_raw = connection
+            .send_and_receive(&message)
+            .await
+            .wrap_err("failed to roll back start-topic-debug-stream message")?;
+        let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
+            .wrap_err("failed to deserialize rollback stop-topic-debug-stream reply")?;
+        match reply {
+            DaemonCoordinatorReply::StopTopicDebugStreamResult(Ok(())) => {}
+            DaemonCoordinatorReply::StopTopicDebugStreamResult(Err(err)) => {
+                tracing::warn!(%daemon_id, %subscription_id, "failed to roll back topic debug stream: {err}");
+            }
+            other => {
+                tracing::warn!(%daemon_id, %subscription_id, "unexpected rollback reply: {other:?}");
+            }
+        }
+    }
+    Ok(())
 }
 
 async fn stop_topic_debug_stream(
@@ -3048,10 +3133,9 @@ mod tests {
         daemon_connections.add(daemon_id.clone(), connection);
 
         let mut running_dataflows = HashMap::new();
-        running_dataflows.insert(
-            dataflow_id,
-            test_running_dataflow(dataflow_id, daemon_id, node_id.clone()),
-        );
+        let mut dataflow = test_running_dataflow(dataflow_id, daemon_id, node_id.clone());
+        dataflow.descriptor.debug.publish_all_messages_to_zenoh = true;
+        running_dataflows.insert(dataflow_id, dataflow);
         let expected_node_id = node_id.clone();
         let expected_data_id = data_id.clone();
         let seen_subscription = Arc::new(tokio::sync::Mutex::new(None::<Uuid>));
@@ -3113,6 +3197,110 @@ mod tests {
                 .expect("daemon mapping should exist"),
             &vec![(node_id, data_id)]
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    async fn start_topic_debug_stream_rolls_back_on_daemon_error() {
+        #[derive(serde::Deserialize)]
+        struct OutboundRaw {
+            id: String,
+            params: Timestamped<DaemonCoordinatorEvent>,
+        }
+
+        let dataflow_id = Uuid::new_v4();
+        let daemon_id_a = DaemonId::new(Some("daemon-a".to_string()));
+        let daemon_id_b = DaemonId::new(Some("daemon-b".to_string()));
+        let node_id_a: dora_message::id::NodeId = "sender".to_string().into();
+        let node_id_b: dora_message::id::NodeId = "sink".to_string().into();
+        let data_id: dora_core::config::DataId = "message".to_string().into();
+        let (frame_tx, _frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+
+        let mut daemon_connections = DaemonConnections::default();
+        let mut daemon_tasks = Vec::new();
+        for (daemon_id, should_fail) in [(daemon_id_a.clone(), false), (daemon_id_b.clone(), true)]
+        {
+            let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(8);
+            let pending_replies = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let connection =
+                crate::state::DaemonConnection::new(tx, pending_replies.clone(), BTreeMap::new());
+            daemon_connections.add(daemon_id, connection);
+
+            daemon_tasks.push(tokio::spawn(async move {
+                while let Some(outbound) = rx.recv().await {
+                    let outbound_raw: OutboundRaw = serde_json::from_str(&outbound).unwrap();
+                    let request_id = Uuid::parse_str(&outbound_raw.id).expect("valid request id");
+                    let reply = match outbound_raw.params.inner {
+                        DaemonCoordinatorEvent::StartTopicDebugStream { .. } if should_fail => {
+                            serde_json::to_string(
+                                &DaemonCoordinatorReply::StartTopicDebugStreamResult(Err(
+                                    "daemon rejected debug stream".to_string(),
+                                )),
+                            )
+                            .unwrap()
+                        }
+                        DaemonCoordinatorEvent::StartTopicDebugStream { .. } => {
+                            serde_json::to_string(
+                                &DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())),
+                            )
+                            .unwrap()
+                        }
+                        DaemonCoordinatorEvent::StopTopicDebugStream { .. } => {
+                            serde_json::to_string(
+                                &DaemonCoordinatorReply::StopTopicDebugStreamResult(Ok(())),
+                            )
+                            .unwrap()
+                        }
+                        other => panic!("unexpected daemon event during rollback test: {other:?}"),
+                    };
+                    let reply_tx = pending_replies
+                        .lock()
+                        .await
+                        .remove(&request_id)
+                        .expect("pending reply sender should exist");
+                    let _ = reply_tx.send(reply);
+                }
+            }));
+        }
+
+        let mut running_dataflows = HashMap::new();
+        let mut dataflow =
+            test_running_dataflow(dataflow_id, daemon_id_a.clone(), node_id_a.clone());
+        dataflow.descriptor.debug.publish_all_messages_to_zenoh = true;
+        dataflow
+            .node_to_daemon
+            .insert(node_id_b.clone(), daemon_id_b.clone());
+        let mut descriptor_json = serde_json::to_value(&dataflow.descriptor).unwrap();
+        descriptor_json
+            .get_mut("nodes")
+            .and_then(serde_json::Value::as_array_mut)
+            .expect("descriptor nodes array")
+            .push(serde_json::json!({
+                "id": node_id_b,
+                "outputs": [data_id.clone()],
+            }));
+        dataflow.descriptor = serde_json::from_value(descriptor_json).unwrap();
+        running_dataflows.insert(dataflow_id, dataflow);
+
+        let err = start_topic_debug_stream(
+            &mut running_dataflows,
+            &mut daemon_connections,
+            dataflow_id,
+            vec![(node_id_a, data_id.clone()), (node_id_b, data_id)],
+            frame_tx,
+            &HLC::default(),
+        )
+        .await
+        .expect_err("subscription should fail");
+
+        assert!(format!("{err:#}").contains("daemon rejected debug stream"));
+        assert!(
+            running_dataflows[&dataflow_id].topic_subscribers.is_empty(),
+            "failed subscription should be rolled back"
+        );
+
+        for task in daemon_tasks {
+            task.abort();
+        }
     }
 
     #[test]

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2,7 +2,7 @@ use crate::{
     events::set_up_ctrlc_handler,
     handlers::{
         build_dataflow, dataflow_result, handle_destroy, reload_dataflow, resolve_name,
-        restart_node, retrieve_logs, send_heartbeat_message, send_log_message, send_topic_frame,
+        restart_node, retrieve_logs, send_heartbeat_message, send_log_message, send_topic_frames,
         start_dataflow, stop_dataflow, stop_node,
     },
     state::{ArchivedDataflow, CachedResult, ParamTarget, RunningBuild, RunningDataflow},
@@ -1809,17 +1809,17 @@ async fn start_inner(
             }
             Event::TopicDebugData {
                 dataflow_id,
-                subscription_id,
+                subscription_ids,
                 payload,
             } => {
                 tracing::trace!(
                     %dataflow_id,
-                    %subscription_id,
+                    subscriptions = subscription_ids.len(),
                     bytes = payload.len(),
                     "received topic debug frame from daemon"
                 );
                 if let Some(dataflow) = running_dataflows.get_mut(&dataflow_id) {
-                    send_topic_frame(&mut dataflow.topic_subscribers, subscription_id, payload)
+                    send_topic_frames(&mut dataflow.topic_subscribers, subscription_ids, payload)
                         .await;
                 }
             }

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2245,7 +2245,7 @@ async fn start_topic_debug_stream(
     daemon_connections: &mut DaemonConnections,
     dataflow_id: DataflowId,
     topics: Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
-    sender: tokio::sync::mpsc::Sender<Vec<u8>>,
+    sender: tokio::sync::mpsc::Sender<crate::topic_subscriber::TopicFrame>,
     clock: &HLC,
 ) -> eyre::Result<Uuid> {
     let outputs_by_daemon = topic_outputs_by_daemon(running_dataflows, dataflow_id, &topics)?;
@@ -3254,7 +3254,8 @@ mod tests {
         let daemon_id = DaemonId::new(Some("m1".to_string()));
         let node_id: dora_core::config::NodeId = "sender".to_string().into();
         let data_id: dora_core::config::DataId = "message".to_string().into();
-        let (frame_tx, _frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (frame_tx, _frame_rx) =
+            tokio::sync::mpsc::channel::<crate::topic_subscriber::TopicFrame>(4);
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(8);
         let pending_replies = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
@@ -3344,7 +3345,8 @@ mod tests {
         let node_id_a: dora_message::id::NodeId = "sender".to_string().into();
         let node_id_b: dora_message::id::NodeId = "sink".to_string().into();
         let data_id: dora_core::config::DataId = "message".to_string().into();
-        let (frame_tx, _frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+        let (frame_tx, _frame_rx) =
+            tokio::sync::mpsc::channel::<crate::topic_subscriber::TopicFrame>(4);
 
         let mut daemon_connections = DaemonConnections::default();
         let mut daemon_tasks = Vec::new();

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -481,6 +481,9 @@ async fn start_inner(
                                     archived_dataflows.shift_remove_index(0);
                                 }
                                 let mut finished_dataflow = entry.remove();
+                                for subscriber in finished_dataflow.topic_subscribers.values_mut() {
+                                    subscriber.close();
+                                }
                                 let dataflow_id = finished_dataflow.uuid;
                                 send_log_message(
                                     &mut finished_dataflow.log_subscribers,
@@ -2020,6 +2023,14 @@ async fn start_inner(
                 const RECOVERY_BACKOFF: Duration = Duration::from_secs(30);
                 let reported_set: BTreeSet<DataflowId> =
                     reported_dataflows.iter().map(|e| e.dataflow_id).collect();
+                restore_topic_debug_streams_for_daemon(
+                    &running_dataflows,
+                    &mut daemon_connections,
+                    &daemon_id,
+                    &reported_set,
+                    &clock,
+                )
+                .await;
                 let now = Instant::now();
                 for (uuid, df) in &mut running_dataflows {
                     if !df.daemons.contains(&daemon_id) {
@@ -2315,13 +2326,12 @@ async fn rollback_topic_debug_stream(
     started_daemons: &[DaemonId],
     clock: &HLC,
 ) -> eyre::Result<()> {
-    let Some(subscriber) = running_dataflows
+    let Some(_) = running_dataflows
         .get_mut(&dataflow_id)
         .and_then(|dataflow| dataflow.topic_subscribers.remove(&subscription_id))
     else {
         return Ok(());
     };
-    let _outputs_by_daemon = subscriber.outputs_by_daemon().clone();
 
     for daemon_id in started_daemons {
         let Some(connection) = daemon_connections.get_mut(daemon_id).cloned() else {
@@ -2370,10 +2380,14 @@ async fn stop_topic_debug_stream(
     };
 
     for (daemon_id, _) in outputs_by_daemon {
-        let connection = daemon_connections
-            .get_mut(&daemon_id)
-            .wrap_err_with(|| format!("no daemon connection for daemon `{daemon_id}`"))?
-            .clone();
+        let Some(connection) = daemon_connections.get_mut(&daemon_id).cloned() else {
+            tracing::warn!(
+                %daemon_id,
+                %subscription_id,
+                "skipping topic debug stream teardown for missing daemon connection"
+            );
+            continue;
+        };
         let message = serde_json::to_vec(&Timestamped {
             inner: DaemonCoordinatorEvent::StopTopicDebugStream {
                 dataflow_id,
@@ -2397,6 +2411,88 @@ async fn stop_topic_debug_stream(
     }
 
     Ok(())
+}
+
+async fn restore_topic_debug_streams_for_daemon(
+    running_dataflows: &HashMap<DataflowId, RunningDataflow>,
+    daemon_connections: &mut DaemonConnections,
+    daemon_id: &DaemonId,
+    reported_dataflows: &BTreeSet<DataflowId>,
+    clock: &HLC,
+) {
+    let Some(connection) = daemon_connections.get_mut(daemon_id).cloned() else {
+        return;
+    };
+
+    for (dataflow_id, dataflow) in running_dataflows {
+        if !reported_dataflows.contains(dataflow_id) {
+            continue;
+        }
+        for (subscription_id, subscriber) in &dataflow.topic_subscribers {
+            let Some(outputs) = subscriber.outputs_by_daemon().get(daemon_id).cloned() else {
+                continue;
+            };
+            let message = match serde_json::to_vec(&Timestamped {
+                inner: DaemonCoordinatorEvent::StartTopicDebugStream {
+                    dataflow_id: *dataflow_id,
+                    outputs,
+                    subscription_id: *subscription_id,
+                },
+                timestamp: clock.new_timestamp(),
+            }) {
+                Ok(message) => message,
+                Err(err) => {
+                    tracing::warn!(
+                        %daemon_id,
+                        %dataflow_id,
+                        %subscription_id,
+                        "failed to serialize topic debug stream restore message: {err}"
+                    );
+                    continue;
+                }
+            };
+
+            match connection.send_and_receive(&message).await {
+                Ok(reply_raw) => {
+                    match serde_json::from_slice::<DaemonCoordinatorReply>(&reply_raw) {
+                        Ok(DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(()))) => {}
+                        Ok(DaemonCoordinatorReply::StartTopicDebugStreamResult(Err(err))) => {
+                            tracing::warn!(
+                                %daemon_id,
+                                %dataflow_id,
+                                %subscription_id,
+                                "daemon rejected restored topic debug stream: {err}"
+                            );
+                        }
+                        Ok(other) => {
+                            tracing::warn!(
+                                %daemon_id,
+                                %dataflow_id,
+                                %subscription_id,
+                                "unexpected restore-topic-debug-stream reply: {other:?}"
+                            );
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                %daemon_id,
+                                %dataflow_id,
+                                %subscription_id,
+                                "failed to deserialize restore-topic-debug-stream reply: {err}"
+                            );
+                        }
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        %daemon_id,
+                        %dataflow_id,
+                        %subscription_id,
+                        "failed to restore topic debug stream after daemon reconnect: {err}"
+                    );
+                }
+            }
+        }
+    }
 }
 
 async fn handle_pruned_state_catchup_fallback(

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -26,7 +26,7 @@ use dora_message::{
 };
 pub use events::{DaemonRequest, DataflowEvent, Event};
 use eyre::{ContextCompat, Result, WrapErr, bail, eyre};
-use futures::{Future, Stream, StreamExt, stream::FuturesUnordered};
+use futures::{Future, Stream, StreamExt, future::join_all, stream::FuturesUnordered};
 use futures_concurrency::stream::Merge;
 use indexmap::IndexMap;
 use log_subscriber::LogSubscriber;
@@ -2264,7 +2264,7 @@ async fn start_topic_debug_stream(
             topic_subscriber::TopicSubscriber::new(outputs_by_daemon.clone(), sender),
         );
 
-    let mut started_daemons = Vec::new();
+    let mut start_requests = Vec::new();
     for (daemon_id, outputs) in outputs_by_daemon {
         let connection = daemon_connections
             .get_mut(&daemon_id)
@@ -2278,41 +2278,53 @@ async fn start_topic_debug_stream(
             },
             timestamp: clock.new_timestamp(),
         })?;
-        let reply_raw = connection
-            .send_and_receive(&message)
-            .await
-            .wrap_err("failed to send start-topic-debug-stream message")?;
-        let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
-            .wrap_err("failed to deserialize start-topic-debug-stream reply")?;
-        match reply {
-            DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())) => {
-                started_daemons.push(daemon_id);
+        start_requests.push(async move {
+            let result = async {
+                let reply_raw = connection
+                    .send_and_receive(&message)
+                    .await
+                    .wrap_err("failed to send start-topic-debug-stream message")?;
+                let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
+                    .wrap_err("failed to deserialize start-topic-debug-stream reply")?;
+                match reply {
+                    DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())) => Ok(()),
+                    DaemonCoordinatorReply::StartTopicDebugStreamResult(Err(err)) => {
+                        Err(eyre!(err))
+                    }
+                    other => Err(eyre!(
+                        "unexpected start-topic-debug-stream reply: {other:?}"
+                    )),
+                }
             }
-            DaemonCoordinatorReply::StartTopicDebugStreamResult(Err(err)) => {
-                rollback_topic_debug_stream(
-                    running_dataflows,
-                    daemon_connections,
-                    dataflow_id,
-                    subscription_id,
-                    &started_daemons,
-                    clock,
-                )
-                .await?;
-                eyre::bail!("{err}");
-            }
-            other => {
-                rollback_topic_debug_stream(
-                    running_dataflows,
-                    daemon_connections,
-                    dataflow_id,
-                    subscription_id,
-                    &started_daemons,
-                    clock,
-                )
-                .await?;
-                eyre::bail!("unexpected start-topic-debug-stream reply: {other:?}");
+            .await;
+            (daemon_id, result)
+        });
+    }
+
+    let mut started_daemons = Vec::new();
+    let mut first_error = None;
+    for (daemon_id, result) in join_all(start_requests).await {
+        match result {
+            Ok(()) => started_daemons.push(daemon_id),
+            Err(err) => {
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
             }
         }
+    }
+
+    if let Some(err) = first_error {
+        rollback_topic_debug_stream(
+            running_dataflows,
+            daemon_connections,
+            dataflow_id,
+            subscription_id,
+            &started_daemons,
+            clock,
+        )
+        .await?;
+        return Err(err);
     }
 
     Ok(subscription_id)
@@ -2379,6 +2391,7 @@ async fn stop_topic_debug_stream(
         return Ok(());
     };
 
+    let mut stop_requests = Vec::new();
     for (daemon_id, _) in outputs_by_daemon {
         let Some(connection) = daemon_connections.get_mut(&daemon_id).cloned() else {
             tracing::warn!(
@@ -2395,19 +2408,41 @@ async fn stop_topic_debug_stream(
             },
             timestamp: clock.new_timestamp(),
         })?;
-        let reply_raw = connection
-            .send_and_receive(&message)
-            .await
-            .wrap_err("failed to send stop-topic-debug-stream message")?;
-        let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
-            .wrap_err("failed to deserialize stop-topic-debug-stream reply")?;
-        match reply {
-            DaemonCoordinatorReply::StopTopicDebugStreamResult(Ok(())) => {}
-            DaemonCoordinatorReply::StopTopicDebugStreamResult(Err(err)) => {
-                eyre::bail!("{err}");
+        stop_requests.push(async move {
+            let result = async {
+                let reply_raw = connection
+                    .send_and_receive(&message)
+                    .await
+                    .wrap_err("failed to send stop-topic-debug-stream message")?;
+                let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
+                    .wrap_err("failed to deserialize stop-topic-debug-stream reply")?;
+                match reply {
+                    DaemonCoordinatorReply::StopTopicDebugStreamResult(Ok(())) => Ok(()),
+                    DaemonCoordinatorReply::StopTopicDebugStreamResult(Err(err)) => Err(eyre!(err)),
+                    other => Err(eyre!("unexpected stop-topic-debug-stream reply: {other:?}")),
+                }
             }
-            other => eyre::bail!("unexpected stop-topic-debug-stream reply: {other:?}"),
+            .await;
+            (daemon_id, result)
+        });
+    }
+
+    let mut first_error = None;
+    for (daemon_id, result) in join_all(stop_requests).await {
+        if let Err(err) = result {
+            tracing::warn!(
+                %daemon_id,
+                %subscription_id,
+                "failed to stop topic debug stream on daemon: {err}"
+            );
+            if first_error.is_none() {
+                first_error = Some(err);
+            }
         }
+    }
+
+    if let Some(err) = first_error {
+        return Err(err);
     }
 
     Ok(())

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2,8 +2,8 @@ use crate::{
     events::set_up_ctrlc_handler,
     handlers::{
         build_dataflow, dataflow_result, handle_destroy, reload_dataflow, resolve_name,
-        restart_node, retrieve_logs, send_heartbeat_message, send_log_message, start_dataflow,
-        stop_dataflow, stop_node,
+        restart_node, retrieve_logs, send_heartbeat_message, send_log_message, send_topic_frame,
+        start_dataflow, stop_dataflow, stop_node,
     },
     state::{ArchivedDataflow, CachedResult, ParamTarget, RunningBuild, RunningDataflow},
 };
@@ -25,7 +25,7 @@ use dora_message::{
     daemon_to_coordinator::{DaemonCoordinatorReply, DataflowDaemonResult},
 };
 pub use events::{DaemonRequest, DataflowEvent, Event};
-use eyre::{Result, WrapErr, bail, eyre};
+use eyre::{ContextCompat, Result, WrapErr, bail, eyre};
 use futures::{Future, Stream, StreamExt, stream::FuturesUnordered};
 use futures_concurrency::stream::Merge;
 use indexmap::IndexMap;
@@ -41,6 +41,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio_stream::wrappers::ReceiverStream;
+use uuid::Uuid;
 
 const FALLBACK_REPLAY_BACKOFF: Duration = Duration::from_secs(5);
 
@@ -53,6 +54,7 @@ mod log_subscriber;
 mod otel_metrics;
 mod run;
 mod state;
+mod topic_subscriber;
 mod ws_control;
 mod ws_daemon;
 mod ws_server;
@@ -1607,21 +1609,45 @@ async fn start_inner(
                 ControlEvent::TopicSubscribe {
                     dataflow_id,
                     topics,
+                    sender,
+                    done_tx,
+                } => {
+                    let result = start_topic_debug_stream(
+                        &mut running_dataflows,
+                        &mut daemon_connections,
+                        dataflow_id,
+                        topics,
+                        sender,
+                        &clock,
+                    )
+                    .await
+                    .map_err(|err| format!("{err:?}"));
+                    let _ = done_tx.send(result);
+                }
+                ControlEvent::TopicCheck {
+                    dataflow_id,
+                    topics,
                     found_tx,
                 } => {
-                    let found = running_dataflows.get(&dataflow_id).is_some_and(|df| {
-                        if !df.descriptor.debug.publish_all_messages_to_zenoh {
-                            return false;
-                        }
-                        // Validate each requested topic exists in the descriptor
-                        topics.iter().all(|(node_id, data_id)| {
-                            df.descriptor
-                                .nodes
-                                .iter()
-                                .any(|node| node.id == *node_id && node.outputs.contains(data_id))
-                        })
-                    });
+                    let found =
+                        topic_outputs_by_daemon(&running_dataflows, dataflow_id, &topics).is_ok();
                     let _ = found_tx.send(found);
+                }
+                ControlEvent::TopicUnsubscribe {
+                    subscription_id,
+                    done_tx,
+                } => {
+                    if let Err(err) = stop_topic_debug_stream(
+                        &mut running_dataflows,
+                        &mut daemon_connections,
+                        subscription_id,
+                        &clock,
+                    )
+                    .await
+                    {
+                        tracing::warn!("failed to unsubscribe topic debug stream: {err:?}");
+                    }
+                    let _ = done_tx.send(());
                 }
             },
             Event::DaemonHeartbeatInterval => {
@@ -1778,6 +1804,22 @@ async fn start_inner(
                     } else {
                         send_log_message(&mut build.log_subscribers, &message).await;
                     }
+                }
+            }
+            Event::TopicDebugData {
+                dataflow_id,
+                subscription_id,
+                payload,
+            } => {
+                tracing::info!(
+                    %dataflow_id,
+                    %subscription_id,
+                    bytes = payload.len(),
+                    "received topic debug frame from daemon"
+                );
+                if let Some(dataflow) = running_dataflows.get_mut(&dataflow_id) {
+                    send_topic_frame(&mut dataflow.topic_subscribers, subscription_id, payload)
+                        .await;
                 }
             }
             Event::DaemonExit { daemon_id } => {
@@ -2141,6 +2183,137 @@ struct ParamReplaySummary {
     failed: usize,
 }
 
+fn topic_outputs_by_daemon(
+    running_dataflows: &HashMap<DataflowId, RunningDataflow>,
+    dataflow_id: DataflowId,
+    topics: &[(dora_message::id::NodeId, dora_message::id::DataId)],
+) -> eyre::Result<BTreeMap<DaemonId, Vec<(dora_message::id::NodeId, dora_message::id::DataId)>>> {
+    let dataflow = running_dataflows
+        .get(&dataflow_id)
+        .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
+
+    let mut outputs_by_daemon: BTreeMap<
+        DaemonId,
+        Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
+    > = BTreeMap::new();
+    for (node_id, data_id) in topics {
+        let output_exists = dataflow
+            .descriptor
+            .nodes
+            .iter()
+            .any(|node| node.id == *node_id && node.outputs.contains(data_id));
+        if !output_exists {
+            eyre::bail!("no output `{node_id}/{data_id}` in dataflow `{dataflow_id}`");
+        }
+        let daemon_id = dataflow
+            .node_to_daemon
+            .get(node_id)
+            .wrap_err_with(|| format!("no daemon mapping found for node `{node_id}`"))?;
+        outputs_by_daemon
+            .entry(daemon_id.clone())
+            .or_default()
+            .push((node_id.clone(), data_id.clone()));
+    }
+
+    Ok(outputs_by_daemon)
+}
+
+async fn start_topic_debug_stream(
+    running_dataflows: &mut HashMap<DataflowId, RunningDataflow>,
+    daemon_connections: &mut DaemonConnections,
+    dataflow_id: DataflowId,
+    topics: Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
+    sender: tokio::sync::mpsc::Sender<Vec<u8>>,
+    clock: &HLC,
+) -> eyre::Result<Uuid> {
+    let outputs_by_daemon = topic_outputs_by_daemon(running_dataflows, dataflow_id, &topics)?;
+    let outputs_by_daemon_for_state = outputs_by_daemon.clone();
+    let subscription_id = Uuid::new_v4();
+    for (daemon_id, outputs) in outputs_by_daemon {
+        let connection = daemon_connections
+            .get_mut(&daemon_id)
+            .wrap_err_with(|| format!("no daemon connection for daemon `{daemon_id}`"))?
+            .clone();
+        let message = serde_json::to_vec(&Timestamped {
+            inner: DaemonCoordinatorEvent::StartTopicDebugStream {
+                dataflow_id,
+                outputs,
+                subscription_id,
+            },
+            timestamp: clock.new_timestamp(),
+        })?;
+        let reply_raw = connection
+            .send_and_receive(&message)
+            .await
+            .wrap_err("failed to send start-topic-debug-stream message")?;
+        let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
+            .wrap_err("failed to deserialize start-topic-debug-stream reply")?;
+        match reply {
+            DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())) => {}
+            DaemonCoordinatorReply::StartTopicDebugStreamResult(Err(err)) => {
+                eyre::bail!("{err}");
+            }
+            other => eyre::bail!("unexpected start-topic-debug-stream reply: {other:?}"),
+        }
+    }
+
+    let dataflow = running_dataflows
+        .get_mut(&dataflow_id)
+        .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
+    dataflow.topic_subscribers.insert(
+        subscription_id,
+        topic_subscriber::TopicSubscriber::new(outputs_by_daemon_for_state, sender),
+    );
+
+    Ok(subscription_id)
+}
+
+async fn stop_topic_debug_stream(
+    running_dataflows: &mut HashMap<DataflowId, RunningDataflow>,
+    daemon_connections: &mut DaemonConnections,
+    subscription_id: Uuid,
+    clock: &HLC,
+) -> eyre::Result<()> {
+    let Some((dataflow_id, outputs_by_daemon)) =
+        running_dataflows.iter_mut().find_map(|(id, df)| {
+            df.topic_subscribers
+                .remove(&subscription_id)
+                .map(|subscriber| (*id, subscriber.outputs_by_daemon().clone()))
+        })
+    else {
+        return Ok(());
+    };
+
+    for (daemon_id, _) in outputs_by_daemon {
+        let connection = daemon_connections
+            .get_mut(&daemon_id)
+            .wrap_err_with(|| format!("no daemon connection for daemon `{daemon_id}`"))?
+            .clone();
+        let message = serde_json::to_vec(&Timestamped {
+            inner: DaemonCoordinatorEvent::StopTopicDebugStream {
+                dataflow_id,
+                subscription_id,
+            },
+            timestamp: clock.new_timestamp(),
+        })?;
+        let reply_raw = connection
+            .send_and_receive(&message)
+            .await
+            .wrap_err("failed to send stop-topic-debug-stream message")?;
+        let reply: DaemonCoordinatorReply = serde_json::from_slice(&reply_raw)
+            .wrap_err("failed to deserialize stop-topic-debug-stream reply")?;
+        match reply {
+            DaemonCoordinatorReply::StopTopicDebugStreamResult(Ok(())) => {}
+            DaemonCoordinatorReply::StopTopicDebugStreamResult(Err(err)) => {
+                eyre::bail!("{err}");
+            }
+            other => eyre::bail!("unexpected stop-topic-debug-stream reply: {other:?}"),
+        }
+    }
+
+    Ok(())
+}
+
 async fn handle_pruned_state_catchup_fallback(
     dataflow_id: DataflowId,
     dataflow: &mut RunningDataflow,
@@ -2424,19 +2597,18 @@ mod tests {
 
         let mut node_to_daemon = BTreeMap::new();
         node_to_daemon.insert(node_id, daemon_id);
+        let descriptor: Descriptor = serde_json::from_value(serde_json::json!({
+            "nodes": [{
+                "id": "sender",
+                "outputs": ["message"],
+            }]
+        }))
+        .expect("valid test descriptor");
 
         RunningDataflow {
             name: None,
             uuid: dataflow_id,
-            descriptor: Descriptor {
-                nodes: vec![],
-                communication: Default::default(),
-                deploy: None,
-                debug: Default::default(),
-                health_check_interval: None,
-                strict_types: None,
-                type_rules: vec![],
-            },
+            descriptor,
             daemons,
             pending_daemons: BTreeSet::new(),
             exited_before_subscribe: vec![],
@@ -2448,6 +2620,7 @@ mod tests {
             stop_reply_senders: vec![],
             buffered_log_messages: vec![],
             log_subscribers: vec![],
+            topic_subscribers: BTreeMap::new(),
             pending_spawn_results: BTreeSet::new(),
             created_at: 0,
             store_generation: 0,
@@ -2850,6 +3023,96 @@ mod tests {
         );
 
         daemon_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn start_topic_debug_stream_targets_source_daemon() {
+        #[derive(serde::Deserialize)]
+        struct OutboundRaw {
+            id: String,
+            method: String,
+            params: Timestamped<DaemonCoordinatorEvent>,
+        }
+
+        let dataflow_id = DataflowId::from(Uuid::new_v4());
+        let daemon_id = DaemonId::new(Some("m1".to_string()));
+        let node_id: dora_core::config::NodeId = "sender".to_string().into();
+        let data_id: dora_core::config::DataId = "message".to_string().into();
+        let (frame_tx, _frame_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<String>(8);
+        let pending_replies = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let connection =
+            crate::state::DaemonConnection::new(tx, pending_replies.clone(), BTreeMap::new());
+        let mut daemon_connections = DaemonConnections::default();
+        daemon_connections.add(daemon_id.clone(), connection);
+
+        let mut running_dataflows = HashMap::new();
+        running_dataflows.insert(
+            dataflow_id,
+            test_running_dataflow(dataflow_id, daemon_id, node_id.clone()),
+        );
+        let expected_node_id = node_id.clone();
+        let expected_data_id = data_id.clone();
+        let seen_subscription = Arc::new(tokio::sync::Mutex::new(None::<Uuid>));
+        let seen_subscription_task = seen_subscription.clone();
+
+        let daemon_task = tokio::spawn(async move {
+            let outbound = rx
+                .recv()
+                .await
+                .expect("daemon should receive topic stream command");
+            let outbound_raw: OutboundRaw = serde_json::from_str(&outbound).unwrap();
+            assert_eq!(outbound_raw.method, "daemon_command");
+            match outbound_raw.params.inner {
+                DaemonCoordinatorEvent::StartTopicDebugStream {
+                    dataflow_id: start_df,
+                    outputs,
+                    subscription_id,
+                } => {
+                    assert_eq!(start_df, dataflow_id);
+                    assert_eq!(outputs, vec![(expected_node_id, expected_data_id)]);
+                    *seen_subscription_task.lock().await = Some(subscription_id);
+                }
+                other => panic!("unexpected topic stream event: {other:?}"),
+            }
+
+            let request_id = Uuid::parse_str(&outbound_raw.id).expect("valid request id");
+            let reply =
+                serde_json::to_string(&DaemonCoordinatorReply::StartTopicDebugStreamResult(Ok(())))
+                    .unwrap();
+            let reply_tx = pending_replies
+                .lock()
+                .await
+                .remove(&request_id)
+                .expect("pending reply sender should exist");
+            let _ = reply_tx.send(reply);
+        });
+
+        let subscription_id = start_topic_debug_stream(
+            &mut running_dataflows,
+            &mut daemon_connections,
+            dataflow_id,
+            vec![(node_id.clone(), data_id.clone())],
+            frame_tx,
+            &HLC::default(),
+        )
+        .await
+        .expect("subscription should succeed");
+
+        daemon_task.await.unwrap();
+        assert_eq!(Some(subscription_id), *seen_subscription.lock().await);
+        assert_eq!(
+            running_dataflows[&dataflow_id]
+                .topic_subscribers
+                .get(&subscription_id)
+                .expect("subscription should be stored")
+                .outputs_by_daemon()
+                .values()
+                .next()
+                .expect("daemon mapping should exist"),
+            &vec![(node_id, data_id)]
+        );
     }
 
     #[test]

--- a/binaries/coordinator/src/state.rs
+++ b/binaries/coordinator/src/state.rs
@@ -1,4 +1,4 @@
-use crate::log_subscriber::LogSubscriber;
+use crate::{log_subscriber::LogSubscriber, topic_subscriber::TopicSubscriber};
 use dora_coordinator_store::{CoordinatorStore, DataflowRecord, DataflowStatus};
 use dora_core::config::NodeId;
 use dora_message::{
@@ -191,6 +191,7 @@ pub(crate) struct RunningDataflow {
     /// Buffer for log messages that were sent before there were any subscribers.
     pub(crate) buffered_log_messages: Vec<LogMessage>,
     pub(crate) log_subscribers: Vec<LogSubscriber>,
+    pub(crate) topic_subscribers: BTreeMap<Uuid, TopicSubscriber>,
 
     pub(crate) pending_spawn_results: BTreeSet<DaemonId>,
 

--- a/binaries/coordinator/src/topic_subscriber.rs
+++ b/binaries/coordinator/src/topic_subscriber.rs
@@ -1,0 +1,56 @@
+use std::collections::BTreeMap;
+
+pub(crate) struct TopicSubscriber {
+    outputs_by_daemon: BTreeMap<
+        dora_message::common::DaemonId,
+        Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
+    >,
+    sender: Option<tokio::sync::mpsc::Sender<Vec<u8>>>,
+}
+
+impl TopicSubscriber {
+    pub(crate) fn new(
+        outputs_by_daemon: BTreeMap<
+            dora_message::common::DaemonId,
+            Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
+        >,
+        sender: tokio::sync::mpsc::Sender<Vec<u8>>,
+    ) -> Self {
+        Self {
+            outputs_by_daemon,
+            sender: Some(sender),
+        }
+    }
+
+    pub(crate) fn outputs_by_daemon(
+        &self,
+    ) -> &BTreeMap<
+        dora_message::common::DaemonId,
+        Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
+    > {
+        &self.outputs_by_daemon
+    }
+
+    pub(crate) async fn send_frame(&mut self, payload: Vec<u8>) -> eyre::Result<()> {
+        let sender = self
+            .sender
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("subscriber is closed"))?;
+        sender
+            .send(payload)
+            .await
+            .map_err(|_| eyre::eyre!("WS topic subscriber channel closed"))?;
+        Ok(())
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        match &self.sender {
+            None => true,
+            Some(sender) => sender.is_closed(),
+        }
+    }
+
+    pub(crate) fn close(&mut self) {
+        self.sender = None;
+    }
+}

--- a/binaries/coordinator/src/topic_subscriber.rs
+++ b/binaries/coordinator/src/topic_subscriber.rs
@@ -1,11 +1,17 @@
 use std::collections::BTreeMap;
 
+pub struct TopicFrame {
+    pub subscription_id: uuid::Uuid,
+    pub payload: std::sync::Arc<[u8]>,
+}
+
 pub(crate) struct TopicSubscriber {
     outputs_by_daemon: BTreeMap<
         dora_message::common::DaemonId,
         Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
     >,
-    sender: Option<tokio::sync::mpsc::Sender<Vec<u8>>>,
+    sender: Option<tokio::sync::mpsc::Sender<TopicFrame>>,
+    consecutive_timeouts: usize,
 }
 
 impl TopicSubscriber {
@@ -14,11 +20,12 @@ impl TopicSubscriber {
             dora_message::common::DaemonId,
             Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
         >,
-        sender: tokio::sync::mpsc::Sender<Vec<u8>>,
+        sender: tokio::sync::mpsc::Sender<TopicFrame>,
     ) -> Self {
         Self {
             outputs_by_daemon,
             sender: Some(sender),
+            consecutive_timeouts: 0,
         }
     }
 
@@ -31,16 +38,25 @@ impl TopicSubscriber {
         &self.outputs_by_daemon
     }
 
-    pub(crate) async fn send_frame(&mut self, payload: Vec<u8>) -> eyre::Result<()> {
+    pub(crate) async fn send_frame(&mut self, frame: TopicFrame) -> eyre::Result<()> {
         let sender = self
             .sender
             .as_ref()
             .ok_or_else(|| eyre::eyre!("subscriber is closed"))?;
         sender
-            .send(payload)
+            .send(frame)
             .await
             .map_err(|_| eyre::eyre!("WS topic subscriber channel closed"))?;
         Ok(())
+    }
+
+    pub(crate) fn reset_timeout_streak(&mut self) {
+        self.consecutive_timeouts = 0;
+    }
+
+    pub(crate) fn record_timeout(&mut self) -> usize {
+        self.consecutive_timeouts += 1;
+        self.consecutive_timeouts
     }
 
     pub(crate) fn is_closed(&self) -> bool {

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -275,7 +275,7 @@ pub(crate) async fn handle_control_ws(
                             let resp = WsResponse::err(
                                 req.id,
                                 format!(
-                                    "dataflow {dataflow_id} not found, output unavailable, or `_unstable_debug.publish_all_messages_to_zenoh` is not enabled"
+                                    "dataflow {dataflow_id} not found, output unavailable, or topic publish requires `_unstable_debug.publish_all_messages_to_zenoh: true`"
                                 ),
                             );
                             let _ = send_ws_response(&mut ws_tx, &resp).await;

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -20,6 +20,13 @@ const MAX_TOPICS_PER_SUBSCRIBE: usize = 64;
 /// Maximum concurrent topic subscriptions per WebSocket connection.
 const MAX_SUBSCRIPTIONS_PER_CONNECTION: usize = 16;
 
+#[derive(Clone)]
+struct ActiveTopicSubscription {
+    subscription_id: Uuid,
+    dataflow_id: Uuid,
+    topics: Vec<(dora_message::id::NodeId, dora_message::id::DataId)>,
+}
+
 /// Serialize a `WsResponse` and send it over the WS connection.
 /// Returns `Err` if the WS send fails (connection closed).
 async fn send_ws_response(
@@ -73,7 +80,8 @@ pub(crate) async fn handle_control_ws(
     let (log_tx, mut log_rx) = mpsc::channel::<String>(64);
     // Channel for binary topic data frames
     let (binary_tx, mut binary_rx) = mpsc::channel::<Vec<u8>>(64);
-    let mut topic_subscriptions: Vec<Uuid> = Vec::new();
+    let mut topic_subscriptions: Vec<ActiveTopicSubscription> = Vec::new();
+    let mut publish_session: Option<zenoh::Session> = None;
 
     loop {
         tokio::select! {
@@ -177,6 +185,23 @@ pub(crate) async fn handle_control_ws(
                         continue;
                     }
                     ControlRequest::TopicSubscribe { dataflow_id, topics } => {
+                        let mut normalized_topics = topics.clone();
+                        normalized_topics.sort();
+
+                        if let Some(existing) = topic_subscriptions.iter().find(|subscription| {
+                            subscription.dataflow_id == *dataflow_id
+                                && subscription.topics == normalized_topics
+                        }) {
+                            let reply = ControlRequestReply::TopicSubscribed {
+                                subscription_id: existing.subscription_id,
+                            };
+                            let resp_json = format_response_json(req.id, &reply);
+                            if ws_tx.send(Message::Text(resp_json.into())).await.is_err() {
+                                break;
+                            }
+                            continue;
+                        }
+
                         // Validate topic count
                         if topics.len() > MAX_TOPICS_PER_SUBSCRIBE {
                             let resp = WsResponse::err(
@@ -215,7 +240,11 @@ pub(crate) async fn handle_control_ws(
 
                         let subscription_id = match done_rx.await {
                             Ok(Ok(subscription_id)) => {
-                                topic_subscriptions.push(subscription_id);
+                                topic_subscriptions.push(ActiveTopicSubscription {
+                                    subscription_id,
+                                    dataflow_id: *dataflow_id,
+                                    topics: normalized_topics,
+                                });
                                 subscription_id
                             }
                             Ok(Err(err)) => {
@@ -241,7 +270,8 @@ pub(crate) async fn handle_control_ws(
                         continue;
                     }
                     ControlRequest::TopicUnsubscribe { subscription_id } => {
-                        topic_subscriptions.retain(|active| active != subscription_id);
+                        topic_subscriptions
+                            .retain(|active| active.subscription_id != *subscription_id);
                         let (done_tx, done_rx) = oneshot::channel();
                         let _ = event_tx
                             .send(Event::Control(ControlEvent::TopicUnsubscribe {
@@ -288,6 +318,7 @@ pub(crate) async fn handle_control_ws(
                             output_id,
                             data_json,
                             &clock,
+                            &mut publish_session,
                         )
                         .await
                         {
@@ -361,7 +392,10 @@ pub(crate) async fn handle_control_ws(
         }
     }
 
-    for subscription_id in topic_subscriptions {
+    for subscription_id in topic_subscriptions
+        .into_iter()
+        .map(|active| active.subscription_id)
+    {
         let (done_tx, done_rx) = oneshot::channel();
         let _ = event_tx
             .send(Event::Control(ControlEvent::TopicUnsubscribe {
@@ -382,6 +416,7 @@ async fn publish_topic(
     output_id: &dora_message::id::DataId,
     data_json: &str,
     clock: &dora_core::uhlc::HLC,
+    session: &mut Option<zenoh::Session>,
 ) -> Result<(), String> {
     let topic = dora_core::topics::zenoh_output_publish_topic(dataflow_id, node_id, output_id);
 
@@ -422,9 +457,17 @@ async fn publish_topic(
         .serialize()
         .map_err(|e| format!("failed to serialize event: {e}"))?;
 
-    dora_core::topics::open_zenoh_session(None)
-        .await
-        .map_err(|e| format!("failed to open zenoh session: {e}"))?
+    if session.is_none() {
+        *session = Some(
+            dora_core::topics::open_zenoh_session(None)
+                .await
+                .map_err(|e| format!("failed to open zenoh session: {e}"))?,
+        );
+    }
+
+    session
+        .as_mut()
+        .expect("zenoh publish session initialized")
         .put(&topic, payload)
         .await
         .map_err(|e| format!("failed to publish to zenoh: {e}"))?;

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -79,7 +79,7 @@ pub(crate) async fn handle_control_ws(
     // Channel for log events to push back on same WS connection
     let (log_tx, mut log_rx) = mpsc::channel::<String>(64);
     // Channel for binary topic data frames
-    let (binary_tx, mut binary_rx) = mpsc::channel::<Vec<u8>>(64);
+    let (binary_tx, mut binary_rx) = mpsc::channel::<crate::topic_subscriber::TopicFrame>(64);
     let mut topic_subscriptions: Vec<ActiveTopicSubscription> = Vec::new();
     let mut publish_session: Option<zenoh::Session> = None;
 
@@ -384,7 +384,10 @@ pub(crate) async fn handle_control_ws(
                 }
             }
             // Binary topic data to push to CLI
-            Some(data) = binary_rx.recv() => {
+            Some(frame) = binary_rx.recv() => {
+                let mut data = Vec::with_capacity(16 + frame.payload.len());
+                data.extend_from_slice(&frame.subscription_id.into_bytes());
+                data.extend_from_slice(&frame.payload);
                 if ws_tx.send(Message::Binary(data.into())).await.is_err() {
                     break;
                 }

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -1,6 +1,5 @@
 use crate::{Event, control::ControlEvent};
 use axum::extract::ws::{Message, WebSocket};
-use dora_core::topics::zenoh_output_publish_topic;
 use dora_message::{
     cli_to_coordinator::{ControlRequest, check_cli_version},
     common::Timestamped,
@@ -11,10 +10,8 @@ use dora_message::{
     ws_protocol::{WsRequest, WsResponse},
 };
 use futures::{SinkExt, StreamExt};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
-use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 /// Maximum topics allowed in a single TopicSubscribe request.
@@ -22,9 +19,6 @@ const MAX_TOPICS_PER_SUBSCRIBE: usize = 64;
 
 /// Maximum concurrent topic subscriptions per WebSocket connection.
 const MAX_SUBSCRIPTIONS_PER_CONNECTION: usize = 16;
-
-/// Maximum binary payload size forwarded from Zenoh (64 MiB).
-const MAX_BINARY_PAYLOAD_BYTES: usize = 64 * 1024 * 1024;
 
 /// Serialize a `WsResponse` and send it over the WS connection.
 /// Returns `Err` if the WS send fails (connection closed).
@@ -59,22 +53,6 @@ fn format_response_json(id: Uuid, reply: &impl serde::Serialize) -> String {
     }
 }
 
-/// Lazily-initialized Zenoh session shared across topic subscriptions.
-async fn get_or_init_zenoh(
-    zenoh_session: &mut Option<zenoh::Session>,
-) -> Result<zenoh::Session, String> {
-    if let Some(session) = zenoh_session.as_ref() {
-        return Ok(session.clone());
-    }
-    match dora_core::topics::open_zenoh_session(None).await {
-        Ok(session) => {
-            *zenoh_session = Some(session.clone());
-            Ok(session)
-        }
-        Err(e) => Err(format!("failed to open zenoh session: {e}")),
-    }
-}
-
 /// Handle a single CLI WebSocket connection on `/api/control`.
 ///
 /// For normal requests: deserialize ControlRequest from WsRequest.params,
@@ -83,8 +61,8 @@ async fn get_or_init_zenoh(
 /// For LogSubscribe/BuildLogSubscribe: ack via WsResponse, then push WsEvent{event:"log"}
 /// on the same connection.
 ///
-/// For TopicSubscribe: validate via coordinator, open Zenoh subscribers, forward as binary
-/// WS frames with `subscription_id ++ payload` format.
+/// For TopicSubscribe: register a daemon-backed debug stream via coordinator
+/// and forward binary frames with `subscription_id ++ payload` format.
 pub(crate) async fn handle_control_ws(
     socket: WebSocket,
     event_tx: mpsc::Sender<Event>,
@@ -95,10 +73,7 @@ pub(crate) async fn handle_control_ws(
     let (log_tx, mut log_rx) = mpsc::channel::<String>(64);
     // Channel for binary topic data frames
     let (binary_tx, mut binary_rx) = mpsc::channel::<Vec<u8>>(64);
-    // Active topic subscription tasks, keyed by subscription_id
-    let mut topic_tasks: HashMap<Uuid, Vec<JoinHandle<()>>> = HashMap::new();
-    // Lazily initialized Zenoh session
-    let mut zenoh_session: Option<zenoh::Session> = None;
+    let mut topic_subscriptions: Vec<Uuid> = Vec::new();
 
     loop {
         tokio::select! {
@@ -217,12 +192,12 @@ pub(crate) async fn handle_control_ws(
                         }
 
                         // Validate subscription count
-                        if topic_tasks.len() >= MAX_SUBSCRIPTIONS_PER_CONNECTION {
+                        if topic_subscriptions.len() >= MAX_SUBSCRIPTIONS_PER_CONNECTION {
                             let resp = WsResponse::err(
                                 req.id,
                                 format!(
                                     "too many active subscriptions ({}, max {})",
-                                    topic_tasks.len(),
+                                    topic_subscriptions.len(),
                                     MAX_SUBSCRIPTIONS_PER_CONNECTION
                                 ),
                             );
@@ -230,83 +205,33 @@ pub(crate) async fn handle_control_ws(
                             continue;
                         }
 
-                        let (found_tx, found_rx) = oneshot::channel();
+                        let (done_tx, done_rx) = oneshot::channel();
                         let _ = event_tx.send(Event::Control(ControlEvent::TopicSubscribe {
                             dataflow_id: *dataflow_id,
                             topics: topics.clone(),
-                            found_tx,
+                            sender: binary_tx.clone(),
+                            done_tx,
                         })).await;
 
-                        let found = found_rx.await.unwrap_or(false);
-                        if !found {
-                            let resp = WsResponse::err(
-                                req.id,
-                                format!(
-                                    "dataflow {dataflow_id} not found or publish_all_messages_to_zenoh not enabled"
-                                ),
-                            );
-                            let _ = send_ws_response(&mut ws_tx, &resp).await;
-                            continue;
-                        }
-
-                        // Open Zenoh session lazily
-                        let session = match get_or_init_zenoh(&mut zenoh_session).await {
-                            Ok(s) => s,
-                            Err(e) => {
-                                let resp = WsResponse::err(req.id, e);
+                        let subscription_id = match done_rx.await {
+                            Ok(Ok(subscription_id)) => {
+                                topic_subscriptions.push(subscription_id);
+                                subscription_id
+                            }
+                            Ok(Err(err)) => {
+                                let resp = WsResponse::err(req.id, err);
+                                let _ = send_ws_response(&mut ws_tx, &resp).await;
+                                continue;
+                            }
+                            Err(_) => {
+                                let resp = WsResponse::err(
+                                    req.id,
+                                    "topic subscribe request dropped before completion".to_string(),
+                                );
                                 let _ = send_ws_response(&mut ws_tx, &resp).await;
                                 continue;
                             }
                         };
-
-                        let subscription_id = Uuid::new_v4();
-                        let mut handles = Vec::with_capacity(topics.len());
-
-                        for (node_id, data_id) in topics {
-                            let topic = zenoh_output_publish_topic(
-                                *dataflow_id,
-                                node_id,
-                                data_id,
-                            );
-                            let session = session.clone();
-                            let binary_tx = binary_tx.clone();
-                            let sub_id_bytes = subscription_id.into_bytes();
-
-                            handles.push(tokio::spawn(async move {
-                                let subscriber = match session.declare_subscriber(&topic).await {
-                                    Ok(s) => s,
-                                    Err(e) => {
-                                        tracing::warn!("failed to subscribe to zenoh topic {topic}: {e}");
-                                        return;
-                                    }
-                                };
-
-                                let mut dropped: u64 = 0;
-                                while let Ok(sample) = subscriber.recv_async().await {
-                                    let payload = sample.payload().to_bytes();
-                                    if payload.len() > MAX_BINARY_PAYLOAD_BYTES {
-                                        tracing::warn!(
-                                            "dropping oversized payload ({} bytes) on {topic}",
-                                            payload.len()
-                                        );
-                                        continue;
-                                    }
-                                    let mut frame = Vec::with_capacity(16 + payload.len());
-                                    frame.extend_from_slice(&sub_id_bytes);
-                                    frame.extend_from_slice(&payload);
-                                    if binary_tx.try_send(frame).is_err() {
-                                        dropped += 1;
-                                        if dropped == 1 || dropped.is_multiple_of(100) {
-                                            tracing::warn!(
-                                                "backpressure: dropped {dropped} frame(s) on {topic} (channel full)"
-                                            );
-                                        }
-                                    }
-                                }
-                            }));
-                        }
-
-                        topic_tasks.insert(subscription_id, handles);
 
                         let reply = ControlRequestReply::TopicSubscribed { subscription_id };
                         let resp_json = format_response_json(req.id, &reply);
@@ -316,11 +241,15 @@ pub(crate) async fn handle_control_ws(
                         continue;
                     }
                     ControlRequest::TopicUnsubscribe { subscription_id } => {
-                        if let Some(handles) = topic_tasks.remove(subscription_id) {
-                            for h in handles {
-                                h.abort();
-                            }
-                        }
+                        topic_subscriptions.retain(|active| active != subscription_id);
+                        let (done_tx, done_rx) = oneshot::channel();
+                        let _ = event_tx
+                            .send(Event::Control(ControlEvent::TopicUnsubscribe {
+                                subscription_id: *subscription_id,
+                                done_tx,
+                            }))
+                            .await;
+                        let _ = done_rx.await;
                         let resp = WsResponse::ok(
                             req.id,
                             serde_json::json!({"unsubscribed": true, "subscription_id": subscription_id}),
@@ -336,7 +265,7 @@ pub(crate) async fn handle_control_ws(
                     } => {
                         // Validate that the dataflow has debug publishing enabled
                         let (found_tx, found_rx) = oneshot::channel();
-                        let _ = event_tx.send(Event::Control(ControlEvent::TopicSubscribe {
+                        let _ = event_tx.send(Event::Control(ControlEvent::TopicCheck {
                             dataflow_id: *dataflow_id,
                             topics: vec![(node_id.clone(), output_id.clone())],
                             found_tx,
@@ -354,7 +283,6 @@ pub(crate) async fn handle_control_ws(
                         }
 
                         let resp = match publish_topic(
-                            &mut zenoh_session,
                             *dataflow_id,
                             node_id,
                             output_id,
@@ -433,11 +361,15 @@ pub(crate) async fn handle_control_ws(
         }
     }
 
-    // Clean up: abort all topic subscription tasks
-    for (_, handles) in topic_tasks {
-        for h in handles {
-            h.abort();
-        }
+    for subscription_id in topic_subscriptions {
+        let (done_tx, done_rx) = oneshot::channel();
+        let _ = event_tx
+            .send(Event::Control(ControlEvent::TopicUnsubscribe {
+                subscription_id,
+                done_tx,
+            }))
+            .await;
+        let _ = done_rx.await;
     }
 }
 
@@ -445,15 +377,13 @@ pub(crate) async fn handle_control_ws(
 ///
 /// The JSON string is stored as raw UTF-8 bytes in a UInt8 Arrow array.
 async fn publish_topic(
-    zenoh_session: &mut Option<zenoh::Session>,
     dataflow_id: Uuid,
     node_id: &dora_message::id::NodeId,
     output_id: &dora_message::id::DataId,
     data_json: &str,
     clock: &dora_core::uhlc::HLC,
 ) -> Result<(), String> {
-    let session = get_or_init_zenoh(zenoh_session).await?;
-    let topic = zenoh_output_publish_topic(dataflow_id, node_id, output_id);
+    let topic = dora_core::topics::zenoh_output_publish_topic(dataflow_id, node_id, output_id);
 
     // Store JSON as raw UTF-8 bytes in a UInt8 array
     let data_bytes = data_json.as_bytes();
@@ -492,7 +422,9 @@ async fn publish_topic(
         .serialize()
         .map_err(|e| format!("failed to serialize event: {e}"))?;
 
-    session
+    dora_core::topics::open_zenoh_session(None)
+        .await
+        .map_err(|e| format!("failed to open zenoh session: {e}"))?
         .put(&topic, payload)
         .await
         .map_err(|e| format!("failed to publish to zenoh: {e}"))?;

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -275,7 +275,7 @@ pub(crate) async fn handle_control_ws(
                             let resp = WsResponse::err(
                                 req.id,
                                 format!(
-                                    "dataflow {dataflow_id} not found or publish_all_messages_to_zenoh not enabled"
+                                    "dataflow {dataflow_id} not found, output unavailable, or `_unstable_debug.publish_all_messages_to_zenoh` is not enabled"
                                 ),
                             );
                             let _ = send_ws_response(&mut ws_tx, &resp).await;

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -222,11 +222,11 @@ fn translate_daemon_event(daemon_id: DaemonId, event: DaemonEvent) -> Option<Eve
         }),
         DaemonEvent::TopicDebugData {
             dataflow_id,
-            subscription_id,
+            subscription_ids,
             payload,
         } => Some(Event::TopicDebugData {
             dataflow_id,
-            subscription_id,
+            subscription_ids,
             payload,
         }),
         DaemonEvent::BuildResult { build_id, result } => Some(Event::DataflowBuildResult {

--- a/binaries/coordinator/src/ws_daemon.rs
+++ b/binaries/coordinator/src/ws_daemon.rs
@@ -220,6 +220,15 @@ fn translate_daemon_event(daemon_id: DaemonId, event: DaemonEvent) -> Option<Eve
             metrics,
             network,
         }),
+        DaemonEvent::TopicDebugData {
+            dataflow_id,
+            subscription_id,
+            payload,
+        } => Some(Event::TopicDebugData {
+            dataflow_id,
+            subscription_id,
+            payload,
+        }),
         DaemonEvent::BuildResult { build_id, result } => Some(Event::DataflowBuildResult {
             build_id,
             daemon_id,

--- a/binaries/coordinator/tests/common/mod.rs
+++ b/binaries/coordinator/tests/common/mod.rs
@@ -1,15 +1,32 @@
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+
+fn coordinator_test_lock() -> &'static Arc<tokio::sync::Mutex<()>> {
+    static LOCK: OnceLock<Arc<tokio::sync::Mutex<()>>> = OnceLock::new();
+    LOCK.get_or_init(|| Arc::new(tokio::sync::Mutex::new(())))
+}
+
+pub struct TestCoordinatorHandle {
+    handle: tokio::task::JoinHandle<()>,
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl Drop for TestCoordinatorHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
 
 /// Start a coordinator on a random port and return (port, background_task).
-pub async fn start_test_coordinator() -> (u16, tokio::task::JoinHandle<()>) {
+pub async fn start_test_coordinator() -> (u16, TestCoordinatorHandle) {
     start_test_coordinator_with_store(Arc::new(dora_coordinator::InMemoryStore::new())).await
 }
 
 /// Start a coordinator with a caller-provided store.
 pub async fn start_test_coordinator_with_store(
     store: Arc<dyn dora_coordinator::CoordinatorStore>,
-) -> (u16, tokio::task::JoinHandle<()>) {
+) -> (u16, TestCoordinatorHandle) {
+    let guard = coordinator_test_lock().clone().lock_owned().await;
     let bind: SocketAddr = "127.0.0.1:0".parse().unwrap();
     let (port, future) =
         dora_coordinator::start_testing_with_store(bind, futures::stream::empty(), store)
@@ -32,5 +49,11 @@ pub async fn start_test_coordinator_with_store(
         }
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
-    (port, handle)
+    (
+        port,
+        TestCoordinatorHandle {
+            handle,
+            _guard: guard,
+        },
+    )
 }

--- a/binaries/coordinator/tests/ws_control_tests.rs
+++ b/binaries/coordinator/tests/ws_control_tests.rs
@@ -79,7 +79,7 @@ fn seed_dataflow_record(store: &dyn CoordinatorStore, dataflow_id: Uuid, node_id
     store.put_dataflow(&record).expect("seed dataflow record");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_and_health_check() {
     let (port, _handle) = common::start_test_coordinator().await;
 
@@ -99,7 +99,7 @@ async fn connect_and_health_check() {
     assert!(response.ends_with("ok") || response.contains("\r\n\r\nok"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_list_empty() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -120,7 +120,7 @@ async fn control_list_empty() {
     assert!(list.as_array().unwrap().is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_invalid_json() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -139,7 +139,7 @@ async fn control_invalid_json() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_invalid_params() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -149,7 +149,7 @@ async fn control_invalid_params() {
     assert!(resp.error.unwrap().contains("invalid params"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_destroy_nonexistent() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -163,7 +163,7 @@ async fn control_destroy_nonexistent() {
     assert_eq!(result, json!("DestroyOk"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_status() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -178,7 +178,7 @@ async fn control_status() {
     assert_eq!(connected, &json!(false));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_ping_pong() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -192,7 +192,7 @@ async fn control_ping_pong() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_concurrent_requests() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -233,7 +233,7 @@ async fn control_concurrent_requests() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_connection_close() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -256,7 +256,7 @@ async fn control_connection_close() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn log_subscribe_nonexistent() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -277,7 +277,7 @@ async fn log_subscribe_nonexistent() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn control_error_does_not_leak_internal_chain() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -304,7 +304,7 @@ async fn control_error_does_not_leak_internal_chain() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn build_log_subscribe_nonexistent() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -324,7 +324,7 @@ async fn build_log_subscribe_nonexistent() {
 
 // -- Phase 2: Node restart/stop error paths --
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn restart_node_nonexistent_dataflow() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -352,7 +352,7 @@ async fn restart_node_nonexistent_dataflow() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn stop_node_nonexistent_dataflow() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -372,7 +372,7 @@ async fn stop_node_nonexistent_dataflow() {
 
 // -- Phase 3: Parameter CRUD via coordinator --
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_list_empty() {
     let store_impl = Arc::new(dora_coordinator::InMemoryStore::new());
     let dataflow_id = Uuid::new_v4();
@@ -395,7 +395,7 @@ async fn param_list_empty() {
     assert!(params_arr.is_empty());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_set_then_get() {
     let store_impl = Arc::new(dora_coordinator::InMemoryStore::new());
     let df_id = Uuid::new_v4();
@@ -431,7 +431,7 @@ async fn param_set_then_get() {
     assert_eq!(pv.get("value").unwrap(), &json!(42));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_set_list_delete() {
     let store_impl = Arc::new(dora_coordinator::InMemoryStore::new());
     let df_id = Uuid::new_v4();
@@ -504,7 +504,7 @@ async fn param_set_list_delete() {
     assert_eq!(arr[0].as_array().unwrap()[0], "resolution");
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_set_rejects_unknown_target() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -522,7 +522,7 @@ async fn param_set_rejects_unknown_target() {
     assert!(result.get("Error").is_some());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_delete_rejects_unknown_target() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -539,7 +539,7 @@ async fn param_delete_rejects_unknown_target() {
     assert!(result.get("Error").is_some());
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_get_nonexistent() {
     let store_impl = Arc::new(dora_coordinator::InMemoryStore::new());
     let dataflow_id = Uuid::new_v4();
@@ -563,7 +563,7 @@ async fn param_get_nonexistent() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_get_rejects_unknown_target() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;
@@ -583,7 +583,7 @@ async fn param_get_rejects_unknown_target() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn param_list_rejects_unknown_target() {
     let (port, _handle) = common::start_test_coordinator().await;
     let mut ws = connect_control(port).await;

--- a/binaries/daemon/src/coordinator.rs
+++ b/binaries/daemon/src/coordinator.rs
@@ -32,20 +32,52 @@ pub struct CoordinatorSender {
     sender: mpsc::Sender<String>,
 }
 
+#[derive(Debug)]
+pub enum TrySendEventError {
+    InvalidUtf8(std::str::Utf8Error),
+    Full,
+    Closed,
+}
+
+impl std::fmt::Display for TrySendEventError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidUtf8(err) => write!(f, "event message not UTF-8: {err}"),
+            Self::Full => write!(f, "WS send channel full"),
+            Self::Closed => write!(f, "WS send channel closed"),
+        }
+    }
+}
+
+impl std::error::Error for TrySendEventError {}
+
 impl CoordinatorSender {
+    fn format_event_message(message: &[u8]) -> Result<String, TrySendEventError> {
+        let params_str = std::str::from_utf8(message).map_err(TrySendEventError::InvalidUtf8)?;
+        let id = Uuid::new_v4();
+        Ok(format!(
+            r#"{{"id":"{id}","method":"daemon_event","params":{params_str}}}"#
+        ))
+    }
+
     /// Send a serialized event message to the coordinator (fire-and-forget).
     ///
     /// Embeds the raw JSON bytes directly to preserve u128 fidelity
     /// for uhlc::ID inside timestamps.
     pub async fn send_event(&self, message: &[u8]) -> eyre::Result<()> {
-        let params_str =
-            std::str::from_utf8(message).map_err(|e| eyre!("event message not UTF-8: {e}"))?;
-        let id = Uuid::new_v4();
-        let json = format!(r#"{{"id":"{id}","method":"daemon_event","params":{params_str}}}"#);
+        let json = Self::format_event_message(message).map_err(|err| eyre!("{err}"))?;
         self.sender
             .send(json)
             .await
             .map_err(|_| eyre!("WS send channel closed"))
+    }
+
+    pub fn try_send_event(&self, message: &[u8]) -> Result<(), TrySendEventError> {
+        let json = Self::format_event_message(message)?;
+        self.sender.try_send(json).map_err(|err| match err {
+            mpsc::error::TrySendError::Full(_) => TrySendEventError::Full,
+            mpsc::error::TrySendError::Closed(_) => TrySendEventError::Closed,
+        })
     }
 }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -1817,6 +1817,62 @@ impl Daemon {
                 let _ = reply_tx.send(None);
                 RunStatus::Continue
             }
+            DaemonCoordinatorEvent::StartTopicDebugStream {
+                dataflow_id,
+                outputs,
+                subscription_id,
+            } => {
+                let result = if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
+                    for (node_id, data_id) in outputs {
+                        let output_id = OutputId(node_id.clone(), data_id.clone());
+                        dataflow
+                            .debug_topic_subscriptions
+                            .entry(subscription_id)
+                            .or_default()
+                            .insert(output_id.clone());
+                        dataflow
+                            .debug_topic_watchers
+                            .entry(output_id)
+                            .or_default()
+                            .insert(subscription_id);
+                    }
+                    Ok(())
+                } else {
+                    Err(format!("no running dataflow with ID `{dataflow_id}`"))
+                };
+                let _ = reply_tx.send(Some(DaemonCoordinatorReply::StartTopicDebugStreamResult(
+                    result,
+                )));
+                RunStatus::Continue
+            }
+            DaemonCoordinatorEvent::StopTopicDebugStream {
+                dataflow_id,
+                subscription_id,
+            } => {
+                let result = if let Some(dataflow) = self.running.get_mut(&dataflow_id) {
+                    if let Some(outputs) =
+                        dataflow.debug_topic_subscriptions.remove(&subscription_id)
+                    {
+                        for output_id in outputs {
+                            if let Some(watchers) =
+                                dataflow.debug_topic_watchers.get_mut(&output_id)
+                            {
+                                watchers.remove(&subscription_id);
+                                if watchers.is_empty() {
+                                    dataflow.debug_topic_watchers.remove(&output_id);
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                } else {
+                    Err(format!("no running dataflow with ID `{dataflow_id}`"))
+                };
+                let _ = reply_tx.send(Some(DaemonCoordinatorReply::StopTopicDebugStreamResult(
+                    result,
+                )));
+                RunStatus::Continue
+            }
             DaemonCoordinatorEvent::StateCatchUp {
                 dataflow_id,
                 entries,
@@ -2889,15 +2945,25 @@ impl Daemon {
         .await?;
 
         let output_id = output_id_key;
+        let event = InterDaemonEvent::Output {
+            dataflow_id,
+            node_id: output_id.0.clone(),
+            output_id: output_id.1.clone(),
+            metadata,
+            data: data_bytes,
+        };
+        let serialized_event = Timestamped {
+            inner: event,
+            timestamp: self.clock.new_timestamp(),
+        }
+        .serialize()
+        .wrap_err("failed to serialize inter-daemon event")?;
+
+        self.send_topic_debug_frames(dataflow_id, &output_id, &serialized_event)
+            .await?;
+
         if remote_receivers {
-            let event = InterDaemonEvent::Output {
-                dataflow_id,
-                node_id: output_id.0.clone(),
-                output_id: output_id.1.clone(),
-                metadata,
-                data: data_bytes,
-            };
-            self.send_to_remote_receivers(dataflow_id, &output_id, event)
+            self.send_to_remote_receivers(dataflow_id, &output_id, serialized_event)
                 .await?;
         }
 
@@ -2908,7 +2974,7 @@ impl Daemon {
         &mut self,
         dataflow_id: Uuid,
         output_id: &OutputId,
-        event: InterDaemonEvent,
+        serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
         let dataflow = self.running.get_mut(&dataflow_id).wrap_err_with(|| {
             format!("send out failed: no running dataflow with ID `{dataflow_id}`")
@@ -2932,13 +2998,6 @@ impl Daemon {
                 arc
             }
         };
-
-        let serialized_event = Timestamped {
-            inner: event,
-            timestamp: self.clock.new_timestamp(),
-        }
-        .serialize()
-        .wrap_err("failed to serialize inter-daemon event")?;
         let payload_len = serialized_event.len() as u64;
 
         // Offload Zenoh I/O to the drain task — never blocks the event loop.
@@ -2961,6 +3020,43 @@ impl Daemon {
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 tracing::error!("zenoh drain task is gone — inter-daemon publish channel closed");
             }
+        }
+
+        Ok(())
+    }
+
+    async fn send_topic_debug_frames(
+        &self,
+        dataflow_id: Uuid,
+        output_id: &OutputId,
+        serialized_event: &[u8],
+    ) -> Result<(), eyre::Error> {
+        let Some(sender) = &self.coordinator_sender else {
+            return Ok(());
+        };
+        let Some(dataflow) = self.running.get(&dataflow_id) else {
+            return Ok(());
+        };
+        let Some(subscription_ids) = dataflow.debug_topic_watchers.get(output_id) else {
+            return Ok(());
+        };
+
+        for subscription_id in subscription_ids {
+            let message = serde_json::to_vec(&Timestamped {
+                inner: CoordinatorRequest::Event {
+                    daemon_id: self.daemon_id.clone(),
+                    event: DaemonEvent::TopicDebugData {
+                        dataflow_id,
+                        subscription_id: *subscription_id,
+                        payload: serialized_event.to_vec(),
+                    },
+                },
+                timestamp: self.clock.new_timestamp(),
+            })?;
+            sender
+                .send_event(&message)
+                .await
+                .wrap_err("failed to send topic debug frame to coordinator")?;
         }
 
         Ok(())
@@ -2995,12 +3091,17 @@ impl Daemon {
         }
 
         for output_id in closed {
-            let event = InterDaemonEvent::OutputClosed {
-                dataflow_id,
-                node_id: output_id.0.clone(),
-                output_id: output_id.1.clone(),
-            };
-            self.send_to_remote_receivers(dataflow_id, &output_id, event)
+            let serialized_event = Timestamped {
+                inner: InterDaemonEvent::OutputClosed {
+                    dataflow_id,
+                    node_id: output_id.0.clone(),
+                    output_id: output_id.1.clone(),
+                },
+                timestamp: self.clock.new_timestamp(),
+            }
+            .serialize()
+            .wrap_err("failed to serialize inter-daemon output-closed event")?;
+            self.send_to_remote_receivers(dataflow_id, &output_id, serialized_event)
                 .await?;
         }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3047,42 +3047,41 @@ impl Daemon {
         let Some(subscription_ids) = dataflow.debug_topic_watchers.get(output_id) else {
             return Ok(());
         };
+        let subscription_ids: Vec<_> = subscription_ids.iter().copied().collect();
 
-        for subscription_id in subscription_ids {
-            let message = serde_json::to_vec(&Timestamped {
-                inner: CoordinatorRequest::Event {
-                    daemon_id: self.daemon_id.clone(),
-                    event: DaemonEvent::TopicDebugData {
-                        dataflow_id,
-                        subscription_id: *subscription_id,
-                        payload: serialized_event.to_vec(),
-                    },
+        let message = serde_json::to_vec(&Timestamped {
+            inner: CoordinatorRequest::Event {
+                daemon_id: self.daemon_id.clone(),
+                event: DaemonEvent::TopicDebugData {
+                    dataflow_id,
+                    subscription_ids: subscription_ids.clone(),
+                    payload: serialized_event.to_vec(),
                 },
-                timestamp: self.clock.new_timestamp(),
-            })?;
-            match sender.try_send_event(&message) {
-                Ok(()) => {}
-                Err(crate::coordinator::TrySendEventError::Full) => {
-                    tracing::warn!(
-                        %dataflow_id,
-                        output = %format!("{}/{}", output_id.0, output_id.1),
-                        %subscription_id,
-                        "dropping topic debug frame because coordinator WS send channel is full"
-                    );
-                }
-                Err(crate::coordinator::TrySendEventError::Closed) => {
-                    tracing::warn!(
-                        %dataflow_id,
-                        output = %format!("{}/{}", output_id.0, output_id.1),
-                        %subscription_id,
-                        "dropping topic debug frame because coordinator WS send channel is closed"
-                    );
-                }
-                Err(crate::coordinator::TrySendEventError::InvalidUtf8(err)) => {
-                    return Err(eyre!(
-                        "failed to encode topic debug frame for coordinator: {err}"
-                    ));
-                }
+            },
+            timestamp: self.clock.new_timestamp(),
+        })?;
+        match sender.try_send_event(&message) {
+            Ok(()) => {}
+            Err(crate::coordinator::TrySendEventError::Full) => {
+                tracing::warn!(
+                    %dataflow_id,
+                    output = %format!("{}/{}", output_id.0, output_id.1),
+                    subscriptions = subscription_ids.len(),
+                    "dropping topic debug frame because coordinator WS send channel is full"
+                );
+            }
+            Err(crate::coordinator::TrySendEventError::Closed) => {
+                tracing::warn!(
+                    %dataflow_id,
+                    output = %format!("{}/{}", output_id.0, output_id.1),
+                    subscriptions = subscription_ids.len(),
+                    "dropping topic debug frame because coordinator WS send channel is closed"
+                );
+            }
+            Err(crate::coordinator::TrySendEventError::InvalidUtf8(err)) => {
+                return Err(eyre!(
+                    "failed to encode topic debug frame for coordinator: {err}"
+                ));
             }
         }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2932,6 +2932,7 @@ impl Daemon {
         let output_id_key = OutputId(node_id.clone(), output_id.clone());
         let remote_receivers = dataflow.open_external_mappings.contains(&output_id_key)
             || dataflow.publish_all_messages_to_zenoh;
+        let has_debug_watchers = dataflow.debug_topic_watchers.contains_key(&output_id_key);
         let data_bytes = send_output_to_local_receivers(
             node_id.clone(),
             output_id.clone(),
@@ -2943,6 +2944,10 @@ impl Daemon {
             remote_receivers,
         )
         .await?;
+
+        if !remote_receivers && !has_debug_watchers {
+            return Ok(());
+        }
 
         let output_id = output_id_key;
         let event = InterDaemonEvent::Output {
@@ -2959,8 +2964,10 @@ impl Daemon {
         .serialize()
         .wrap_err("failed to serialize inter-daemon event")?;
 
-        self.send_topic_debug_frames(dataflow_id, &output_id, &serialized_event)
-            .await?;
+        if has_debug_watchers {
+            self.send_topic_debug_frames(dataflow_id, &output_id, &serialized_event)
+                .await?;
+        }
 
         if remote_receivers {
             self.send_to_remote_receivers(dataflow_id, &output_id, serialized_event)
@@ -3053,10 +3060,30 @@ impl Daemon {
                 },
                 timestamp: self.clock.new_timestamp(),
             })?;
-            sender
-                .send_event(&message)
-                .await
-                .wrap_err("failed to send topic debug frame to coordinator")?;
+            match sender.try_send_event(&message) {
+                Ok(()) => {}
+                Err(crate::coordinator::TrySendEventError::Full) => {
+                    tracing::warn!(
+                        %dataflow_id,
+                        output = %format!("{}/{}", output_id.0, output_id.1),
+                        %subscription_id,
+                        "dropping topic debug frame because coordinator WS send channel is full"
+                    );
+                }
+                Err(crate::coordinator::TrySendEventError::Closed) => {
+                    tracing::warn!(
+                        %dataflow_id,
+                        output = %format!("{}/{}", output_id.0, output_id.1),
+                        %subscription_id,
+                        "dropping topic debug frame because coordinator WS send channel is closed"
+                    );
+                }
+                Err(crate::coordinator::TrySendEventError::InvalidUtf8(err)) => {
+                    return Err(eyre!(
+                        "failed to encode topic debug frame for coordinator: {err}"
+                    ));
+                }
+            }
         }
 
         Ok(())

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -3048,13 +3048,14 @@ impl Daemon {
             return Ok(());
         };
         let subscription_ids: Vec<_> = subscription_ids.iter().copied().collect();
+        let subscription_count = subscription_ids.len();
 
         let message = serde_json::to_vec(&Timestamped {
             inner: CoordinatorRequest::Event {
                 daemon_id: self.daemon_id.clone(),
                 event: DaemonEvent::TopicDebugData {
                     dataflow_id,
-                    subscription_ids: subscription_ids.clone(),
+                    subscription_ids,
                     payload: serialized_event.to_vec(),
                 },
             },
@@ -3066,7 +3067,7 @@ impl Daemon {
                 tracing::warn!(
                     %dataflow_id,
                     output = %format!("{}/{}", output_id.0, output_id.1),
-                    subscriptions = subscription_ids.len(),
+                    subscriptions = subscription_count,
                     "dropping topic debug frame because coordinator WS send channel is full"
                 );
             }
@@ -3074,7 +3075,7 @@ impl Daemon {
                 tracing::warn!(
                     %dataflow_id,
                     output = %format!("{}/{}", output_id.0, output_id.1),
-                    subscriptions = subscription_ids.len(),
+                    subscriptions = subscription_count,
                     "dropping topic debug frame because coordinator WS send channel is closed"
                 );
             }

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -2965,8 +2965,14 @@ impl Daemon {
         .wrap_err("failed to serialize inter-daemon event")?;
 
         if has_debug_watchers {
-            self.send_topic_debug_frames(dataflow_id, &output_id, &serialized_event)
-                .await?;
+            if remote_receivers {
+                self.send_topic_debug_frames(dataflow_id, &output_id, serialized_event.clone())
+                    .await?;
+            } else {
+                self.send_topic_debug_frames(dataflow_id, &output_id, serialized_event)
+                    .await?;
+                return Ok(());
+            }
         }
 
         if remote_receivers {
@@ -3036,7 +3042,7 @@ impl Daemon {
         &self,
         dataflow_id: Uuid,
         output_id: &OutputId,
-        serialized_event: &[u8],
+        serialized_event: Vec<u8>,
     ) -> Result<(), eyre::Error> {
         let Some(sender) = &self.coordinator_sender else {
             return Ok(());
@@ -3056,7 +3062,7 @@ impl Daemon {
                 event: DaemonEvent::TopicDebugData {
                     dataflow_id,
                     subscription_ids,
-                    payload: serialized_event.to_vec(),
+                    payload: serialized_event,
                 },
             },
             timestamp: self.clock.new_timestamp(),

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -201,6 +201,8 @@ pub struct RunningDataflow {
     pub(crate) grace_duration_kills: Arc<crossbeam_skiplist::SkipSet<NodeId>>,
     pub(crate) node_stderr_most_recent: BTreeMap<NodeId, Arc<ArrayQueue<String>>>,
     pub(crate) publishers: BTreeMap<OutputId, Arc<zenoh::pubsub::Publisher<'static>>>,
+    pub(crate) debug_topic_subscriptions: BTreeMap<uuid::Uuid, BTreeSet<OutputId>>,
+    pub(crate) debug_topic_watchers: BTreeMap<OutputId, BTreeSet<uuid::Uuid>>,
     pub(crate) finished_tx: broadcast::Sender<()>,
     /// Shutdown signal for listener loops — send `true` when dataflow finishes.
     pub(crate) listener_shutdown_tx: tokio::sync::watch::Sender<bool>,
@@ -256,6 +258,8 @@ impl RunningDataflow {
             grace_duration_kills: Default::default(),
             node_stderr_most_recent: BTreeMap::new(),
             publishers: Default::default(),
+            debug_topic_subscriptions: Default::default(),
+            debug_topic_watchers: Default::default(),
             finished_tx,
             listener_shutdown_tx,
             listener_shutdown_rx,

--- a/libraries/message/src/coordinator_to_daemon.rs
+++ b/libraries/message/src/coordinator_to_daemon.rs
@@ -136,6 +136,19 @@ pub enum DaemonCoordinatorEvent {
         target_node: NodeId,
         target_input: DataId,
     },
+    /// Start forwarding matching output frames back to the coordinator over
+    /// the daemon control channel for CLI topic inspection.
+    StartTopicDebugStream {
+        dataflow_id: DataflowId,
+        outputs: Vec<(NodeId, DataId)>,
+        subscription_id: uuid::Uuid,
+    },
+    /// Stop forwarding output frames for a previously registered CLI topic
+    /// inspection subscription.
+    StopTopicDebugStream {
+        dataflow_id: DataflowId,
+        subscription_id: uuid::Uuid,
+    },
     /// Incremental state catch-up: replays missed state mutations to a
     /// reconnecting daemon.
     StateCatchUp {

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -94,7 +94,7 @@ pub enum DaemonEvent {
     },
     TopicDebugData {
         dataflow_id: DataflowId,
-        subscription_id: uuid::Uuid,
+        subscription_ids: Vec<uuid::Uuid>,
         payload: Vec<u8>,
     },
     /// Daemon acknowledges state catch-up through a given sequence number.

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -92,6 +92,11 @@ pub enum DaemonEvent {
         #[serde(default)]
         network: Option<NetworkMetrics>,
     },
+    TopicDebugData {
+        dataflow_id: DataflowId,
+        subscription_id: uuid::Uuid,
+        payload: Vec<u8>,
+    },
     /// Daemon acknowledges state catch-up through a given sequence number.
     StateCatchUpAck {
         dataflow_id: DataflowId,
@@ -197,4 +202,6 @@ pub enum DaemonCoordinatorReply {
     StopNodeResult(Result<(), String>),
     SetParamResult(Result<(), String>),
     DeleteParamResult(Result<(), String>),
+    StartTopicDebugStreamResult(Result<(), String>),
+    StopTopicDebugStreamResult(Result<(), String>),
 }

--- a/libraries/message/src/daemon_to_coordinator.rs
+++ b/libraries/message/src/daemon_to_coordinator.rs
@@ -92,6 +92,10 @@ pub enum DaemonEvent {
         #[serde(default)]
         network: Option<NetworkMetrics>,
     },
+    /// Topic debug payload destined for one or more active CLI subscriptions.
+    ///
+    /// Daemon and coordinator are co-deployed from the same build, so this
+    /// multi-subscriber shape is safe to evolve within the repository.
     TopicDebugData {
         dataflow_id: DataflowId,
         subscription_ids: Vec<uuid::Uuid>,

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -1,8 +1,8 @@
 //! End-to-end tests: coordinator + CLI WsSession over real WebSocket connections.
 //!
-//! `WsSession` creates its own tokio runtime internally (`block_on`), so these
-//! tests run the coordinator on a background thread and use `WsSession` from
-//! the main test thread (no nested runtimes).
+//! `WsSession` creates its own tokio runtime internally, so these tests run the
+//! coordinator on a background thread and use `WsSession` from the main test
+//! thread (no nested runtimes).
 //!
 //! Tests in the `real_dataflow` module use full coordinator+daemon+node stack
 //! via `dora up` CLI to test the complete lifecycle.
@@ -10,8 +10,14 @@
 use dora_cli::WsSession;
 use dora_coordinator::dora_coordinator_store::{DataflowRecord, DataflowStatus};
 use dora_coordinator::{CoordinatorStore, InMemoryStore};
-use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
+use dora_message::{
+    cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply,
+    current_crate_version, ws_protocol::WsRequest,
+};
+use futures::{SinkExt, StreamExt};
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
+use tokio_tungstenite::accept_async;
+use uuid::Uuid;
 
 /// Start a coordinator on a background tokio runtime. Returns the bound port.
 fn start_coordinator_background() -> u16 {
@@ -73,6 +79,101 @@ fn seed_dataflow_record(store: &dyn CoordinatorStore, dataflow_id: uuid::Uuid, n
         updated_at: 0,
     };
     store.put_dataflow(&record).expect("seed dataflow record");
+}
+
+/// Start a minimal control websocket server that acks `TopicSubscribe` and
+/// later pushes a binary frame on the same connection.
+fn start_mock_topic_server(subscription_id: Uuid, payload: Vec<u8>) -> u16 {
+    async fn handle_mock_control_ws<S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin>(
+        socket: tokio_tungstenite::WebSocketStream<S>,
+        subscription_id: Uuid,
+        payload: Vec<u8>,
+    ) {
+        use tokio_tungstenite::tungstenite::Message;
+
+        let (mut ws_tx, mut ws_rx) = socket.split();
+        while let Some(message) = ws_rx.next().await {
+            let Ok(Message::Text(text)) = message else {
+                continue;
+            };
+            let request: WsRequest = serde_json::from_str(&text).expect("parse WsRequest");
+            let control_request: ControlRequest =
+                serde_json::from_value(request.params).expect("parse control request");
+            match control_request {
+                ControlRequest::Hello { .. } => {
+                    let reply = ControlRequestReply::HelloOk {
+                        dora_version: current_crate_version(),
+                    };
+                    let response = serde_json::json!({
+                        "id": request.id,
+                        "result": reply,
+                    });
+                    ws_tx
+                        .send(Message::Text(response.to_string().into()))
+                        .await
+                        .expect("send hello reply");
+                }
+                ControlRequest::TopicSubscribe { .. } => {
+                    let reply = ControlRequestReply::TopicSubscribed { subscription_id };
+                    let response = serde_json::json!({
+                        "id": request.id,
+                        "result": reply,
+                    });
+                    ws_tx
+                        .send(Message::Text(response.to_string().into()))
+                        .await
+                        .expect("send topic subscribe reply");
+
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    let mut frame = subscription_id.as_bytes().to_vec();
+                    frame.extend_from_slice(&payload);
+                    ws_tx
+                        .send(Message::Binary(frame.into()))
+                        .await
+                        .expect("send binary frame");
+                    break;
+                }
+                other => panic!("unexpected control request: {other:?}"),
+            }
+        }
+    }
+
+    let (port_tx, port_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create mock topic runtime");
+
+        rt.block_on(async move {
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("bind mock topic server");
+            let port = listener.local_addr().expect("mock local addr").port();
+            port_tx.send(port).expect("send mock server port");
+            loop {
+                let (stream, _) = listener.accept().await.expect("accept mock topic client");
+                let payload = payload.clone();
+                tokio::spawn(async move {
+                    let ws_stream = accept_async(stream).await.expect("accept websocket");
+                    handle_mock_control_ws(ws_stream, subscription_id, payload).await;
+                });
+            }
+        });
+    });
+
+    let port = port_rx.recv().expect("receive mock topic port");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            panic!("mock topic server did not become ready within 2s");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    port
 }
 
 /// Helper: send a ControlRequest via WsSession and deserialize the reply.
@@ -168,6 +269,29 @@ fn cli_multiple_requests_same_session() {
         }
         other => panic!("expected ConnectedDaemons, got {other:?}"),
     }
+}
+
+#[test]
+fn cli_topic_subscription_receives_binary_frames_after_subscribe_returns() {
+    let subscription_id = Uuid::new_v4();
+    let expected_payload = b"topic-payload".to_vec();
+    let port = start_mock_topic_server(subscription_id, expected_payload.clone());
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+    let session = WsSession::connect(addr).expect("failed to connect WsSession");
+
+    let (received_subscription_id, data_rx) = session
+        .subscribe_topics(
+            Uuid::new_v4(),
+            vec![("node".to_string().into(), "output".to_string().into())],
+        )
+        .expect("subscribe topics");
+
+    assert_eq!(received_subscription_id, subscription_id);
+    let payload = data_rx
+        .recv_timeout(std::time::Duration::from_secs(2))
+        .expect("receive topic payload")
+        .expect("topic payload should be ok");
+    assert_eq!(payload, expected_payload);
 }
 
 // -- Phase 2: Node control error paths via WsSession --

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -123,8 +123,6 @@ fn start_mock_topic_server(subscription_id: Uuid, payload: Vec<u8>) -> u16 {
                         .send(Message::Text(response.to_string().into()))
                         .await
                         .expect("send topic subscribe reply");
-
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                     let mut frame = subscription_id.as_bytes().to_vec();
                     frame.extend_from_slice(&payload);
                     ws_tx
@@ -272,7 +270,7 @@ fn cli_multiple_requests_same_session() {
 }
 
 #[test]
-fn cli_topic_subscription_receives_binary_frames_after_subscribe_returns() {
+fn cli_topic_subscription_receives_binary_frames_immediately_after_subscribe_ack() {
     let subscription_id = Uuid::new_v4();
     let expected_payload = b"topic-payload".to_vec();
     let port = start_mock_topic_server(subscription_id, expected_payload.clone());


### PR DESCRIPTION
## Summary
- replace coordinator-side Zenoh topic inspection with a daemon->coordinator->CLI websocket stream for , , and 
- keep topic publish on the existing path while removing the user-facing requirement that inspection depends on 
- fix  so background websocket streaming continues after synchronous subscribe calls return, and add a regression test for late binary-frame delivery

## Why
Fixes #236. The original failure mode was late topic inspection subscribers attaching after the daemon publisher was already active and never receiving data. This patch removes that dependency from the CLI inspection path.

## Validation
- 
- 
running 1 test
test cli_topic_subscription_receives_binary_frames_after_subscribe_returns ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 15 filtered out; finished in 0.11s
- 
running 12 tests
test command::topic::hz::tests::parse_window_one ... ok
test command::topic::hz::tests::parse_window_valid ... ok
test command::topic::hz::tests::parse_window_non_numeric ... ok
test command::topic::hz::tests::parse_window_zero ... ok
test ws_client::tests::handle_response_topic_subscribe_ack ... ok
test command::tests::parse_topic_list ... ok
test command::tests::parse_topic_echo ... ok
test command::tests::parse_topic_hz ... ok
test command::tests::parse_topic_pub ... ok
test command::tests::parse_record_with_topics ... ok
test command::tests::reject_topic_pub_no_data_or_file ... ok
test command::tests::parse_topic_pub_with_file ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 120 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
running 1 test
test tests::start_topic_debug_stream_targets_source_daemon ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 27 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 22 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.00s
- 
running 27 tests
test log::tests::log_path_format ... ok
test log::tests::log_path_rotated_format ... ok
test fault_tolerance_tests::param_delete_fails_on_closed_channel ... ok
test fault_tolerance_tests::param_delete_delivered_to_node ... ok
test fault_tolerance_tests::param_update_fails_on_closed_channel ... ok
test running_dataflow::tests::armed_deadline_past_timeout_is_timed_out ... ok
test running_dataflow::tests::armed_deadline_within_timeout_is_not_timed_out ... ok
test running_dataflow::tests::arming_a_previously_unarmed_deadline_starts_the_clock ... ok
test running_dataflow::tests::submit_to_dropped_receiver_returns_false ... ok
test fault_tolerance_tests::param_update_delivered_to_node ... ok
test running_dataflow::tests::submit_to_live_receiver_succeeds ... ok
test running_dataflow::tests::two_independent_channels_do_not_cross_deliver ... ok
test spawn::command::tests::shlex_rejects_unmatched_quote ... ok
test spawn::command::tests::shlex_splits_quoted_args ... ok
test fault_tolerance_tests::close_input_on_already_broken_input ... ok
test fault_tolerance_tests::close_input_sends_all_inputs_closed ... ok
test fault_tolerance_tests::close_input_deferred_by_broken_inputs ... ok
test fault_tolerance_tests::break_input_sends_input_closed ... ok
test fault_tolerance_tests::close_input_removes_from_open_inputs ... ok
test fault_tolerance_tests::break_input_defers_all_inputs_closed ... ok
test fault_tolerance_tests::circuit_breaker_recovery ... ok
test fault_tolerance_tests::full_circuit_breaker_cycle ... ok
test log::tests::rotate_noop_when_no_files ... ok
test log::tests::rotate_creates_dot_1_from_current ... ok
test log::tests::rotate_shifts_existing_files ... ok
test log::tests::rotate_deletes_oldest_beyond_max ... ok
test running_dataflow::tests::unarmed_deadline_is_never_timed_out ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
- 
