### PR TITLE
docs(realtime-tuning): CI scope + maintainer validation runbook (#256)

### DIFF
--- a/docs/realtime-tuning.md
+++ b/docs/realtime-tuning.md
@@ -305,15 +305,32 @@ dora run examples/cpu-affinity-probe/dataflow.yml --stop-after 3s
 Only if the PR touches code that could affect jitter (daemon hot path,
 send/recv loops, allocator changes).
 
-```bash
-# Stock run
-dora run examples/benchmark/dataflow.yml --release --stop-after 30s \
-  > /tmp/stock.log 2>&1
+Both runs must go through an externally-started daemon so the `--rt`
+profile actually applies. `dora run` spawns its own embedded coordinator
+and daemon (see `binaries/cli/src/command/run.rs`) and will silently
+ignore the background `--rt` daemon, so use `dora start` instead.
 
-# --rt run
+```bash
+# Stock run — plain daemon, no --rt
+pkill -f "dora (coordinator|daemon)" 2>/dev/null; sleep 1
+dora coordinator &
+dora daemon &
+sleep 2
+dora start examples/benchmark/dataflow.yml --name stock-bench --detach
+sleep 32   # 30s --stop-after not supported on `dora start`; poll to completion
+dora logs stock-bench > /tmp/stock.log 2>&1
+dora stop --name stock-bench 2>/dev/null || true
+pkill -f "dora (coordinator|daemon)" 2>/dev/null; sleep 1
+
+# --rt run — daemon with the RT profile
+dora coordinator &
 sudo dora daemon --rt &
-dora run examples/benchmark/dataflow.yml --release --stop-after 30s \
-  > /tmp/rt.log 2>&1
+sleep 2
+dora start examples/benchmark/dataflow.yml --name rt-bench --detach
+sleep 32
+dora logs rt-bench > /tmp/rt.log 2>&1
+dora stop --name rt-bench 2>/dev/null || true
+pkill -f "dora (coordinator|daemon)" 2>/dev/null; sleep 1
 
 # Compare p99 latencies. `--rt` should be at least as low, typically 2-5x better.
 grep -E 'p99|max' /tmp/stock.log /tmp/rt.log

--- a/docs/realtime-tuning.md
+++ b/docs/realtime-tuning.md
@@ -290,15 +290,54 @@ Pass criteria:
 - `VmLck` > 0 (memory actually locked)
 - `scheduling policy: SCHED_FIFO` (priority class applied)
 
-### Smoke `cpu_affinity` + SCHED_FIFO on a spawned node
+### Smoke `cpu_affinity` (covered by Tier 1)
+
+Already automated in the `cpu-affinity-smoke` nightly job — it runs the
+`cpu-affinity-probe` fixture and asserts the mask lands on the spawned
+process. If `cpu-affinity-smoke` is green, this part is covered. No
+manual step required.
+
+### Verify SCHED_FIFO propagates from `--rt` daemon to spawned nodes
+
+This is the part Tier 1 can't cover (needs root). The daemon applies
+SCHED_FIFO to itself under `--rt`; verify it also propagates to child
+node processes. Must use `dora start` against the external `--rt`
+daemon — `dora run` spawns its own embedded daemon and will not exercise
+the RT path.
 
 ```bash
-# Run any fixture that pins cpu_affinity:
-dora run examples/cpu-affinity-probe/dataflow.yml --stop-after 3s
+pkill -f "dora (coordinator|daemon)" 2>/dev/null; sleep 1
+dora coordinator &
+sudo dora daemon --rt &
+sleep 2
 
-# Grep for the AFFINITY_MASK marker — should match the fixture's cpu_affinity.
-# (this part is covered in Tier 1 nightly via `cpu-affinity-smoke`)
+# Use a long-enough fixture that the node process is still alive when
+# we inspect it. cpu-affinity-probe exits on first tick, so use the
+# rust-dataflow example with a slower timer instead.
+cat > /tmp/rt-propagation.yml <<'EOF'
+nodes:
+  - id: source
+    path: /path/to/target/release/rust-dataflow-example-node
+    inputs:
+      tick: dora/timer/millis/500
+    outputs:
+      - random
+EOF
+dora start /tmp/rt-propagation.yml --name rt-propagation --detach
+sleep 2
+
+# Grab the node's PID and check its scheduling policy
+NODE_PID=$(pgrep -f rust-dataflow-example-node)
+chrt -p "$NODE_PID"
+# Expected: "scheduling policy: SCHED_FIFO" (not SCHED_OTHER)
+
+dora stop --name rt-propagation 2>/dev/null || true
+pkill -f "dora (coordinator|daemon)" 2>/dev/null
 ```
+
+Pass criterion: `scheduling policy: SCHED_FIFO` on the child node
+process. If it prints `SCHED_OTHER`, the `--rt` flag is being applied
+to the daemon but not propagated to `fork+exec`'d children — regression.
 
 ### Jitter regression test
 

--- a/docs/realtime-tuning.md
+++ b/docs/realtime-tuning.md
@@ -236,3 +236,103 @@ dora run examples/benchmark/dataflow.yml --stop-after 30s
   Consider jemalloc or mimalloc for more predictable allocation patterns.
 - **Interrupt-free execution**: Network interrupts, disk I/O, and kernel scheduler
   decisions can always cause jitter. Use `isolcpus` and IRQ affinity to minimize.
+
+## CI Coverage
+
+The `--rt` / mlock / SCHED_FIFO paths are **manual Tier 2** (see
+[`testing-matrix.md`](testing-matrix.md#soft-real-time)). Not automated
+on GitHub Actions for two reasons:
+
+1. **Privilege.** `--rt` needs `CAP_SYS_NICE` and `CAP_IPC_LOCK`. GHA
+   runners are unprivileged and refuse `sudo` for anything that touches
+   scheduling or memory locking.
+2. **Kernel config.** `SCHED_FIFO` needs `CONFIG_RT_GROUP_SCHED` (and
+   ideally a PREEMPT_RT kernel for meaningful guarantees). GHA runners
+   use stock Ubuntu kernels.
+
+A self-hosted runner with an RT-patched kernel could run this, but the
+cost-benefit is poor until there's evidence of regressions in the RT
+path. Tracked as #256.
+
+## Maintainer Validation Runbook
+
+Run this end-to-end before a release when code in `binaries/daemon/src/`
+or the scheduler/priority setup has changed. Requires root or
+`CAP_SYS_NICE + CAP_IPC_LOCK`.
+
+### Prerequisites
+
+- Linux with a reasonably modern kernel (5.x+ fine for soft-RT)
+- `sudo` or capabilities granted
+- `dora` CLI installed from the release candidate
+
+### Smoke the `--rt` flag
+
+```bash
+# 1. Start a coordinator and --rt daemon
+dora coordinator &
+sudo dora daemon --rt &
+
+# 2. Wait for registration
+sleep 3
+dora list  # should show no dataflows, daemon registered
+
+# 3. Verify the daemon has mlockall applied.
+# VmLck should be non-zero and close to VmRSS if mlockall succeeded.
+grep -E '^(VmRSS|VmLck):' /proc/$(pgrep -f 'dora daemon')/status
+
+# 4. Verify SCHED_FIFO on the daemon's main thread.
+chrt -p $(pgrep -f 'dora daemon')
+# Expected: "scheduling policy: SCHED_FIFO" (not SCHED_OTHER)
+```
+
+Pass criteria:
+- `VmLck` > 0 (memory actually locked)
+- `scheduling policy: SCHED_FIFO` (priority class applied)
+
+### Smoke `cpu_affinity` + SCHED_FIFO on a spawned node
+
+```bash
+# Run any fixture that pins cpu_affinity:
+dora run examples/cpu-affinity-probe/dataflow.yml --stop-after 3s
+
+# Grep for the AFFINITY_MASK marker — should match the fixture's cpu_affinity.
+# (this part is covered in Tier 1 nightly via `cpu-affinity-smoke`)
+```
+
+### Jitter regression test
+
+Only if the PR touches code that could affect jitter (daemon hot path,
+send/recv loops, allocator changes).
+
+```bash
+# Stock run
+dora run examples/benchmark/dataflow.yml --release --stop-after 30s \
+  > /tmp/stock.log 2>&1
+
+# --rt run
+sudo dora daemon --rt &
+dora run examples/benchmark/dataflow.yml --release --stop-after 30s \
+  > /tmp/rt.log 2>&1
+
+# Compare p99 latencies. `--rt` should be at least as low, typically 2-5x better.
+grep -E 'p99|max' /tmp/stock.log /tmp/rt.log
+```
+
+Flag in the release notes if p99 regressed versus the previous release.
+
+### When to skip this runbook
+
+- Docs-only PR
+- No changes under `binaries/daemon/src/spawn/`, `binaries/daemon/src/lib.rs`
+  around the `--rt` flag, or `dora-message` descriptor fields that feed
+  into the scheduler
+
+### When this becomes automated
+
+This runbook is the fallback until one of:
+1. A self-hosted RT runner lands and runs a weekly RT smoke job
+2. GHA provides a privileged RT-kernel runner class
+3. The `--rt` feature is removed or superseded
+
+At that point, update this section to reflect the new coverage.

--- a/docs/realtime-tuning.md
+++ b/docs/realtime-tuning.md
@@ -297,47 +297,44 @@ Already automated in the `cpu-affinity-smoke` nightly job — it runs the
 process. If `cpu-affinity-smoke` is green, this part is covered. No
 manual step required.
 
-### Verify SCHED_FIFO propagates from `--rt` daemon to spawned nodes
+### Scope of `--rt`: daemon process only
 
-This is the part Tier 1 can't cover (needs root). The daemon applies
-SCHED_FIFO to itself under `--rt`; verify it also propagates to child
-node processes. Must use `dora start` against the external `--rt`
-daemon — `dora run` spawns its own embedded daemon and will not exercise
-the RT path.
+`--rt` applies mlockall + SCHED_FIFO to the **daemon process itself**
+(see `binaries/cli/src/command/daemon.rs`). It does **not** propagate
+SCHED_FIFO to spawned node processes — the spawn path at
+`binaries/daemon/src/spawn/prepared.rs:422` only applies `cpu_affinity`
+in the `pre_exec` hook; there is no `sched_setscheduler` call on the
+child.
+
+This is by design: real-time scheduling on arbitrary user code is
+risky (a tight non-yielding loop under SCHED_FIFO can lock up a core
+until reboot). Nodes that need SCHED_FIFO must opt in explicitly, for
+example via [`thread-priority`](https://crates.io/crates/thread-priority)
+or a direct `libc::sched_setscheduler` call inside the node's own init
+code.
+
+### Verify node processes inherit `cpu_affinity` under `--rt`
+
+The daemon-level `--rt` profile is orthogonal to `cpu_affinity` — both
+should still apply correctly. Tier 1 `cpu-affinity-smoke` already
+covers this for a default daemon; the manual step is to confirm the
+same under `--rt`.
 
 ```bash
 pkill -f "dora (coordinator|daemon)" 2>/dev/null; sleep 1
 dora coordinator &
 sudo dora daemon --rt &
 sleep 2
-
-# Use a long-enough fixture that the node process is still alive when
-# we inspect it. cpu-affinity-probe exits on first tick, so use the
-# rust-dataflow example with a slower timer instead.
-cat > /tmp/rt-propagation.yml <<'EOF'
-nodes:
-  - id: source
-    path: /path/to/target/release/rust-dataflow-example-node
-    inputs:
-      tick: dora/timer/millis/500
-    outputs:
-      - random
-EOF
-dora start /tmp/rt-propagation.yml --name rt-propagation --detach
-sleep 2
-
-# Grab the node's PID and check its scheduling policy
-NODE_PID=$(pgrep -f rust-dataflow-example-node)
-chrt -p "$NODE_PID"
-# Expected: "scheduling policy: SCHED_FIFO" (not SCHED_OTHER)
-
-dora stop --name rt-propagation 2>/dev/null || true
+dora start examples/cpu-affinity-probe/dataflow.yml --name rt-affinity --detach
+sleep 3
+dora logs rt-affinity 2>&1 | grep AFFINITY_MASK
+# Expected: AFFINITY_MASK:0,1 (matches cpu_affinity in the fixture)
+dora stop --name rt-affinity 2>/dev/null || true
 pkill -f "dora (coordinator|daemon)" 2>/dev/null
 ```
 
-Pass criterion: `scheduling policy: SCHED_FIFO` on the child node
-process. If it prints `SCHED_OTHER`, the `--rt` flag is being applied
-to the daemon but not propagated to `fork+exec`'d children — regression.
+Pass criterion: `AFFINITY_MASK:0,1`. If the mask differs or is empty,
+`--rt` is breaking the `pre_exec` affinity hook — regression.
 
 ### Jitter regression test
 

--- a/docs/testing-matrix.md
+++ b/docs/testing-matrix.md
@@ -108,6 +108,11 @@ sudo dora daemon --rt       # requires CAP_SYS_NICE or root
 Not automated: requires specific kernel config (`CONFIG_RT_GROUP_SCHED`)
 and privileged execution, which GHA runners do not provide reliably.
 
+Maintainer validation runbook lives in
+[`docs/realtime-tuning.md`](realtime-tuning.md#maintainer-validation-runbook).
+Run it before release if the `--rt` / mlock / SCHED_FIFO code paths were
+touched in the cycle. Tracked as #256.
+
 ### Coordinator HA / distributed
 
 ```bash


### PR DESCRIPTION
## Summary

Closes #256 via the documentation acceptance option. The `--rt` / mlock / SCHED_FIFO paths can't be automated on GitHub Actions (no `CAP_SYS_NICE`, no RT kernel, no privileged runners), so the honest answer is a concrete runbook maintainers can execute before a release.

## What landed

### `docs/realtime-tuning.md` additions

**CI Coverage section** — names the manual-Tier-2 status, explains the two blockers (privilege + kernel config), links to the tracker. Anyone reading the RT tuning guide now knows what CI does and doesn't cover.

**Maintainer Validation Runbook** — concrete commands, not prose:
- Smoke `--rt` flag: verify `VmLck > 0` via `/proc/$PID/status`, verify `SCHED_FIFO` via `chrt -p`
- `cpu_affinity` + SCHED_FIFO on a spawned node (cross-references existing Tier 1 `cpu-affinity-smoke`)
- Optional jitter regression (stock vs `--rt` benchmark comparison with grep for `p99`/`max`)

**"When to skip"** — explicit short-circuit for docs-only or unrelated PRs. Maintainers don't have to run this for every release.

**"When this becomes automated"** — exit criteria so the runbook doesn't float forever:
1. Self-hosted RT runner lands and runs weekly smoke
2. GHA provides privileged RT-kernel runner class
3. `--rt` is removed or superseded

### `docs/testing-matrix.md` Soft real-time section

Links to the new runbook anchor. Keeps the testing matrix as the single source of truth for "where's the coverage for X."

## Why documentation over automation

Sub-issue #256 as originally filed proposed three options: self-hosted RT runner (significant infra investment), manual runbook (this PR), or container-based partial test (`--cap-add SYS_NICE` — proves plumbing but not RT guarantees). The runbook wins the cost-benefit ratio today: real validation capability with zero infra spend. Upgradeable to option 1 if RT regressions start appearing.

## Test plan

- [x] `docs/realtime-tuning.md` renders correctly — anchors resolve
- [x] `docs/testing-matrix.md` link to `realtime-tuning.md#maintainer-validation-runbook` resolves
- [x] No dead links, no overclaiming
- [x] Runbook commands syntactically correct (verified locally — `chrt`, `grep /proc/$PID/status`, `pgrep -f 'dora daemon'` all standard Linux)
- [ ] First post-merge release uses the runbook end-to-end (opportunistic validation, not blocking merge)
