### PR TITLE
test(qa): partial state reconstruction smoke + doc accuracy (#255)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -691,10 +691,95 @@ jobs:
           pkill -CONT -f "dora daemon" 2>/dev/null || true
           pkill -f "dora (daemon|coordinator)" 2>/dev/null || true
 
+  state-reconstruction-smoke:
+    # Partial regression test for #255. Validates what the current redb
+    # backend + recovery path actually delivers on coord restart: store
+    # records survive, and the coord transitions previously-Running
+    # dataflows to Recovering on startup.
+    #
+    # NOT tested here: daemons keeping running dataflows alive across
+    # coord disconnect. That part of the README claim ('dataflow state
+    # reconstruction on coordinator restart') is aspirational — see the
+    # follow-up issue for the implementation gap. When the daemon side
+    # lands, this job should be extended to assert the Recovering -> Running
+    # reconciliation path at binaries/coordinator/src/lib.rs:1996.
+    name: state reconstruction end-to-end (partial)
+    runs-on: ubuntu-latest
+    needs: build-cli
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Download dora CLI
+        uses: actions/download-artifact@v4
+        with:
+          name: dora-cli
+          path: ./cli-bin
+      - name: Install CLI to PATH
+        run: |
+          chmod +x ./cli-bin/dora
+          echo "$PWD/cli-bin" >> "$GITHUB_PATH"
+      - name: Pre-build example nodes
+        run: |
+          cargo build -p rust-dataflow-example-node
+      - name: Session 1 — run long-lived dataflow, kill coord
+        run: |
+          STORE=/tmp/state-reconstruct.db
+          rm -f "$STORE"
+          # 500ms timer × 100-tick source node → ~50s runtime, long enough
+          # for the record to be persisted as Running before we kill coord.
+          cat > examples/rust-dataflow/long-running.yml <<'EOF'
+          nodes:
+            - id: source
+              path: ../../target/debug/rust-dataflow-example-node
+              inputs:
+                tick: dora/timer/millis/500
+              outputs:
+                - random
+          EOF
+          dora coordinator --store "redb:$STORE" > /tmp/sr-c1.log 2>&1 &
+          sleep 2
+          dora daemon > /tmp/sr-d1.log 2>&1 &
+          sleep 2
+          dora start examples/rust-dataflow/long-running.yml --name sr-test --detach
+          sleep 4
+          # The dataflow name must appear in the store as evidence of
+          # a Running record being persisted.
+          if ! strings "$STORE" | grep -q "sr-test"; then
+            echo "ERROR: dataflow name not in store — writes missing"
+            exit 1
+          fi
+          echo "OK: Running dataflow persisted to store"
+          pkill -TERM -f "dora coordinator" || true
+          sleep 2
+      - name: Session 2 — restart coord, assert Recovering transition
+        run: |
+          STORE=/tmp/state-reconstruct.db
+          dora coordinator --store "redb:$STORE" > /tmp/sr-c2.log 2>&1 &
+          sleep 4
+          echo "=== sr-c2 log ==="
+          cat /tmp/sr-c2.log
+          # The startup code at binaries/coordinator/src/lib.rs:302 reads
+          # persisted Running records and transitions them to Recovering.
+          # This log line is the observable proof.
+          if ! grep -q "coordinator restarted:.*-> Recovering" /tmp/sr-c2.log; then
+            echo "ERROR: coord did not mark previously-Running dataflow as Recovering"
+            exit 1
+          fi
+          echo "OK: coord hydrated Running record as Recovering on startup"
+      - name: Teardown
+        if: always()
+        run: |
+          pkill -f "dora (daemon|coordinator)" 2>/dev/null || true
+          rm -f examples/rust-dataflow/long-running.yml
+
   file-issue-on-failure:
     name: File issue on nightly failure
     runs-on: ubuntu-latest
-    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke, redb-backend-smoke, daemon-reconnect-smoke]
+    needs: [build-cli, smoke-suite, log-sinks, service-action, streaming, record-replay, cluster-smoke, topic-and-top-smoke, cpu-affinity-smoke, redb-backend-smoke, daemon-reconnect-smoke, state-reconstruction-smoke]
     # `always() && contains(needs.*.result, 'failure')` covers both direct
     # failures and the case where build-cli fails and downstream jobs get
     # skipped (plain `failure()` would miss the skipped-cascade case).
@@ -755,6 +840,7 @@ jobs:
           - cpu-affinity-smoke
           - redb-backend-smoke
           - daemon-reconnect-smoke
+          - state-reconstruction-smoke
 
           See the run for per-job status and logs. Subsequent failures
           will comment on this issue instead of opening new ones. Close

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 - **Fault tolerance** -- per-node restart policies (never/on-failure/always), exponential backoff, health monitoring, circuit breakers with configurable input timeouts
 - **Distributed by default** -- local shared memory between co-located nodes, automatic [Zenoh](https://zenoh.io/) pub-sub for cross-machine communication, SSH-based [cluster management](docs/distributed-deployment.md) with label scheduling, rolling upgrades, and auto-recovery
-- **Coordinator HA** -- persistent redb-backed state store (default), daemon auto-reconnect with exponential backoff, dataflow state reconstruction on coordinator restart
+- **Coordinator HA** -- persistent redb-backed state store (default), daemon auto-reconnect with exponential backoff, dataflow records survive coordinator restart (running dataflow reclaim-across-restart is partial, see the open issue tracker)
 - **Dynamic topology** -- add and remove nodes from running dataflows via CLI (`dora node add/remove/connect/disconnect`) without restarting
 - **Soft real-time** -- optional `--rt` flag for mlockall + SCHED_FIFO; per-node `cpu_affinity` pinning in YAML; comprehensive [tuning guide](docs/realtime-tuning.md) for memory locking, kernel params, and container deployment
 - **OpenTelemetry** -- built-in structured logging with rotation/routing, metrics, distributed tracing, and zero-setup trace viewing via CLI

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -41,6 +41,7 @@ the `nightly-regression` label but do not block PRs.
 | `cpu_affinity` end-to-end (mask actually applied) | `cpu-affinity-smoke` (Linux only) |
 | redb coordinator store survives restart | `redb-backend-smoke` |
 | Daemon auto-reconnect (SIGSTOP past heartbeat → SIGCONT → re-register) | `daemon-reconnect-smoke` (Linux only) |
+| State reconstruction (partial: store hydrate + Running → Recovering) | `state-reconstruction-smoke` |
 
 Run locally:
 ```bash

--- a/guide/src/introduction.md
+++ b/guide/src/introduction.md
@@ -23,7 +23,7 @@
 
 - **Fault tolerance** -- per-node restart policies (never/on-failure/always), exponential backoff, health monitoring, circuit breakers with configurable input timeouts
 - **Distributed by default** -- local shared memory between co-located nodes, automatic [Zenoh](https://zenoh.io/) pub-sub for cross-machine communication, SSH-based cluster management with label scheduling
-- **Coordinator HA** -- persistent redb state store, daemon auto-reconnect, dataflow state reconstruction on coordinator restart
+- **Coordinator HA** -- persistent redb state store, daemon auto-reconnect, dataflow records survive coordinator restart (full running-dataflow reclaim across restart is partial; see open tracker)
 - **Dynamic topology** -- add and remove nodes from running dataflows via CLI without restarting
 - **Configurable queue policies** -- `drop_oldest` (default) or `backpressure` per input, with metrics on dropped messages
 - **Soft real-time** -- optional `--rt` flag for mlockall + SCHED_FIFO; per-node `cpu_affinity` pinning


### PR DESCRIPTION
## Summary

Closes #255 for the scope actually achievable today. Discovered during implementation that the feature the README advertises ("dataflow state reconstruction on coordinator restart") is only partially implemented. Delivers the honest partial test + files a new issue for the real gap + fixes doc accuracy.

## What landed

### 1. Partial nightly test

New `state-reconstruction-smoke` nightly job. Validates what the current implementation does deliver:

- **Session 1**: start coord (redb) + daemon + long-running dataflow. Assert the dataflow name appears in the redb store file via `strings $STORE | grep sr-test` — proves writes happen for Running dataflows.
- **Session 2**: kill coord, restart against the same store. Assert `coordinator restarted: dataflow X -> Recovering` log line — proves the startup hydration path at `binaries/coordinator/src/lib.rs:302` reads persisted Running records and transitions them to Recovering.

Local validation: both assertions pass in ~15s.

### 2. Design gap issue (#260)

During implementation I hit a surprise: when the coord WS disconnects, the daemon's `ProcessHandle::drop` at `binaries/daemon/src/running_dataflow.rs:157-163` kills the running nodes with SIGKILL. Evidence:

```
daemon log:
  WARN running_dataflow: process was killed on drop because it was still running
  ERROR spawn::prepared: node exited with error: Signal(9)

coord session 2:
  INFO coordinator restarted: dataflow ... -> Recovering
  INFO daemon X reports 0 running dataflow(s)   ← 0, not 1
```

The reconciliation path at `lib.rs:1983` would promote Recovering → Running if the daemon reported a still-alive dataflow. It doesn't. Eventually the Recovering record times out to Failed via the 60s watchdog.

Filed dora-rs/adora#260 with a repro and proposed scope. Not in this PR — that's daemon lifecycle work, separate surface area.

### 3. Docs updated to match reality

`README.md:49` and `guide/src/introduction.md:26` both said "dataflow state reconstruction on coordinator restart." Updated to:

> "dataflow records survive coordinator restart (full running-dataflow reclaim across restart is partial; see open tracker)"

Honest about what's implemented. When #260 lands, this reverts to the strong claim.

## Why not lock in the broken behavior via a test

Option C ("test what current-broken does, fail when someone fixes it") was considered. Rejected because it ties the test to a specific bug manifestation rather than the desired behavior. The partial test here stays green when the gap is fixed; the new assertion gets added then (see the TODO comment inline in the job).

## Test plan

- [x] Local repro on macOS — both assertions pass
- [x] Gap reproduced + documented in #260
- [x] `cargo fmt --all -- --check` — n/a (YAML + markdown only)
- [ ] Nightly run on GHA Linux picks up the new job
- [ ] 3 consecutive green nightlies → eligible for Tier 0 promotion (follow-up)
