### PR TITLE
ci(nightly): smoke coverage for dora trace list/view (#215 thread C)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -362,6 +362,35 @@ jobs:
           out=$(dora top --once || true)
           echo "$out"
           echo "$out" | grep -qE '^\[' || { echo "ERROR: top --once didn't produce JSON array"; exit 1; }
+      - name: dora trace list on empty coordinator
+        run: |
+          # With no dataflow run yet, the trace store is empty. The command
+          # must exit 0 and print the canonical empty-state message (not
+          # error, not hang).
+          out=$(dora trace list)
+          echo "$out"
+          echo "$out" | grep -q "No traces captured yet." \
+            || { echo "ERROR: trace list empty-state message missing"; exit 1; }
+      - name: dora trace view with known-absent UUID
+        run: |
+          # Valid UUID that the coordinator has no spans for. Must exit 0
+          # and report the empty-spans message.
+          out=$(dora trace view 00000000-0000-0000-0000-000000000000)
+          echo "$out"
+          echo "$out" | grep -q "No spans found for this trace." \
+            || { echo "ERROR: trace view absent-UUID empty-state message missing"; exit 1; }
+      - name: dora trace view with unresolvable prefix errors clearly
+        run: |
+          # Non-UUID prefix with no matches must exit non-zero and surface
+          # a clear "no trace found" message, not a generic protocol error.
+          if out=$(dora trace view definitely-not-a-trace 2>&1); then
+            echo "ERROR: expected non-zero exit for unresolvable prefix"
+            echo "$out"
+            exit 1
+          fi
+          echo "$out"
+          echo "$out" | grep -q "no trace found matching prefix" \
+            || { echo "ERROR: trace view missing prefix-error message"; exit 1; }
       - name: Start a debug-enabled dataflow
         # The fixture uses Python source nodes (ticker.py / sink.py) so the
         # dataflow runs forever (rust-dataflow-example-node hits a tick limit

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -135,7 +135,6 @@ Not automated: requires two networked hosts.
 
 Tracked in issue #215. Selected items:
 
-- `dora trace list/view`
 - `dora self update`
 - `dora top` interactive mode (non-`--once`)
 
@@ -153,6 +152,9 @@ These were on the gap list but now have nightly coverage in
 - `dora topic echo --count N` (asserts N frames of correct topic name)
 - `dora topic hz --duration N` (asserts `samples >= 10` on 10Hz fixture)
 - `dora topic pub --count N`
+- `dora trace list` (empty-state message)
+- `dora trace view <absent-uuid>` (empty-spans message, exit 0)
+- `dora trace view <bad-prefix>` (clear error message, exit non-zero)
 
 ## Platform parity
 


### PR DESCRIPTION
## Summary

Closes #215 thread C. Adds nightly smoke coverage for `dora trace list` and `dora trace view` — both previously on the "NOT covered" list in `docs/testing-matrix.md`.

## Coverage added

Three steps in the existing `topic-and-top-smoke` nightly job, all against an empty coordinator (no dataflow needed):

1. **`dora trace list`** → asserts "No traces captured yet." empty-state message, exit 0
2. **`dora trace view <absent-uuid>`** → valid UUID with no spans returns "No spans found for this trace.", exit 0 (empty is not error)
3. **`dora trace view <bad-prefix>`** → non-UUID prefix with no matches must exit non-zero with "no trace found matching prefix" — regression guard against a generic protocol error replacing the helpful message

## Why nightly

Same rationale as #243: the command paths are read-only and cheap, but adding three more HTTP round-trips to every PR push isn't worth it. Promotion to Tier 0 eligible after 3 consecutive green nightlies per the existing promotion policy.

## Validation (local)

Ran against `dora coordinator` with no dataflow:

```
=== trace list (empty) ===
No traces captured yet.
=== trace view with unknown uuid ===
No spans found for this trace.
=== trace view with unknown prefix ===
[ERROR]
no trace found matching prefix `nonexistent`
```

All three assertions pass.

## Remaining threads on #215

- Thread B: `dora top` interactive mode — defer, `--once` already covers the data layer
- Thread D: `dora self update` — destructive, needs dedicated sandbox harness

## Test plan

- [x] Local repro against live coordinator
- [ ] Nightly run completes with new steps green
- [ ] 3 consecutive green nightlies → eligible for Tier 0 promotion (follow-up)
