### PR TITLE
fix(arrow): checked_add for Arrow IPC buffer-offset bounds (upstream #1479)

### DIFF
--- a/apis/rust/node/src/node/arrow_utils.rs
+++ b/apis/rust/node/src/node/arrow_utils.rs
@@ -149,7 +149,13 @@ fn buffer_into_arrow_array_inner(
 
     let mut buffers = Vec::new();
     for BufferOffset { offset, len } in &type_info.buffer_offsets {
-        if offset + len > raw_buffer.len() {
+        // Use checked_add to guard against malicious/buggy peers sending
+        // `offset` or `len` values that would overflow `usize` on addition
+        // and bypass the bounds check below.
+        let end = offset
+            .checked_add(*len)
+            .ok_or_else(|| eyre::eyre!("buffer offset overflow: offset={offset}, len={len}"))?;
+        if end > raw_buffer.len() {
             eyre::bail!(
                 "buffer offset out of bounds: offset={offset}, len={len}, buffer_len={}",
                 raw_buffer.len()
@@ -298,6 +304,33 @@ mod tests {
         let encoded = encode_arrow_ipc(&data).unwrap();
         let decoded = decode_arrow_ipc(&encoded).unwrap();
         assert_eq!(data, decoded);
+    }
+
+    #[test]
+    fn buffer_into_arrow_array_rejects_overflow_offset() {
+        // A peer-controlled BufferOffset with offset = usize::MAX would overflow
+        // `offset + len` to a small value and bypass the bounds check, then panic
+        // inside arrow's slice_with_length. We must reject it with an error.
+        let info = ArrowTypeInfo {
+            data_type: arrow_schema::DataType::UInt8,
+            len: 0,
+            null_count: 0,
+            validity: None,
+            offset: 0,
+            buffer_offsets: vec![BufferOffset {
+                offset: usize::MAX,
+                len: 1,
+            }],
+            child_data: vec![],
+            field_names: None,
+            schema_hash: None,
+        };
+        let buf = arrow::buffer::Buffer::from(vec![0u8; 1024]);
+        let err = buffer_into_arrow_array(&buf, &info).unwrap_err();
+        assert!(
+            err.to_string().contains("overflow"),
+            "expected overflow error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace unchecked `offset + len` with `checked_add` in Arrow IPC buffer-offset bounds check (`apis/rust/node/src/node/arrow_utils.rs`)
- Add regression test exercising `offset = usize::MAX`

## Why

`buffer_into_arrow_array_inner` validates wire-received `BufferOffset` values against the raw buffer length:

```rust
if offset + len > raw_buffer.len() {
```

`offset` and `len` are `usize` fields in `ArrowTypeInfo::buffer_offsets`, received from another node. A peer sending `offset = usize::MAX, len = 1` overflows the add to `0`, passes the check, then `raw_buffer.slice_with_length(usize::MAX, 1)` panics inside arrow — aborting the node process.

The fix uses `checked_add` and returns an eyre error on overflow, same pattern the file already uses for the other wire-bounds checks (`MAX_TYPE_DEPTH`, `MAX_ENTRIES`, `MAX_IPC_BYTES`).

Backport of upstream [dora-rs/dora#1479](https://github.com/dora-rs/dora/pull/1479). Refs #263, #201.

### Scope note

#263 originally batched four upstream PRs. After auditing, three don't apply to adora and were dropped with rationale (see #263 comment):
- #1438 / #1440 — `to_str().unwrap()` on `CARGO_MANIFEST_DIR` is unreachable (compile-time path)
- #1562 — all non-test `Uuid::parse_str` in adora already `.ok()`-based; no log-field parse path
- #1430 — URL source validation is UX, not panic-safety; folded into #266

## Test plan

- [x] `cargo test -p dora-node-api` — 7/7 arrow_utils tests pass, including new `buffer_into_arrow_array_rejects_overflow_offset`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p dora-node-api -- -D warnings`
- [ ] CI green on Ubuntu/macOS/Windows
