### PR TITLE
refactor: rename publish_all_messages_to_zenoh → enable_debug_inspection (#240)

### DIFF
--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -189,7 +189,7 @@ impl Executable for Run {
             .expand(working_dir)
             .wrap_err("failed to expand modules in dataflow descriptor")?;
         if self.debug {
-            dataflow_descriptor.debug.publish_all_messages_to_zenoh = true;
+            dataflow_descriptor.debug.enable_debug_inspection = true;
         }
 
         // Validate: dora run doesn't support deploy keys

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -131,7 +131,7 @@ fn start_dataflow(
         DataflowSession::read_session(&dataflow).context("failed to read DataflowSession")?;
 
     if debug {
-        dataflow_descriptor.debug.publish_all_messages_to_zenoh = true;
+        dataflow_descriptor.debug.enable_debug_inspection = true;
     }
 
     let session = connect_to_coordinator(coordinator_socket)?;

--- a/binaries/cli/src/command/topic/echo.rs
+++ b/binaries/cli/src/command/topic/echo.rs
@@ -25,7 +25,7 @@ use crate::{
 ///
 /// ```yaml
 /// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
+///   enable_debug_inspection: true
 /// ```
 ///
 /// Examples:
@@ -127,7 +127,7 @@ fn inspect(
                 }
                 if !hint_shown {
                     eprintln!(
-                        "{}: no topic data received during the wait window. Ensure `_unstable_debug.publish_all_messages_to_zenoh: true` is enabled on the dataflow.",
+                        "{}: no topic data received during the wait window. Ensure `_unstable_debug.enable_debug_inspection: true` is enabled on the dataflow.",
                         "hint".yellow().bold(),
                     );
                     hint_shown = true;

--- a/binaries/cli/src/command/topic/hz.rs
+++ b/binaries/cli/src/command/topic/hz.rs
@@ -30,7 +30,7 @@ use crate::{
 ///
 /// ```yaml
 /// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
+///   enable_debug_inspection: true
 /// ```
 ///
 /// If no `DATA` is provided, all outputs from the selected dataflow will be

--- a/binaries/cli/src/command/topic/info.rs
+++ b/binaries/cli/src/command/topic/info.rs
@@ -24,7 +24,7 @@ use crate::{
 ///
 /// ```yaml
 /// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
+///   enable_debug_inspection: true
 /// ```
 ///
 /// Examples:

--- a/binaries/cli/src/command/topic/pub_.rs
+++ b/binaries/cli/src/command/topic/pub_.rs
@@ -21,7 +21,7 @@ use eyre::{Context, bail};
 ///
 /// ```yaml
 /// _unstable_debug:
-///   publish_all_messages_to_zenoh: true
+///   enable_debug_inspection: true
 /// ```
 ///
 /// Examples:

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -2235,7 +2235,7 @@ fn topic_debug_enabled(
     let dataflow = running_dataflows
         .get(&dataflow_id)
         .wrap_err_with(|| format!("no running dataflow with ID `{dataflow_id}`"))?;
-    Ok(dataflow.descriptor.debug.publish_all_messages_to_zenoh)
+    Ok(dataflow.descriptor.debug.enable_debug_inspection)
 }
 
 async fn start_topic_debug_stream(
@@ -2249,7 +2249,8 @@ async fn start_topic_debug_stream(
     let outputs_by_daemon = topic_outputs_by_daemon(running_dataflows, dataflow_id, &topics)?;
     if !topic_debug_enabled(running_dataflows, dataflow_id)? {
         eyre::bail!(
-            "topic inspection requires `_unstable_debug.publish_all_messages_to_zenoh: true`"
+            "topic inspection requires `_unstable_debug.enable_debug_inspection: true` \
+             (the flag was previously named `publish_all_messages_to_zenoh`; the old name is still accepted)"
         );
     }
     let subscription_id = Uuid::new_v4();
@@ -3278,7 +3279,7 @@ mod tests {
 
         let mut running_dataflows = HashMap::new();
         let mut dataflow = test_running_dataflow(dataflow_id, daemon_id, node_id.clone());
-        dataflow.descriptor.debug.publish_all_messages_to_zenoh = true;
+        dataflow.descriptor.debug.enable_debug_inspection = true;
         running_dataflows.insert(dataflow_id, dataflow);
         let expected_node_id = node_id.clone();
         let expected_data_id = data_id.clone();
@@ -3410,7 +3411,7 @@ mod tests {
         let mut running_dataflows = HashMap::new();
         let mut dataflow =
             test_running_dataflow(dataflow_id, daemon_id_a.clone(), node_id_a.clone());
-        dataflow.descriptor.debug.publish_all_messages_to_zenoh = true;
+        dataflow.descriptor.debug.enable_debug_inspection = true;
         dataflow
             .node_to_daemon
             .insert(node_id_b.clone(), daemon_id_b.clone());

--- a/binaries/coordinator/src/ws_control.rs
+++ b/binaries/coordinator/src/ws_control.rs
@@ -305,7 +305,7 @@ pub(crate) async fn handle_control_ws(
                             let resp = WsResponse::err(
                                 req.id,
                                 format!(
-                                    "dataflow {dataflow_id} not found, output unavailable, or topic publish requires `_unstable_debug.publish_all_messages_to_zenoh: true`"
+                                    "dataflow {dataflow_id} not found, output unavailable, or topic publish requires `_unstable_debug.enable_debug_inspection: true` (previously named `publish_all_messages_to_zenoh`; old name is still accepted)"
                                 ),
                             );
                             let _ = send_ws_response(&mut ws_tx, &resp).await;

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -572,7 +572,7 @@ impl Daemon {
 
         let mut descriptor = read_as_descriptor(dataflow_path).await?;
         if debug {
-            descriptor.debug.publish_all_messages_to_zenoh = true;
+            descriptor.debug.enable_debug_inspection = true;
         }
         if let Some(node) = descriptor.nodes.iter().find(|n| n.deploy.is_some()) {
             eyre::bail!(
@@ -2931,7 +2931,7 @@ impl Daemon {
         })?;
         let output_id_key = OutputId(node_id.clone(), output_id.clone());
         let remote_receivers = dataflow.open_external_mappings.contains(&output_id_key)
-            || dataflow.publish_all_messages_to_zenoh;
+            || dataflow.enable_debug_inspection;
         let has_debug_watchers = dataflow.debug_topic_watchers.contains_key(&output_id_key);
         let data_bytes = send_output_to_local_receivers(
             node_id.clone(),

--- a/binaries/daemon/src/running_dataflow.rs
+++ b/binaries/daemon/src/running_dataflow.rs
@@ -207,7 +207,7 @@ pub struct RunningDataflow {
     /// Shutdown signal for listener loops — send `true` when dataflow finishes.
     pub(crate) listener_shutdown_tx: tokio::sync::watch::Sender<bool>,
     pub(crate) listener_shutdown_rx: tokio::sync::watch::Receiver<bool>,
-    pub(crate) publish_all_messages_to_zenoh: bool,
+    pub(crate) enable_debug_inspection: bool,
     /// Cross-daemon Zenoh network counters
     pub(crate) net_bytes_sent: Arc<AtomicU64>,
     pub(crate) net_bytes_received: Arc<AtomicU64>,
@@ -263,7 +263,7 @@ impl RunningDataflow {
             finished_tx,
             listener_shutdown_tx,
             listener_shutdown_rx,
-            publish_all_messages_to_zenoh: dataflow_descriptor.debug.publish_all_messages_to_zenoh,
+            enable_debug_inspection: dataflow_descriptor.debug.enable_debug_inspection,
             descriptor: dataflow_descriptor,
             net_bytes_sent: Default::default(),
             net_bytes_received: Default::default(),

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,7 +184,7 @@ nodes:
 
 # Debug settings
 _unstable_debug:
-  publish_all_messages_to_zenoh: true   # required for topic echo/hz/info
+  enable_debug_inspection: true   # required for topic echo/hz/info
 ```
 
 ### Built-in Timer Nodes
@@ -275,7 +275,7 @@ dora run <PATH> [OPTIONS]
 | `<PATH>` | required | Path to dataflow descriptor YAML |
 | `--stop-after <DURATION>` | | Auto-stop after duration (e.g., `30s`, `5m`) |
 | `--uv` | false | Use `uv` for Python node management |
-| `--debug` | false | Enable debug topics (equivalent to `publish_all_messages_to_zenoh: true`) |
+| `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--allow-shell-nodes` | false | Enable shell-based node execution |
 | `--log-level <LEVEL>` | `stdout` | Min display level: `error\|warn\|info\|debug\|trace\|stdout` |
 | `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact` |
@@ -367,7 +367,7 @@ dora start <PATH> [OPTIONS]
 | `--name <NAME>`, `-n` | | Assign a name to the dataflow |
 | `--attach` | auto | Attach to log stream and wait for completion |
 | `--detach` | auto | Return immediately after spawn |
-| `--debug` | false | Enable debug topics (equivalent to `publish_all_messages_to_zenoh: true`) |
+| `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--hot-reload` | false | Watch Python files and reload on change |
 | `--uv` | false | Use `uv` for Python nodes |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
@@ -443,7 +443,7 @@ dora record <DATAFLOW_YAML> [OPTIONS]
 | `--proxy` | false | Stream via WebSocket instead of recording on target |
 | `--output-yaml <PATH>` | | Write modified YAML without running (dry run) |
 
-Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `publish_all_messages_to_zenoh: true`.
+Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `enable_debug_inspection: true`.
 
 #### `dora replay`
 
@@ -604,7 +604,7 @@ dora topic echo [OPTIONS] [DATA...]
 | `[DATA...]` | all outputs | Topics to echo (e.g., `node1/output`) |
 | `--format <FMT>` | `table` | Output format: `table\|json` |
 
-Requires `_unstable_debug.publish_all_messages_to_zenoh: true` in the descriptor.
+Requires `_unstable_debug.enable_debug_inspection: true` in the descriptor.
 
 #### `dora topic hz`
 
@@ -739,7 +739,7 @@ dora node disconnect <SOURCE/OUTPUT> <TARGET/INPUT> [OPTIONS]
 
 #### `dora topic pub`
 
-Publish JSON data to a topic in a running dataflow. Requires `publish_all_messages_to_zenoh: true`.
+Publish JSON data to a topic in a running dataflow. Requires `enable_debug_inspection: true`.
 
 ```
 dora topic pub <TOPIC> [DATA] [OPTIONS]
@@ -1559,12 +1559,12 @@ State is persisted to `~/.dora/coordinator.redb`. On restart, stale dataflows ar
 - Run `dora up` first, or check `DORA_COORDINATOR_ADDR`/`DORA_COORDINATOR_PORT`
 - Verify with `dora status`
 
-**"publish_all_messages_to_zenoh not enabled"**
+**"enable_debug_inspection not enabled"**
 - Use `--debug` flag: `dora start dataflow.yml --debug` or `dora run dataflow.yml --debug`
 - Or add to your dataflow YAML:
   ```yaml
   _unstable_debug:
-    publish_all_messages_to_zenoh: true
+    enable_debug_inspection: true
   ```
 - Required for `topic echo`, `topic hz`, `topic info`
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -55,7 +55,7 @@ dora run dataflow.yml --debug
 
 ```yaml
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 ```
 
 This tells the daemon to publish all inter-node messages to Zenoh, where the coordinator can proxy them to CLI clients via WebSocket. Without this flag, topic inspection commands will return an error.
@@ -162,7 +162,7 @@ How proxy mode works:
 4. Message data streams through WebSocket binary frames to the CLI
 5. The CLI writes the `.adorec` file locally
 
-This requires `publish_all_messages_to_zenoh: true` in the descriptor.
+This requires `enable_debug_inspection: true` in the descriptor.
 
 **When to use `--proxy`:**
 - Embedded targets with no local disk
@@ -172,7 +172,7 @@ This requires `publish_all_messages_to_zenoh: true` in the descriptor.
 **When to use default mode (no `--proxy`):**
 - Same machine or shared filesystem
 - High-throughput scenarios (no WebSocket overhead)
-- No need for `publish_all_messages_to_zenoh`
+- No need for `enable_debug_inspection`
 
 ### Replaying a Recording
 
@@ -304,7 +304,7 @@ dora node stop -d my-dataflow camera --grace 5s
 
 ## Topic Inspection
 
-Topic inspection commands subscribe to live dataflow messages via the coordinator's WebSocket proxy. They require `--debug` flag or `publish_all_messages_to_zenoh: true`.
+Topic inspection commands subscribe to live dataflow messages via the coordinator's WebSocket proxy. They require `--debug` flag or `enable_debug_inspection: true`.
 
 ### Listing Topics
 
@@ -316,7 +316,7 @@ dora topic list -d my-dataflow
 dora topic list -d my-dataflow --format json
 ```
 
-Shows each output, which node publishes it, and which nodes subscribe to it. This command reads from the descriptor and does **not** require `publish_all_messages_to_zenoh`.
+Shows each output, which node publishes it, and which nodes subscribe to it. This command reads from the descriptor and does **not** require `enable_debug_inspection`.
 
 ### Echoing Topic Data
 
@@ -364,7 +364,7 @@ Press `q` or Ctrl-C to exit. Requires an interactive terminal.
 
 ### Publishing Test Data
 
-Inject data into a running dataflow for testing. Requires `publish_all_messages_to_zenoh: true`.
+Inject data into a running dataflow for testing. Requires `enable_debug_inspection: true`.
 
 ```bash
 # Publish a single Arrow array

--- a/docs/websocket-topic-data-channel.md
+++ b/docs/websocket-topic-data-channel.md
@@ -138,7 +138,7 @@ CLI                         WsSession                     Coordinator
 
 ### Coordinator internals
 
-1. **Validation**: `ControlEvent::TopicSubscribe` is sent to the coordinator event loop, which checks that the dataflow exists and has `publish_all_messages_to_zenoh: true` enabled
+1. **Validation**: `ControlEvent::TopicSubscribe` is sent to the coordinator event loop, which checks that the dataflow exists and has `enable_debug_inspection: true` enabled
 2. **Lazy Zenoh**: The coordinator's Zenoh session is opened on the first `TopicSubscribe` request and reused for subsequent subscriptions on the same WS connection
 3. **Per-topic tasks**: Each `(node_id, data_id)` pair spawns a tokio task that subscribes to the corresponding Zenoh topic and forwards samples to the binary frame channel
 4. **Backpressure**: The binary frame channel has capacity 64. `try_send` is used -- if the channel is full (slow consumer), samples are silently dropped rather than blocking the Zenoh subscriber
@@ -166,12 +166,12 @@ The dataflow descriptor must enable debug message publishing:
 
 ```yaml
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 ```
 
 Without this, the coordinator rejects the `TopicSubscribe` with:
 ```
-dataflow {id} not found or publish_all_messages_to_zenoh not enabled
+dataflow {id} not found or enable_debug_inspection not enabled
 ```
 
 ---
@@ -269,7 +269,7 @@ For high-throughput topics (camera images, point clouds), the binary frame chann
 | Error | Source | Response |
 |-------|--------|----------|
 | Dataflow not found | Coordinator validation | WsResponse with error message |
-| `publish_all_messages_to_zenoh` not enabled | Coordinator validation | WsResponse with error message |
+| `enable_debug_inspection` not enabled | Coordinator validation | WsResponse with error message |
 | Zenoh session open failure | Coordinator | WsResponse with error message |
 | Zenoh subscriber failure | Per-topic task | Warning log, task exits |
 | Binary frame too short (<16 bytes) | CLI session_loop | Warning log, frame dropped |

--- a/docs/yaml-spec.md
+++ b/docs/yaml-spec.md
@@ -486,7 +486,7 @@ QoS can be set at the bridge level (applies to all topics) or per-topic:
 
 ```yaml
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 ```
 
 Required for `dora topic echo`, `dora topic hz`, and `dora topic info` commands.
@@ -508,7 +508,7 @@ See [Communication Patterns](../../../docs/patterns.md) for details and examples
 health_check_interval: 10.0
 
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 
 nodes:
   - id: webcam

--- a/dora-schema.json
+++ b/dora-schema.json
@@ -579,8 +579,13 @@
       "description": "Debug options for development.",
       "type": "object",
       "properties": {
+        "enable_debug_inspection": {
+          "description": "Mirror every node output to the coordinator WebSocket so `dora topic echo/hz/info` can inspect runtime messages. Previously named `publish_all_messages_to_zenoh`; the old name is still accepted as an alias for backward compatibility.",
+          "type": "boolean",
+          "default": false
+        },
         "publish_all_messages_to_zenoh": {
-          "description": "Publish all messages to Zenoh for debugging (required for `dora topic echo/hz/info`).",
+          "description": "Deprecated alias for `enable_debug_inspection`. Still accepted for backward compatibility; will be removed in a future release.",
           "type": "boolean",
           "default": false
         }

--- a/guide/po/messages.pot
+++ b/guide/po/messages.pot
@@ -5497,7 +5497,7 @@ msgstr ""
 #: src/concepts/dataflow-yaml.md:489 src/concepts/dataflow-yaml.md:511
 #: src/operations/cli.md:187 src/operations/cli.md:1515
 #: src/operations/debugging.md:58 src/advanced/ws-topic.md:169
-msgid "publish_all_messages_to_zenoh"
+msgid "enable_debug_inspection"
 msgstr ""
 
 #: src/concepts/dataflow-yaml.md:492
@@ -11952,7 +11952,7 @@ msgid "`--debug`"
 msgstr ""
 
 #: src/operations/cli.md:278 src/operations/cli.md:361
-msgid "Enable debug topics (equivalent to `publish_all_messages_to_zenoh: true`)"
+msgid "Enable debug topics (equivalent to `enable_debug_inspection: true`)"
 msgstr ""
 
 #: src/operations/cli.md:279
@@ -12410,7 +12410,7 @@ msgstr ""
 #: src/operations/cli.md:437
 msgid ""
 "Default mode injects a record node into the dataflow. `--proxy` mode "
-"requires a running dataflow and `publish_all_messages_to_zenoh: true`."
+"requires a running dataflow and `enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/cli.md:439
@@ -12826,7 +12826,7 @@ msgstr ""
 
 #: src/operations/cli.md:598
 msgid ""
-"Requires `_unstable_debug.publish_all_messages_to_zenoh: true` in the "
+"Requires `_unstable_debug.enable_debug_inspection: true` in the "
 "descriptor."
 msgstr ""
 
@@ -12977,7 +12977,7 @@ msgstr ""
 #: src/operations/cli.md:690
 msgid ""
 "Publish JSON data to a topic in a running dataflow. Requires "
-"`publish_all_messages_to_zenoh: true`."
+"`enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/cli.md:698
@@ -14136,7 +14136,7 @@ msgid "Verify with `dora status`"
 msgstr ""
 
 #: src/operations/cli.md:1510
-msgid "**\"publish_all_messages_to_zenoh not enabled\"**"
+msgid "**\"enable_debug_inspection not enabled\"**"
 msgstr ""
 
 #: src/operations/cli.md:1511
@@ -17164,7 +17164,7 @@ msgid "The CLI writes the `.adorec` file locally"
 msgstr ""
 
 #: src/operations/debugging.md:165
-msgid "This requires `publish_all_messages_to_zenoh: true` in the descriptor."
+msgid "This requires `enable_debug_inspection: true` in the descriptor."
 msgstr ""
 
 #: src/operations/debugging.md:167
@@ -17196,7 +17196,7 @@ msgid "High-throughput scenarios (no WebSocket overhead)"
 msgstr ""
 
 #: src/operations/debugging.md:175
-msgid "No need for `publish_all_messages_to_zenoh`"
+msgid "No need for `enable_debug_inspection`"
 msgstr ""
 
 #: src/operations/debugging.md:177
@@ -17389,7 +17389,7 @@ msgstr ""
 msgid ""
 "Topic inspection commands subscribe to live dataflow messages via the "
 "coordinator's WebSocket proxy. They require `--debug` flag or "
-"`publish_all_messages_to_zenoh: true`."
+"`enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/debugging.md:309
@@ -17404,7 +17404,7 @@ msgstr ""
 msgid ""
 "Shows each output, which node publishes it, and which nodes subscribe to it. "
 "This command reads from the descriptor and does **not** require "
-"`publish_all_messages_to_zenoh`."
+"`enable_debug_inspection`."
 msgstr ""
 
 #: src/operations/debugging.md:321
@@ -17492,7 +17492,7 @@ msgstr ""
 #: src/operations/debugging.md:367
 msgid ""
 "Inject data into a running dataflow for testing. Requires "
-"`publish_all_messages_to_zenoh: true`."
+"`enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/debugging.md:370
@@ -24883,7 +24883,7 @@ msgstr ""
 msgid ""
 "**Validation**: `ControlEvent::TopicSubscribe` is sent to the coordinator "
 "event loop, which checks that the dataflow exists and has "
-"`publish_all_messages_to_zenoh: true` enabled"
+"`enable_debug_inspection: true` enabled"
 msgstr ""
 
 #: src/advanced/ws-topic.md:142
@@ -25135,7 +25135,7 @@ msgid "WsResponse with error message"
 msgstr ""
 
 #: src/advanced/ws-topic.md:272
-msgid "`publish_all_messages_to_zenoh` not enabled"
+msgid "`enable_debug_inspection` not enabled"
 msgstr ""
 
 #: src/advanced/ws-topic.md:273

--- a/guide/po/zh-CN.po
+++ b/guide/po/zh-CN.po
@@ -5768,7 +5768,7 @@ msgstr ""
 #: src/concepts/dataflow-yaml.md:489 src/concepts/dataflow-yaml.md:511
 #: src/operations/cli.md:187 src/operations/cli.md:1515
 #: src/operations/debugging.md:58 src/advanced/ws-topic.md:169
-msgid "publish_all_messages_to_zenoh"
+msgid "enable_debug_inspection"
 msgstr ""
 
 #: src/concepts/dataflow-yaml.md:492
@@ -12400,7 +12400,7 @@ msgstr ""
 
 #: src/operations/cli.md:278 src/operations/cli.md:361
 msgid ""
-"Enable debug topics (equivalent to `publish_all_messages_to_zenoh: true`)"
+"Enable debug topics (equivalent to `enable_debug_inspection: true`)"
 msgstr ""
 
 #: src/operations/cli.md:279
@@ -12858,7 +12858,7 @@ msgstr ""
 #: src/operations/cli.md:437
 msgid ""
 "Default mode injects a record node into the dataflow. `--proxy` mode "
-"requires a running dataflow and `publish_all_messages_to_zenoh: true`."
+"requires a running dataflow and `enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/cli.md:439
@@ -13274,7 +13274,7 @@ msgstr ""
 
 #: src/operations/cli.md:598
 msgid ""
-"Requires `_unstable_debug.publish_all_messages_to_zenoh: true` in the "
+"Requires `_unstable_debug.enable_debug_inspection: true` in the "
 "descriptor."
 msgstr ""
 
@@ -13435,7 +13435,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Publish JSON data to a topic in a running dataflow. Requires "
-"`publish_all_messages_to_zenoh: true`."
+"`enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/cli.md:698
@@ -14620,7 +14620,7 @@ msgid "Verify with `dora status`"
 msgstr ""
 
 #: src/operations/cli.md:1510
-msgid "**\"publish_all_messages_to_zenoh not enabled\"**"
+msgid "**\"enable_debug_inspection not enabled\"**"
 msgstr ""
 
 #: src/operations/cli.md:1511
@@ -17724,7 +17724,7 @@ msgid "The CLI writes the `.adorec` file locally"
 msgstr ""
 
 #: src/operations/debugging.md:165
-msgid "This requires `publish_all_messages_to_zenoh: true` in the descriptor."
+msgid "This requires `enable_debug_inspection: true` in the descriptor."
 msgstr ""
 
 #: src/operations/debugging.md:167
@@ -17756,7 +17756,7 @@ msgid "High-throughput scenarios (no WebSocket overhead)"
 msgstr ""
 
 #: src/operations/debugging.md:175
-msgid "No need for `publish_all_messages_to_zenoh`"
+msgid "No need for `enable_debug_inspection`"
 msgstr ""
 
 #: src/operations/debugging.md:177
@@ -17956,7 +17956,7 @@ msgstr "主题检查"
 msgid ""
 "Topic inspection commands subscribe to live dataflow messages via the "
 "coordinator's WebSocket proxy. They require `--debug` flag or "
-"`publish_all_messages_to_zenoh: true`."
+"`enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/debugging.md:309
@@ -17971,7 +17971,7 @@ msgstr ""
 msgid ""
 "Shows each output, which node publishes it, and which nodes subscribe to it. "
 "This command reads from the descriptor and does **not** require "
-"`publish_all_messages_to_zenoh`."
+"`enable_debug_inspection`."
 msgstr ""
 
 #: src/operations/debugging.md:321
@@ -18061,7 +18061,7 @@ msgstr ""
 #, fuzzy
 msgid ""
 "Inject data into a running dataflow for testing. Requires "
-"`publish_all_messages_to_zenoh: true`."
+"`enable_debug_inspection: true`."
 msgstr ""
 
 #: src/operations/debugging.md:370
@@ -25618,7 +25618,7 @@ msgstr ""
 msgid ""
 "**Validation**: `ControlEvent::TopicSubscribe` is sent to the coordinator "
 "event loop, which checks that the dataflow exists and has "
-"`publish_all_messages_to_zenoh: true` enabled"
+"`enable_debug_inspection: true` enabled"
 msgstr ""
 
 #: src/advanced/ws-topic.md:142
@@ -25870,7 +25870,7 @@ msgid "WsResponse with error message"
 msgstr ""
 
 #: src/advanced/ws-topic.md:272
-msgid "`publish_all_messages_to_zenoh` not enabled"
+msgid "`enable_debug_inspection` not enabled"
 msgstr ""
 
 #: src/advanced/ws-topic.md:273

--- a/guide/src/advanced/ws-topic.md
+++ b/guide/src/advanced/ws-topic.md
@@ -138,7 +138,7 @@ CLI                         WsSession                     Coordinator
 
 ### Coordinator internals
 
-1. **Validation**: `ControlEvent::TopicSubscribe` is sent to the coordinator event loop, which checks that the dataflow exists and has `publish_all_messages_to_zenoh: true` enabled
+1. **Validation**: `ControlEvent::TopicSubscribe` is sent to the coordinator event loop, which checks that the dataflow exists and has `enable_debug_inspection: true` enabled
 2. **Lazy Zenoh**: The coordinator's Zenoh session is opened on the first `TopicSubscribe` request and reused for subsequent subscriptions on the same WS connection
 3. **Per-topic tasks**: Each `(node_id, data_id)` pair spawns a tokio task that subscribes to the corresponding Zenoh topic and forwards samples to the binary frame channel
 4. **Backpressure**: The binary frame channel has capacity 64. `try_send` is used -- if the channel is full (slow consumer), samples are silently dropped rather than blocking the Zenoh subscriber
@@ -166,12 +166,12 @@ The dataflow descriptor must enable debug message publishing:
 
 ```yaml
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 ```
 
 Without this, the coordinator rejects the `TopicSubscribe` with:
 ```
-dataflow {id} not found or publish_all_messages_to_zenoh not enabled
+dataflow {id} not found or enable_debug_inspection not enabled
 ```
 
 ---
@@ -269,7 +269,7 @@ For high-throughput topics (camera images, point clouds), the binary frame chann
 | Error | Source | Response |
 |-------|--------|----------|
 | Dataflow not found | Coordinator validation | WsResponse with error message |
-| `publish_all_messages_to_zenoh` not enabled | Coordinator validation | WsResponse with error message |
+| `enable_debug_inspection` not enabled | Coordinator validation | WsResponse with error message |
 | Zenoh session open failure | Coordinator | WsResponse with error message |
 | Zenoh subscriber failure | Per-topic task | Warning log, task exits |
 | Binary frame too short (<16 bytes) | CLI session_loop | Warning log, frame dropped |

--- a/guide/src/concepts/dataflow-yaml.md
+++ b/guide/src/concepts/dataflow-yaml.md
@@ -486,7 +486,7 @@ QoS can be set at the bridge level (applies to all topics) or per-topic:
 
 ```yaml
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 ```
 
 Required for `dora topic echo`, `dora topic hz`, and `dora topic info` commands.
@@ -508,7 +508,7 @@ See [Communication Patterns](../../../docs/patterns.md) for details and examples
 health_check_interval: 10.0
 
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 
 nodes:
   - id: webcam

--- a/guide/src/operations/cli.md
+++ b/guide/src/operations/cli.md
@@ -184,7 +184,7 @@ nodes:
 
 # Debug settings
 _unstable_debug:
-  publish_all_messages_to_zenoh: true   # required for topic echo/hz/info
+  enable_debug_inspection: true   # required for topic echo/hz/info
 ```
 
 ### Built-in Timer Nodes
@@ -275,7 +275,7 @@ dora run <PATH> [OPTIONS]
 | `<PATH>` | required | Path to dataflow descriptor YAML |
 | `--stop-after <DURATION>` | | Auto-stop after duration (e.g., `30s`, `5m`) |
 | `--uv` | false | Use `uv` for Python node management |
-| `--debug` | false | Enable debug topics (equivalent to `publish_all_messages_to_zenoh: true`) |
+| `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--allow-shell-nodes` | false | Enable shell-based node execution |
 | `--log-level <LEVEL>` | `stdout` | Min display level: `error\|warn\|info\|debug\|trace\|stdout` |
 | `--log-format <FORMAT>` | `pretty` | Output format: `pretty\|json\|compact` |
@@ -358,7 +358,7 @@ dora start <PATH> [OPTIONS]
 | `--name <NAME>`, `-n` | | Assign a name to the dataflow |
 | `--attach` | auto | Attach to log stream and wait for completion |
 | `--detach` | auto | Return immediately after spawn |
-| `--debug` | false | Enable debug topics (equivalent to `publish_all_messages_to_zenoh: true`) |
+| `--debug` | false | Enable debug topics (equivalent to `enable_debug_inspection: true`) |
 | `--hot-reload` | false | Watch Python files and reload on change |
 | `--uv` | false | Use `uv` for Python nodes |
 | `--coordinator-addr <IP>` | `127.0.0.1` | Coordinator address |
@@ -434,7 +434,7 @@ dora record <DATAFLOW_YAML> [OPTIONS]
 | `--proxy` | false | Stream via WebSocket instead of recording on target |
 | `--output-yaml <PATH>` | | Write modified YAML without running (dry run) |
 
-Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `publish_all_messages_to_zenoh: true`.
+Default mode injects a record node into the dataflow. `--proxy` mode requires a running dataflow and `enable_debug_inspection: true`.
 
 #### `dora replay`
 
@@ -595,7 +595,7 @@ dora topic echo [OPTIONS] [DATA...]
 | `[DATA...]` | all outputs | Topics to echo (e.g., `node1/output`) |
 | `--format <FMT>` | `table` | Output format: `table\|json` |
 
-Requires `_unstable_debug.publish_all_messages_to_zenoh: true` in the descriptor.
+Requires `_unstable_debug.enable_debug_inspection: true` in the descriptor.
 
 #### `dora topic hz`
 
@@ -687,7 +687,7 @@ dora node stop <NODE> [OPTIONS]
 
 #### `dora topic pub`
 
-Publish JSON data to a topic in a running dataflow. Requires `publish_all_messages_to_zenoh: true`.
+Publish JSON data to a topic in a running dataflow. Requires `enable_debug_inspection: true`.
 
 ```
 dora topic pub <TOPIC> [DATA] [OPTIONS]
@@ -1507,12 +1507,12 @@ State is persisted to `~/.dora/coordinator.redb`. On restart, stale dataflows ar
 - Run `dora up` first, or check `DORA_COORDINATOR_ADDR`/`DORA_COORDINATOR_PORT`
 - Verify with `dora status`
 
-**"publish_all_messages_to_zenoh not enabled"**
+**"enable_debug_inspection not enabled"**
 - Use `--debug` flag: `dora start dataflow.yml --debug` or `dora run dataflow.yml --debug`
 - Or add to your dataflow YAML:
   ```yaml
   _unstable_debug:
-    publish_all_messages_to_zenoh: true
+    enable_debug_inspection: true
   ```
 - Required for `topic echo`, `topic hz`, `topic info`
 

--- a/guide/src/operations/debugging.md
+++ b/guide/src/operations/debugging.md
@@ -55,7 +55,7 @@ dora run dataflow.yml --debug
 
 ```yaml
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true
 ```
 
 This tells the daemon to publish all inter-node messages to Zenoh, where the coordinator can proxy them to CLI clients via WebSocket. Without this flag, topic inspection commands will return an error.
@@ -162,7 +162,7 @@ How proxy mode works:
 4. Message data streams through WebSocket binary frames to the CLI
 5. The CLI writes the `.adorec` file locally
 
-This requires `publish_all_messages_to_zenoh: true` in the descriptor.
+This requires `enable_debug_inspection: true` in the descriptor.
 
 **When to use `--proxy`:**
 - Embedded targets with no local disk
@@ -172,7 +172,7 @@ This requires `publish_all_messages_to_zenoh: true` in the descriptor.
 **When to use default mode (no `--proxy`):**
 - Same machine or shared filesystem
 - High-throughput scenarios (no WebSocket overhead)
-- No need for `publish_all_messages_to_zenoh`
+- No need for `enable_debug_inspection`
 
 ### Replaying a Recording
 
@@ -304,7 +304,7 @@ dora node stop -d my-dataflow camera --grace 5s
 
 ## Topic Inspection
 
-Topic inspection commands subscribe to live dataflow messages via the coordinator's WebSocket proxy. They require `--debug` flag or `publish_all_messages_to_zenoh: true`.
+Topic inspection commands subscribe to live dataflow messages via the coordinator's WebSocket proxy. They require `--debug` flag or `enable_debug_inspection: true`.
 
 ### Listing Topics
 
@@ -316,7 +316,7 @@ dora topic list -d my-dataflow
 dora topic list -d my-dataflow --format json
 ```
 
-Shows each output, which node publishes it, and which nodes subscribe to it. This command reads from the descriptor and does **not** require `publish_all_messages_to_zenoh`.
+Shows each output, which node publishes it, and which nodes subscribe to it. This command reads from the descriptor and does **not** require `enable_debug_inspection`.
 
 ### Echoing Topic Data
 
@@ -364,7 +364,7 @@ Press `q` or Ctrl-C to exit. Requires an interactive terminal.
 
 ### Publishing Test Data
 
-Inject data into a running dataflow for testing. Requires `publish_all_messages_to_zenoh: true`.
+Inject data into a running dataflow for testing. Requires `enable_debug_inspection: true`.
 
 ```bash
 # Publish a single Arrow array

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -191,9 +191,16 @@ pub enum DistributeStrategy {
 /// Debug options for dataflow development and troubleshooting.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct Debug {
-    /// Whether to publish all messages to Zenoh for debugging
-    #[serde(default)]
-    pub publish_all_messages_to_zenoh: bool,
+    /// When true, daemons mirror every node output to the coordinator WebSocket
+    /// so that `dora topic echo`, `dora topic hz`, and `dora topic info` can
+    /// inspect runtime messages.
+    ///
+    /// The field was previously named `publish_all_messages_to_zenoh` (from
+    /// before the CLI inspection path moved off zenoh in PR #238). Serde still
+    /// accepts the old name as an alias for backward compatibility with
+    /// existing dataflow YAML; the alias will be removed in a future release.
+    #[serde(default, alias = "publish_all_messages_to_zenoh")]
+    pub enable_debug_inspection: bool,
 }
 
 /// # Dora Node Configuration
@@ -1328,5 +1335,34 @@ nodes:
 "#;
         let desc: Descriptor = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(desc.nodes[0].cpu_affinity, None);
+    }
+
+    #[test]
+    fn debug_flag_accepts_new_name() {
+        let yaml = r#"
+nodes:
+  - id: test
+    path: test.py
+_unstable_debug:
+  enable_debug_inspection: true
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).unwrap();
+        assert!(desc.debug.enable_debug_inspection);
+    }
+
+    #[test]
+    fn debug_flag_accepts_legacy_alias() {
+        // Backward-compat regression guard (#240): dataflow YAML in the wild
+        // still uses `publish_all_messages_to_zenoh`. The serde alias must
+        // keep deserializing that into the renamed field.
+        let yaml = r#"
+nodes:
+  - id: test
+    path: test.py
+_unstable_debug:
+  publish_all_messages_to_zenoh: true
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).unwrap();
+        assert!(desc.debug.enable_debug_inspection);
     }
 }

--- a/tests/fixtures/zenoh-debug-dataflow.yml
+++ b/tests/fixtures/zenoh-debug-dataflow.yml
@@ -1,6 +1,7 @@
-# Dataflow with `publish_all_messages_to_zenoh: true` enabled — required
-# for `dora topic echo`, `topic info`, and `topic pub` to inspect/inject
-# runtime messages. Used by the nightly TUI smoke job.
+# Dataflow with `enable_debug_inspection: true` enabled (previously named
+# `publish_all_messages_to_zenoh`) — required for `dora topic echo`,
+# `topic info`, and `topic pub` to inspect/inject runtime messages.
+# Used by the nightly TUI smoke job.
 #
 # Uses Python timer source so the dataflow runs indefinitely until
 # explicitly stopped (rust-dataflow nodes hit their tick limit and exit).
@@ -22,4 +23,4 @@ nodes:
       count: std/core/v1/UInt64
 
 _unstable_debug:
-  publish_all_messages_to_zenoh: true
+  enable_debug_inspection: true


### PR DESCRIPTION
## Summary

Closes #240. The flag `publish_all_messages_to_zenoh` has been misleading since #238 landed — it no longer publishes to zenoh for CLI inspection. It gates the coordinator WebSocket debug stream. Renamed to `enable_debug_inspection`, which reflects what the flag actually does.

## Backward compatibility

The serde alias on the `Debug` struct keeps existing dataflow YAML parsing:

```rust
#[serde(default, alias = "publish_all_messages_to_zenoh")]
pub enable_debug_inspection: bool,
```

Two unit tests in `libraries/message/src/descriptor.rs` lock this in:
- `debug_flag_accepts_new_name` — new spelling works
- `debug_flag_accepts_legacy_alias` — old spelling still deserializes into the new field

## What changed

- **`libraries/message/src/descriptor.rs`** — field rename + serde alias + 2 tests
- **`binaries/{coordinator,daemon,cli}/**.rs`** — every call site updated to the new field name
- **Error messages** in `ws_control.rs` and `coordinator/lib.rs` now mention both names so users hitting the error know the migration happened
- **`docs/*.md`, `guide/src/**/*.md`** — sed rename across all user-facing docs
- **`dora-schema.json`** — documents both names, with the old one flagged as deprecated
- **`tests/fixtures/zenoh-debug-dataflow.yml`** — uses the new name so CI smoke exercises the new path

## Test plan

- [x] `cargo test --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python --exclude dora-cli-api-python --exclude dora-examples` — all pass, no failures
- [x] `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings` — clean (CI invocation)
- [x] `cargo fmt --all -- --check` — clean
- [x] `debug_flag_accepts_legacy_alias` test proves existing YAML files keep working

## Follow-up (out of scope)

Removal of the serde alias itself — do it in a later release once users have had time to migrate. File a tracking issue near that release.
