### PR TITLE
test(qa): cpu_affinity end-to-end regression test (#252)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -485,10 +485,53 @@ jobs:
           dora stop --name tui-smoke --grace-duration 5s 2>/dev/null || true
           dora destroy 2>/dev/null || true
 
+  cpu-affinity-smoke:
+    # Regression test for #252. Spawns `cpu-affinity-probe` pinned to cores
+    # [0, 1] via the dataflow YAML; the probe reads its own affinity mask
+    # via sched_getaffinity and prints it. Test asserts the mask matches
+    # the requested set. Linux-only (sched_{get,set}affinity are Linux APIs).
+    name: cpu_affinity end-to-end (Linux)
+    runs-on: ubuntu-latest
+    needs: build-cli
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
+      - name: Run cpu-affinity-probe fixture (cpu_affinity: [0, 1])
+        run: |
+          cd examples/cpu-affinity-probe
+          out=$(dora run dataflow.yml --stop-after 3s 2>&1)
+          echo "$out"
+          # The probe prints exactly one `AFFINITY_MASK:<csv>` line from stdout.
+          # `dora run` prefixes node stdout with "stdout probe:" so extract the
+          # csv tail.
+          mask=$(echo "$out" | grep -oE 'AFFINITY_MASK:[^[:space:]]+' | head -1 | cut -d: -f2)
+          if [ -z "$mask" ]; then
+            echo "ERROR: probe did not print AFFINITY_MASK — cpu-affinity-probe failed to run"
+            exit 1
+          fi
+          if [ "$mask" != "0,1" ]; then
+            echo "ERROR: expected AFFINITY_MASK:0,1, got: $mask"
+            exit 1
+          fi
+          echo "OK: probe ran with the expected affinity mask: $mask"
+
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke]
+    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke]
     # `always() && contains(needs.*.result, 'failure')` covers both direct
     # failures and the case where build-cli fails and downstream jobs get
     # skipped (plain `failure()` would miss the skipped-cascade case).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -589,6 +589,7 @@ jobs:
           - record-replay
           - cluster-smoke
           - topic-and-top-smoke
+          - cpu-affinity-smoke
 
           See the run for per-job status and logs. Subsequent failures
           will comment on this issue instead of opening new ones. Close

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpu-affinity-probe"
+version = "0.2.1"
+dependencies = [
+ "dora-node-api",
+ "eyre",
+ "libc",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "examples/multiple-daemons/node",
     "examples/multiple-daemons/operator",
     "examples/multiple-daemons/sink",
+    "examples/cpu-affinity-probe",
     "examples/log-sink-tcp",
     "examples/log-sink-file",
     "examples/log-sink-alert",

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -38,6 +38,7 @@ the `nightly-regression` label but do not block PRs.
 | Record / replay round-trip | `record-replay` |
 | Cluster lifecycle (`cluster status`, `cluster down`) | `cluster-smoke` |
 | Inspection commands (`top --once`, `topic list/info/pub`) | `topic-and-top-smoke` |
+| `cpu_affinity` end-to-end (mask actually applied) | `cpu-affinity-smoke` (Linux only) |
 
 Run locally:
 ```bash

--- a/examples/cpu-affinity-probe/Cargo.toml
+++ b/examples/cpu-affinity-probe/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cpu-affinity-probe"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+dora-node-api = { workspace = true }
+eyre = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"

--- a/examples/cpu-affinity-probe/dataflow.yml
+++ b/examples/cpu-affinity-probe/dataflow.yml
@@ -1,0 +1,10 @@
+# Regression fixture for `cpu_affinity` (tracks #252). A probe binary
+# reads its own affinity mask via sched_getaffinity() and prints it.
+# The e2e test asserts the printed mask equals the requested set.
+nodes:
+  - id: probe
+    build: cargo build -p cpu-affinity-probe
+    path: ../../target/debug/cpu-affinity-probe
+    cpu_affinity: [0, 1]
+    inputs:
+      tick: dora/timer/millis/100

--- a/examples/cpu-affinity-probe/src/main.rs
+++ b/examples/cpu-affinity-probe/src/main.rs
@@ -1,0 +1,65 @@
+//! Diagnostic node for regression-testing `cpu_affinity`.
+//!
+//! On Linux, queries its own scheduler affinity mask via `sched_getaffinity`
+//! and prints it as a comma-separated list of core IDs prefixed with
+//! `AFFINITY_MASK:`. The e2e test greps for that marker line and compares
+//! the mask against the value configured in the fixture YAML.
+//!
+//! On non-Linux, prints `AFFINITY_MASK:unsupported` so the test skips
+//! cleanly.
+
+use dora_node_api::DoraNode;
+use eyre::Context;
+
+fn main() -> eyre::Result<()> {
+    // Initialize as a dora node so the daemon can manage the process
+    // lifecycle. We don't consume events; the node prints its mask and
+    // exits on the first tick (or immediately).
+    let (_node, _events) =
+        DoraNode::init_from_env().context("failed to init dora node from env")?;
+
+    #[cfg(target_os = "linux")]
+    {
+        let mask = read_affinity_mask()?;
+        // Sort for deterministic comparison.
+        let mut sorted = mask;
+        sorted.sort_unstable();
+        let csv = sorted
+            .iter()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        println!("AFFINITY_MASK:{csv}");
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        println!("AFFINITY_MASK:unsupported");
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn read_affinity_mask() -> eyre::Result<Vec<usize>> {
+    // SAFETY: sched_getaffinity is thread-safe; we pass a correctly-sized
+    // zero-initialized cpu_set_t and our own PID (0 means current thread).
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        let ret = libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set);
+        if ret != 0 {
+            return Err(eyre::eyre!(
+                "sched_getaffinity failed: {}",
+                std::io::Error::last_os_error()
+            ));
+        }
+        let max = std::mem::size_of::<libc::cpu_set_t>() * 8;
+        let mut cores = Vec::new();
+        for core in 0..max {
+            if libc::CPU_ISSET(core, &set) {
+                cores.push(core);
+            }
+        }
+        Ok(cores)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #252. Adds a real regression test for `cpu_affinity` — proves the `sched_setaffinity` call at `binaries/daemon/src/spawn/prepared.rs:438` actually lands the requested CPU mask on the spawned process.

## What's added

- **`examples/cpu-affinity-probe/`** — small Rust binary that reads its own affinity mask via `sched_getaffinity(0, ...)` and prints `AFFINITY_MASK:<csv>` to stdout. On non-Linux it prints `AFFINITY_MASK:unsupported` (graceful skip, so the probe itself builds everywhere).
- **`examples/cpu-affinity-probe/dataflow.yml`** — fixture that pins the probe to cores `[0, 1]`.
- **`.github/workflows/nightly.yml`** — new `cpu-affinity-smoke` job (Linux-only, ~5 min). Runs the fixture, greps stdout for the marker line, asserts mask == `"0,1"`. Fails with a clear diff if the pin stops applying.
- **`docs/testing-matrix.md`** — entry in Tier 1 table.

## Validation (local, macOS)

```
$ dora run dataflow.yml --stop-after 3s
...
15:34:21 stdout  probe:  AFFINITY_MASK:unsupported
15:34:21 INFO    probe: daemon  probe finished successfully
```

Works end-to-end: probe spawns, reads affinity, prints marker, exits cleanly. On macOS the output is "unsupported" (by design). The nightly runs on ubuntu-latest where the probe returns the actual mask.

## Why nightly

Same rationale as #243, #247, #248: this is a Linux-only integration test with a real `cargo build` dependency, adding it to every PR push isn't worth ~1 min/run. Promotion to Tier 0 eligible after 3 consecutive green nightlies per the existing policy.

## What this catches

- Regressions in the `pre_exec` hook (`binaries/daemon/src/spawn/prepared.rs:427`) that compute the wrong mask
- Regressions that skip the `sched_setaffinity` call entirely
- Regressions in YAML parsing that drop the `cpu_affinity` field
- Platform-specific bugs if someone accidentally wraps the call in `cfg(target_os)` incorrectly

## What this does not catch

- macOS/Windows: neither OS has `sched_setaffinity`; the feature is Linux-only. The probe gracefully reports "unsupported" so the code runs without error, but actual pinning is not tested there.
- CPU reservation enforcement: this test only checks the process's *allowed* CPU set, not that the scheduler actually prefers those cores under load.

## Test plan

- [x] `cargo build -p cpu-affinity-probe` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all --exclude dora-node-api-python --exclude dora-operator-api-python --exclude dora-ros2-bridge-python -- -D warnings` — clean (CI invocation)
- [x] Local `dora run examples/cpu-affinity-probe/dataflow.yml --stop-after 3s` on macOS — probe runs, prints "unsupported" marker
- [ ] Nightly run on Linux completes with mask == `0,1`
