### PR TITLE
ci(nightly): topic echo/hz smoke + #236 regression guard

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -309,9 +309,10 @@ jobs:
 
   topic-and-top-smoke:
     # Smoke-tests the inspection commands: `dora top --once`, `dora topic
-    # list/info/pub`. Each has a non-interactive mode (--once / built-in
-    # exit / --duration / --count). `topic echo` and `topic hz` stream
-    # without bound — tracked separately, need --duration/--count flags.
+    # list/info/echo/hz/pub`. Each has a non-interactive mode (--once /
+    # built-in exit / --duration / --count). Topic inspection (echo/hz/info)
+    # streams over the coordinator WebSocket (PR #238) — requires
+    # `_unstable_debug.publish_all_messages_to_zenoh: true` in the fixture.
     #
     # Uses Python source nodes (ticker.py / sink.py) so the dataflow runs
     # indefinitely until stopped (rust-dataflow nodes hit tick limits).
@@ -389,6 +390,38 @@ jobs:
         run: |
           dora topic info -d tui-smoke ticker/count --duration 3 2>&1 | tee info.out
           grep -q 'ticker/count' info.out || { echo "ERROR: info output missing topic"; exit 1; }
+          # Assert messages actually flowed. Pre-#238 this step passed with
+          # `Total messages: 0` because the zenoh late-subscribe path dropped
+          # frames silently. Guard against regression.
+          total=$(grep -oE 'Total messages: [0-9]+' info.out | grep -oE '[0-9]+' || echo 0)
+          if [ "$total" -lt 10 ]; then
+            echo "ERROR: info received $total messages in 3s on a 10Hz fixture; expected >= 10"
+            exit 1
+          fi
+      - name: dora topic echo --count 5 (JSON frames)
+        run: |
+          # Tests the CLI-side WebSocket subscription path end-to-end (#238).
+          # Fixture emits at 10 Hz, so 5 frames arrive in ~500ms — generous
+          # 15s timeout protects against daemon startup delay.
+          timeout 15 dora topic echo -d tui-smoke ticker/count --count 5 --format json \
+            2>&1 | tee echo.out
+          lines=$(grep -c '"name":"ticker/count"' echo.out || echo 0)
+          if [ "$lines" -lt 5 ]; then
+            echo "ERROR: echo --count 5 produced $lines frames; expected 5"
+            exit 1
+          fi
+      - name: dora topic hz --duration 3 (non-TTY stats)
+        run: |
+          # --duration mode skips ratatui and prints a tab-separated stats
+          # table. The "ALL" row aggregates across all subscribed topics.
+          dora topic hz -d tui-smoke ticker/count --duration 3 2>&1 | tee hz.out
+          # Fixture is 10 Hz; expect ~30 samples in 3 seconds. Accept >= 10
+          # to absorb scheduler jitter on slow runners.
+          samples=$(awk -F'\t' '/^ticker\/count/ { print $NF }' hz.out)
+          if [ -z "$samples" ] || [ "$samples" -lt 10 ]; then
+            echo "ERROR: hz received ${samples:-0} samples in 3s on a 10Hz fixture; expected >= 10"
+            exit 1
+          fi
       - name: dora topic pub --count 3
         run: |
           dora topic pub -d tui-smoke ticker/count '42' --count 3 2>&1 | tee pub.out

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -135,10 +135,9 @@ Not automated: requires two networked hosts.
 
 Tracked in issue #215. Selected items:
 
-- `dora topic echo` and `dora topic hz` — stream forever, need bounded modes
-  (filed as #233)
 - `dora trace list/view`
 - `dora self update`
+- `dora top` interactive mode (non-`--once`)
 
 Most of these are interactive TUI commands that need either non-interactive
 modes or an expect-style harness. Opening separate issues as we pick them
@@ -150,7 +149,9 @@ These were on the gap list but now have nightly coverage in
 `topic-and-top-smoke`:
 - `dora top --once` (JSON snapshot)
 - `dora topic list --format json` (NDJSON parse)
-- `dora topic info --duration N`
+- `dora topic info --duration N` (asserts `Total messages >= 10` on 10Hz fixture — regression guard for #236)
+- `dora topic echo --count N` (asserts N frames of correct topic name)
+- `dora topic hz --duration N` (asserts `samples >= 10` on 10Hz fixture)
 - `dora topic pub --count N`
 
 ## Platform parity


### PR DESCRIPTION
## Summary

Part of #215 thread A (CI smoke for topic echo/hz/info on the WS inspection path, unblocked by #238).

- Add `dora topic echo --count 5` and `dora topic hz --duration 3` steps to the nightly `topic-and-top-smoke` job
- Strengthen the existing `dora topic info --duration 3` step to assert `Total messages >= 10` on a 10Hz fixture — the pre-#238 bug passed this step with `Total messages: 0` because zenoh silently dropped frames
- Update the job's header comment to reflect the WS inspection architecture
- Update `docs/testing-matrix.md`: remove echo/hz from "NOT covered", add them to `topic-and-top-smoke` coverage list with the regression-guard assertions

## Why nightly and not Tier 0

The WS inspection path is new (just landed in #238). Nightly lets us catch regressions without adding a new ~2-minute job to every push. Promote to Tier 0 after 3 consecutive green nightlies per the existing promotion policy (`docs/testing-matrix.md:176`).

## Validation (local)

Ran against `tests/fixtures/zenoh-debug-dataflow.yml` with the merged #238 CLI:

```
=== echo ===
{"timestamp":..,"name":"ticker/count","data":[29],"metadata":null}
{"timestamp":..,"name":"ticker/count","data":[30],"metadata":null}
{"timestamp":..,"name":"ticker/count","data":[31],"metadata":null}
=== hz ===
topic            avg_ms  avg_hz  min_ms  max_ms  std_ms  samples
ALL              100.04  10.00   77.32   124.61  6.56    30
ticker/count     100.04  10.00   77.32   124.61  6.56    30
=== info ===
Statistics:
  Total messages: 30
```

All three assertions pass.

## Test plan

- [x] Local repro against live coordinator+daemon with #238 CLI
- [ ] Nightly run completes with new steps green
- [ ] 3 consecutive green nightlies → eligible for Tier 0 promotion (follow-up)
