### PR TITLE
ci(nightly): smoke dora self update --check-only (#215 thread D read path)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -391,6 +391,29 @@ jobs:
           echo "$out"
           echo "$out" | grep -q "no trace found matching prefix" \
             || { echo "ERROR: trace view missing prefix-error message"; exit 1; }
+      - name: dora self update --check-only read path
+        # Smokes the read path only (never swaps the binary). Queries the
+        # GitHub releases API for dora-rs/dora and reports whether an
+        # update is available. Catches regressions in CLI flag parsing,
+        # the self_update crate integration, and the API-response contract.
+        run: |
+          out=$(timeout 30 dora self update --check-only 2>&1) || exit_code=$?
+          echo "$out"
+          # Must always print the entry banner — if this is missing, the
+          # command didn't even start the check path.
+          echo "$out" | grep -q "Checking for updates" \
+            || { echo "ERROR: --check-only didn't enter update-check path"; exit 1; }
+          # One of the two valid outcomes must print. If neither appears,
+          # either GitHub rate-limited us (tolerated) or the output format
+          # regressed (fail).
+          if echo "$out" | grep -qE "latest version|update is available"; then
+            echo "OK: check-only produced a valid outcome message"
+          elif echo "$out" | grep -qE "rate limit|403|429"; then
+            echo "WARN: GitHub API rate-limited on shared runner IP — skipping outcome assertion"
+          else
+            echo "ERROR: --check-only produced no recognized outcome message"
+            exit 1
+          fi
       - name: Start a debug-enabled dataflow
         # The fixture uses Python source nodes (ticker.py / sink.py) so the
         # dataflow runs forever (rust-dataflow-example-node hits a tick limit

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -135,7 +135,7 @@ Not automated: requires two networked hosts.
 
 Tracked in issue #215. Selected items:
 
-- `dora self update`
+- `dora self update` (destructive path — binary swap; `--check-only` is covered in nightly but the actual upgrade requires a sandbox harness)
 - `dora top` interactive mode (non-`--once`)
 
 Most of these are interactive TUI commands that need either non-interactive
@@ -155,6 +155,7 @@ These were on the gap list but now have nightly coverage in
 - `dora trace list` (empty-state message)
 - `dora trace view <absent-uuid>` (empty-spans message, exit 0)
 - `dora trace view <bad-prefix>` (clear error message, exit non-zero)
+- `dora self update --check-only` (read-only path against live GitHub releases; tolerates API rate limits)
 
 ## Platform parity
 


### PR DESCRIPTION
## Summary

Closes #215 thread D for the read path. Adds a nightly smoke step for `dora self update --check-only`. The destructive binary-swap path stays uncovered (needs a dedicated sandbox harness) and is documented as such in `testing-matrix.md`.

## What the step checks

1. **Entry banner prints** — `"Checking for updates"` must appear. If missing, the flag parsing or the code path entry is broken.
2. **One of two valid outcomes prints** — either `"latest version"` (already current) or `"update is available"` (current < upstream). Either is success.
3. **Rate-limit tolerance** — GHA runner IPs are shared and can hit GitHub's 60 req/hr unauthenticated limit. If neither outcome prints but rate-limit markers (`403`/`429`/"rate limit") appear, emit a warn and pass the step. A missing-outcome *without* rate-limit markers is treated as a real regression in the `self_update` crate's API contract.

## Local validation

```
$ dora self update --check-only
Checking for updates...
An update is available: 0.5.0. Run 'dora self update' to update
```

Matches the assertions.

## What this catches

- CLI flag parsing regressions (the `--check-only` flag)
- Binary builds with a broken `self_update` dependency
- GitHub API response format changes that break `get_latest_release()` (the `self_update` crate would panic or return an unexpected error)
- Silent "no output" regressions from transport errors

## What this does not catch

- Destructive `dora self update` (actual binary swap) — needs sandbox harness, deferred. Documented in `testing-matrix.md` under "NOT covered".

## Test plan

- [x] Local repro against live GitHub API
- [ ] Nightly run completes with new step green
- [ ] 3 consecutive green nightlies → eligible for Tier 0 promotion (follow-up)
