### PR TITLE
ci: re-enable rust-dataflow-git example (closes #206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,12 +211,9 @@ jobs:
       - name: Rust Dataflow example
         timeout-minutes: 30
         run: cargo run --example rust-dataflow
-      # TODO: re-enable once adora has a published tag with matching message format
-      # The git example pulls upstream dora v0.5.0 (message format v0.8.0) which
-      # is incompatible with adora's message format v0.2.1.
-      # - name: Rust Git Dataflow example
-      #   timeout-minutes: 30
-      #   run: cargo run --example rust-dataflow-git
+      - name: Rust Git Dataflow example
+        timeout-minutes: 30
+        run: cargo run --example rust-dataflow-git
       - name: Multiple Daemons example
         timeout-minutes: 30
         run: cargo run --example multiple-daemons

--- a/examples/rust-dataflow-git/dataflow.yml
+++ b/examples/rust-dataflow-git/dataflow.yml
@@ -1,7 +1,12 @@
+# Smoke-tests git-sourced nodes. Pins to an adora commit (not a released
+# tag) so the example runs against matching message-format versions
+# without needing a release. Update `rev:` when a message-format-breaking
+# change lands on main — otherwise the CI job catches the mismatch and
+# signals a compatibility break, which is the whole point of this test.
 nodes:
   - id: rust-node
-    git: https://github.com/dora-rs/dora.git
-    tag: v0.5.0 # pinned tag, update this when releasing a new version
+    git: https://github.com/dora-rs/adora.git
+    rev: c38d5882b3df99ed9dbf632bd89bd7609fc05ca1
     build: cargo build -p rust-dataflow-example-node
     path: target/debug/rust-dataflow-example-node
     inputs:
@@ -10,8 +15,8 @@ nodes:
       - random
 
   - id: rust-status-node
-    git: https://github.com/dora-rs/dora.git
-    tag: v0.5.0 # pinned tag, update this when releasing a new version
+    git: https://github.com/dora-rs/adora.git
+    rev: c38d5882b3df99ed9dbf632bd89bd7609fc05ca1
     build: cargo build -p rust-dataflow-example-status-node
     path: target/debug/rust-dataflow-example-status-node
     inputs:
@@ -21,8 +26,8 @@ nodes:
       - status
 
   - id: rust-sink
-    git: https://github.com/dora-rs/dora.git
-    tag: v0.5.0 # pinned tag, update this when releasing a new version
+    git: https://github.com/dora-rs/adora.git
+    rev: c38d5882b3df99ed9dbf632bd89bd7609fc05ca1
     build: cargo build -p rust-dataflow-example-sink
     path: target/debug/rust-dataflow-example-sink
     inputs:


### PR DESCRIPTION
## Summary

Closes #206. Address every item from the original audit.

## Items

### 1. `rust-dataflow-git` — re-enabled ✅

phil-opp was right on his reply to my earlier comment: git sources accept commit hashes, no published release tag required. Repoint the fixture:

- `git: https://github.com/dora-rs/dora.git` → `https://github.com/dora-rs/adora.git`
- `tag: v0.5.0` → `rev: c38d5882b3df99ed9dbf632bd89bd7609fc05ca1` (current adora main)
- Uncomment `cargo run --example rust-dataflow-git` step in `ci.yml`

The `rev:` pin is intentional. When a message-format-breaking change lands on main, this example fails and signals the compat break — which is the whole point of the test. Update the `rev:` in the same PR as any message-format bump.

Local validation:
```
$ cargo run --example rust-dataflow-git
11:53:01 INFO [dora]: coordinator  dataflow finished
11:53:01 INFO dora_coordinator: stopped
```
Clean exit.

### 2. `rust-dataflow-example-node` — already in coverage ✅

No `--exclude` for this crate anywhere in `ci.yml`. Verified: `cargo test -p rust-dataflow-example-node` → 3 passed, 0 failed.

### 3. `multiple-daemons-example-operator` — already in coverage ✅

Same as above. Verified: `cargo test -p multiple-daemons-example-operator` → builds clean (no tests to run).

### 4. `dataflow_socket.yml` — n/a ✅

File doesn't exist in adora or upstream dora. Nothing to re-enable.

## Kept excluded

- `dora-cli-api-python` — Python cdylib, matches upstream pattern
- `dora-examples` — 45 networked smoke tests; covered by dedicated Examples + CLI Tests CI jobs

## Test plan

- [x] `cargo run --example rust-dataflow-git` locally — clean
- [x] `cargo test -p rust-dataflow-example-node` — 3/3 pass
- [x] `cargo test -p multiple-daemons-example-operator` — builds clean
- [ ] CI examples job picks up the re-enabled git example on 3 platforms
