### PR TITLE
test(qa): daemon auto-reconnect end-to-end smoke (#254)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -605,10 +605,96 @@ jobs:
         run: |
           pkill -f "dora (daemon|coordinator)" 2>/dev/null || true
 
+  daemon-reconnect-smoke:
+    # Regression test for #254. Proves the daemon auto-reconnect loop works
+    # end-to-end by SIGSTOPping the daemon long enough for the coord's
+    # heartbeat watchdog to disconnect it (30s timeout in coord/src/lib.rs:1664),
+    # then SIGCONTing and asserting the daemon rediscovers + re-registers.
+    # Linux-only: relies on SIGSTOP/SIGCONT semantics for freezing the process.
+    name: daemon auto-reconnect end-to-end (Linux)
+    runs-on: ubuntu-latest
+    needs: build-cli
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
+      - name: Start coord + daemon, capture PID
+        run: |
+          dora coordinator > /tmp/coord.log 2>&1 &
+          echo "COORD_PID=$!" >> "$GITHUB_ENV"
+          sleep 2
+          dora daemon > /tmp/daemon.log 2>&1 &
+          echo "DAEMON_PID=$!" >> "$GITHUB_ENV"
+          sleep 3
+          # Sanity: daemon registered and emitted its first status report.
+          if ! grep -q "daemon.*reports.*running dataflow" /tmp/coord.log; then
+            echo "ERROR: daemon did not register — no 'daemon X reports' line in coord log"
+            cat /tmp/coord.log
+            exit 1
+          fi
+          echo "OK: initial daemon registration confirmed"
+      - name: Freeze daemon with SIGSTOP, wait past heartbeat timeout
+        run: |
+          kill -STOP "$DAEMON_PID"
+          echo "daemon frozen at $(date +%s)"
+          # Coord's watchdog: 30s timeout (binaries/coordinator/src/lib.rs:1664).
+          # Wait 35s to give the watchdog 5s of margin.
+          sleep 35
+          if ! grep -q "Disconnecting daemons that failed watchdog" /tmp/coord.log; then
+            echo "ERROR: coord did not log watchdog disconnect after 35s pause"
+            echo "--- coord log ---"
+            cat /tmp/coord.log
+            exit 1
+          fi
+          echo "OK: coord timed out the frozen daemon"
+      - name: Resume daemon with SIGCONT, wait for reconnect
+        run: |
+          kill -CONT "$DAEMON_PID"
+          echo "daemon resumed at $(date +%s)"
+          # Daemon reconnect loop: 1s backoff on first retry. 30s is very
+          # generous but absorbs scheduler jitter on slow runners.
+          sleep 30
+          # Daemon should have noticed the disconnect and retried.
+          if ! grep -q "daemon disconnected from coordinator" /tmp/daemon.log; then
+            echo "ERROR: daemon did not detect disconnect post-resume"
+            echo "--- daemon log ---"
+            cat /tmp/daemon.log
+            exit 1
+          fi
+          echo "OK: daemon detected disconnect"
+          # Coord should show at least two 'daemon X reports' lines — initial
+          # registration and post-reconnect registration.
+          report_count=$(grep -c "daemon.*reports.*running dataflow" /tmp/coord.log || true)
+          echo "coord saw $report_count daemon status reports total"
+          if [ "$report_count" -lt 2 ]; then
+            echo "ERROR: expected >= 2 daemon reports (initial + post-reconnect), got $report_count"
+            echo "--- coord log ---"
+            cat /tmp/coord.log
+            exit 1
+          fi
+          echo "OK: daemon reconnected and re-registered"
+      - name: Teardown
+        if: always()
+        run: |
+          pkill -CONT -f "dora daemon" 2>/dev/null || true
+          pkill -f "dora (daemon|coordinator)" 2>/dev/null || true
+
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke, redb-backend-smoke]
+    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke, redb-backend-smoke, daemon-reconnect-smoke]
     # `always() && contains(needs.*.result, 'failure')` covers both direct
     # failures and the case where build-cli fails and downstream jobs get
     # skipped (plain `failure()` would miss the skipped-cascade case).
@@ -668,6 +754,7 @@ jobs:
           - topic-and-top-smoke
           - cpu-affinity-smoke
           - redb-backend-smoke
+          - daemon-reconnect-smoke
 
           See the run for per-job status and logs. Subsequent failures
           will comment on this issue instead of opening new ones. Close

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -40,6 +40,7 @@ the `nightly-regression` label but do not block PRs.
 | Inspection commands (`top --once`, `topic list/info/pub`) | `topic-and-top-smoke` |
 | `cpu_affinity` end-to-end (mask actually applied) | `cpu-affinity-smoke` (Linux only) |
 | redb coordinator store survives restart | `redb-backend-smoke` |
+| Daemon auto-reconnect (SIGSTOP past heartbeat → SIGCONT → re-register) | `daemon-reconnect-smoke` (Linux only) |
 
 Run locally:
 ```bash


### PR DESCRIPTION
## Summary

Closes #254. End-to-end regression test for the daemon auto-reconnect loop — the piece that catches "daemon silently drops off and never comes back" bugs that unit tests can't see.

## Flow

1. Start coord + daemon, assert initial registration (coord logs `daemon X reports N running dataflow(s)`)
2. `kill -STOP $DAEMON_PID` — simulates network partition or hung process
3. Sleep 35s — coord's watchdog timeout is 30s at `binaries/coordinator/src/lib.rs:1664`
4. Assert coord logged `Disconnecting daemons that failed watchdog`
5. `kill -CONT $DAEMON_PID` — daemon's WS send fails immediately, it enters the reconnect loop (first retry: 1s backoff)
6. Sleep 30s — generous margin for scheduler jitter
7. Assert daemon logged `daemon disconnected from coordinator` (proves it detected the drop)
8. Assert coord saw >= 2 daemon status reports (initial + re-registered)

Total runtime ~70s per nightly run.

## Local validation

Ran the exact same flow on macOS (SIGSTOP/SIGCONT are POSIX, nightly runs on Linux):

```
OK: registered
frozen
OK: watchdog fired
resumed
OK: daemon detected disconnect
coord saw 2 reports
```

All 4 assertions pass.

## Why Linux-only

The test design relies on process-freeze semantics that are POSIX but the implementation paths differ enough across platforms that I'm not gating it cross-platform. macOS would work; Windows would not (no SIGSTOP). Nightly runs on ubuntu-latest, which matches.

## What this catches

- Regressions in the daemon's reconnect loop at `binaries/daemon/src/lib.rs:470-552` (wrong backoff, silent retry bailout, missing re-register)
- Regressions in the coord's watchdog at `binaries/coordinator/src/lib.rs:1655-1710` (timeout threshold change, disconnect cleanup gap)
- Bugs that show up only when the daemon reappears after the coord has already removed it from `daemon_connections`

## What this does not catch

- Subtle state reconciliation bugs after reconnect (e.g., does the daemon correctly resubscribe to active topic streams?). That's #242's `restore_topic_debug_streams_re_issues_start_after_reconnect` territory for topic streams; for other subsystems, it's future work.
- Multi-daemon reconnect scenarios.

## Test plan

- [x] Local repro on macOS — all 4 assertions pass
- [x] `cargo fmt --all -- --check` — n/a (YAML only)
- [x] `cargo clippy --all ... -D warnings` — n/a (YAML only)
- [ ] Nightly runs pass on GHA Linux runner
- [ ] 3 consecutive green nightlies → eligible for Tier 0 promotion (follow-up)
