### PR TITLE
test(qa): redb backend end-to-end smoke (#253)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -528,10 +528,87 @@ jobs:
           fi
           echo "OK: probe ran with the expected affinity mask: $mask"
 
+  redb-backend-smoke:
+    # Regression test for #253. Proves the redb coordinator store survives
+    # a coord restart: writes during normal operation, reads cleanly on
+    # startup. The load signal is a tracing line the restarted coord prints
+    # after reading stored daemon records — see binaries/coordinator/src/lib.rs
+    # `"cleared N stale daemon records"`.
+    name: redb backend end-to-end
+    runs-on: ubuntu-latest
+    needs: build-cli
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
+      - name: Session 1 — write state to redb
+        run: |
+          STORE=/tmp/dora-redb-smoke.db
+          rm -f "$STORE"
+          # Start coord with persistent redb store + daemon.
+          dora coordinator --store "redb:$STORE" > /tmp/coord1.log 2>&1 &
+          sleep 2
+          dora daemon > /tmp/daemon1.log 2>&1 &
+          sleep 2
+          # Run a short dataflow so the coord writes dataflow + daemon records
+          # to the store.
+          dora start examples/cpu-affinity-probe/dataflow.yml --name redb-smoke --detach
+          sleep 6
+          # Verify the store file exists and contains the dataflow name as
+          # evidence of actual writes (not just preallocation).
+          test -f "$STORE" || { echo "ERROR: redb store not created"; exit 1; }
+          if ! strings "$STORE" | grep -q "redb-smoke"; then
+            echo "ERROR: redb store does not contain the dataflow name — writes missing"
+            exit 1
+          fi
+          echo "OK: redb store contains dataflow record"
+          # Kill coord only, leave daemon orphaned (simulates a coord crash).
+          pkill -TERM -f "dora coordinator" || true
+          # Give the coord ~1s to shut down gracefully.
+          sleep 2
+      - name: Session 2 — restart coord, read state from redb
+        run: |
+          STORE=/tmp/dora-redb-smoke.db
+          # Restart coord against the same store.
+          dora coordinator --store "redb:$STORE" > /tmp/coord2.log 2>&1 &
+          sleep 4
+          echo "=== coord2 log ==="
+          cat /tmp/coord2.log
+          # The stale-daemon-cleanup path only runs if the coord successfully
+          # read at least one daemon record from redb. This is the round-trip
+          # proof: writes in session 1 were persisted AND session 2 read them.
+          if ! grep -q "cleared.*stale daemon records" /tmp/coord2.log; then
+            echo "ERROR: session 2 coord did not emit the stale-daemon cleanup log"
+            echo "(expected a line matching 'cleared N stale daemon records')"
+            exit 1
+          fi
+          # Also assert clean startup — no corruption, no panic.
+          if grep -qE "corrupt|panicked|ERROR" /tmp/coord2.log; then
+            echo "ERROR: session 2 coord log contains corruption or panic markers"
+            exit 1
+          fi
+          echo "OK: redb store read cleanly on restart"
+      - name: Teardown
+        if: always()
+        run: |
+          pkill -f "dora (daemon|coordinator)" 2>/dev/null || true
+
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke]
+    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke, redb-backend-smoke]
     # `always() && contains(needs.*.result, 'failure')` covers both direct
     # failures and the case where build-cli fails and downstream jobs get
     # skipped (plain `failure()` would miss the skipped-cascade case).
@@ -590,6 +667,7 @@ jobs:
           - cluster-smoke
           - topic-and-top-smoke
           - cpu-affinity-smoke
+          - redb-backend-smoke
 
           See the run for per-job status and logs. Subsequent failures
           will comment on this issue instead of opening new ones. Close

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -39,6 +39,7 @@ the `nightly-regression` label but do not block PRs.
 | Cluster lifecycle (`cluster status`, `cluster down`) | `cluster-smoke` |
 | Inspection commands (`top --once`, `topic list/info/pub`) | `topic-and-top-smoke` |
 | `cpu_affinity` end-to-end (mask actually applied) | `cpu-affinity-smoke` (Linux only) |
+| redb coordinator store survives restart | `redb-backend-smoke` |
 
 Run locally:
 ```bash


### PR DESCRIPTION
## Summary

Closes #253. Adds a nightly end-to-end smoke test that proves the redb coordinator store survives a coord restart — the capability the README advertises as "persistent redb-backed state store."

## Design: what the test actually proves

Two sessions wrapping a coord restart:

### Session 1 — writes
- Start coord with `--store redb:/tmp/dora-redb-smoke.db` + daemon
- Run a short dataflow (cpu-affinity-probe fixture, finishes in ~1s)
- **Assertion:** `strings $STORE | grep -q "redb-smoke"` — the dataflow name appears in the redb file as evidence of actual writes (not just preallocation — redb creates a 1.5MB file on init regardless of usage)
- SIGTERM the coord, leave daemon orphaned

### Session 2 — reads
- Restart coord against the same store path
- **Assertion:** session 2 coord log contains `cleared N stale daemon records` — that code path only fires if the restart successfully read at least one daemon record from redb. End-to-end round-trip proof.
- **Assertion:** no `corrupt`, `panicked`, or `ERROR` markers in session 2 log

## Why this signal

During local testing, the `"cleared 1 stale daemon records"` line from `binaries/coordinator/src/lib.rs` turned out to be the reliable observable end-to-end indicator:

- Store size doesn't change meaningfully across a short dataflow (preallocation absorbs the delta)
- `dora list` after restart doesn't show Succeeded/Failed dataflows (known limitation: succeeded records aren't re-hydrated into `running_dataflows`, only left in the store)
- Log-level signals at restart are the cleanest semantic proof

## What's not tested

- Full state reconstruction for Running dataflows (covered by sibling #255)
- Daemon auto-reconnect loop (covered by sibling #254)
- The Finished-dataflow hydration into `dora list` — that's a feature gap, not a test bug. `ControlRequest::List` at `lib.rs:973` only reads in-memory state; the store records for Finished dataflows are inaccessible via CLI today. Worth its own issue if surfaced.

## Test plan

- [x] Local validation: coord1 writes dataflow record, coord2 logs `"cleared 1 stale daemon records"` and starts cleanly
- [x] Pre-existing redb unit tests still pass (`cargo test -p dora-coordinator-store`)
- [ ] Nightly runs pass on GHA Linux runner
- [ ] 3 consecutive green nightlies → eligible for Tier 0 promotion (follow-up)
