### PR TITLE
fix(event-stream): replace flume with tokio mpsc to fix GIL deadlock (upstream #1603)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ serde_json = "1.0.145"
 thiserror = "2.0"
 colored = "3.0.0"
 inquire = { version = "0.7.5", default-features = false }
-tokio = { version = "1.24.2", default-features = false }
+tokio = { version = "1.28", default-features = false }
 eyre = "0.6.8"
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1.36"

--- a/apis/rust/node/Cargo.toml
+++ b/apis/rust/node/Cargo.toml
@@ -35,7 +35,7 @@ futures-timer = "3.0.2"
 dora-arrow-convert = { workspace = true }
 aligned-vec = "0.5.0"
 serde_json = { workspace = true, features = ["preserve_order"] }
-tokio = { workspace = true, features = ["rt-multi-thread", "time", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "time", "macros", "sync"] }
 inquire = { workspace = true, features = ["console"] }
 arrow-json = { workspace = true }
 arrow-schema = { workspace = true }

--- a/apis/rust/node/src/event_stream/mod.rs
+++ b/apis/rust/node/src/event_stream/mod.rs
@@ -14,7 +14,7 @@ use dora_message::{
 };
 pub use event::{Event, StopCause};
 use futures::{
-    FutureExt, Stream, StreamExt,
+    FutureExt, Stream,
     future::{Either, select},
 };
 use futures_timer::Delay;
@@ -65,7 +65,11 @@ pub struct EventStream {
     // Drop order: Rust drops fields in declaration order (top to bottom).
     // receiver must drop FIRST so tx_clone.send() in subscriber threads
     // returns Err, causing threads to exit before JoinHandles are dropped.
-    receiver: flume::r#async::RecvStream<'static, EventItem>,
+    // Using `tokio::sync::mpsc::Receiver` — instead of `flume` — avoids the
+    // AB-BA deadlock between flume 0.10's spinlock and pyo3's GIL-acquiring
+    // waker when a Python coroutine polls this stream
+    // (upstream dora-rs/dora#1603).
+    receiver: tokio::sync::mpsc::Receiver<EventItem>,
     _thread_handle: EventStreamThreadHandle,
     _zenoh_thread_handles: Vec<std::thread::JoinHandle<()>>,
     close_channel: DaemonChannel,
@@ -292,7 +296,7 @@ impl EventStream {
 
         close_channel.register(dataflow_id, node_id.clone(), clock.new_timestamp())?;
 
-        let (tx, rx) = flume::bounded(channel_capacity);
+        let (tx, rx) = tokio::sync::mpsc::channel(channel_capacity);
 
         let use_scheduler = match &channel {
             DaemonChannel::IntegrationTestChannel(_) => {
@@ -386,8 +390,13 @@ impl EventStream {
                                     // buffer (dora-rs/adora#132).
                                     let payload = sample.payload().clone();
 
+                                    // blocking_send: this thread is a plain
+                                    // std::thread (synchronous subscriber.recv
+                                    // loop), so calling the async Sender::send
+                                    // would require an executor. blocking_send
+                                    // is the documented primitive for this.
                                     if tx_clone
-                                        .send(EventItem::ZenohInput {
+                                        .blocking_send(EventItem::ZenohInput {
                                             id: input_id.clone(),
                                             metadata: std::sync::Arc::new(metadata),
                                             payload,
@@ -415,7 +424,7 @@ impl EventStream {
 
         Ok(EventStream {
             node_id: node_id.clone(),
-            receiver: rx.into_stream(),
+            receiver: rx,
             _thread_handle: thread_handle,
             _zenoh_thread_handles: zenoh_thread_handles,
             close_channel,
@@ -495,19 +504,19 @@ impl EventStream {
             return Some(event);
         }
         let event = if !self.use_scheduler {
-            self.receiver.next().await.map(Self::convert_event_item)
+            self.receiver.recv().await.map(Self::convert_event_item)
         } else {
             loop {
                 if self.scheduler.is_empty() {
-                    if let Some(event) = self.receiver.next().await {
+                    if let Some(event) = self.receiver.recv().await {
                         self.add_event(event);
                     } else {
                         break;
                     }
                 } else {
-                    match self.receiver.next().now_or_never().flatten() {
-                        Some(event) => self.add_event(event),
-                        None => break, // no other ready events
+                    match self.receiver.try_recv() {
+                        Ok(event) => self.add_event(event),
+                        Err(_) => break, // empty or disconnected
                     };
                 }
             }
@@ -1136,7 +1145,7 @@ impl Stream for EventStream {
 
         let poll = self
             .receiver
-            .poll_next_unpin(cx)
+            .poll_recv(cx)
             .map(|item| item.map(Self::convert_event_item));
 
         // Run first-message type check on the Stream path too.

--- a/apis/rust/node/src/event_stream/thread.rs
+++ b/apis/rust/node/src/event_stream/thread.rs
@@ -12,12 +12,13 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
+use tokio::sync::mpsc;
 
 use crate::daemon_connection::DaemonChannel;
 
 pub fn init(
     node_id: NodeId,
-    tx: flume::Sender<EventItem>,
+    tx: mpsc::Sender<EventItem>,
     channel: DaemonChannel,
     clock: Arc<uhlc::HLC>,
 ) -> eyre::Result<EventStreamThreadHandle> {
@@ -99,7 +100,7 @@ impl Drop for EventStreamThreadHandle {
 #[tracing::instrument(skip(tx, channel, clock))]
 fn event_stream_loop(
     node_id: NodeId,
-    tx: flume::Sender<EventItem>,
+    tx: mpsc::Sender<EventItem>,
     mut channel: DaemonChannel,
     clock: Arc<uhlc::HLC>,
 ) {
@@ -165,13 +166,18 @@ fn event_stream_loop(
 
             if let Some(tx) = tx.as_ref() {
                 let (drop_tx, drop_rx) = flume::bounded(0);
-                match tx.send(EventItem::NodeEvent {
+                // `blocking_send` is used because this function runs on a
+                // dedicated `std::thread` (not a tokio worker). Using
+                // `tokio::sync::mpsc` here — instead of `flume` — avoids the
+                // AB-BA deadlock between flume 0.10's spinlock and pyo3's
+                // GIL-acquiring waker (upstream dora-rs/dora#1603).
+                match tx.blocking_send(EventItem::NodeEvent {
                     event: inner,
                     ack_channel: drop_tx,
                 }) {
                     Ok(()) => {}
                     Err(send_error) => {
-                        let event = send_error.into_inner();
+                        let event = send_error.0;
                         tracing::trace!(
                             "event channel was closed already, could not forward `{event:?}`"
                         );
@@ -194,7 +200,8 @@ fn event_stream_loop(
     };
     if let Err(err) = result {
         if let Some(tx) = tx.as_ref() {
-            if let Err(flume::SendError(item)) = tx.send(EventItem::FatalError(err)) {
+            if let Err(mpsc::error::SendError(item)) = tx.blocking_send(EventItem::FatalError(err))
+            {
                 let err = match item {
                     EventItem::FatalError(err) => err,
                     _ => unreachable!(),


### PR DESCRIPTION
## Summary

Swap the EventStream's `EventItem` channel from `flume` to `tokio::sync::mpsc` to close the AB-BA deadlock described in upstream [dora-rs/dora#1603](https://github.com/dora-rs/dora/pull/1603).

## Why

**The deadlock recipe:**
- `flume 0.10.14`'s `AsyncSignal::fire()` holds `Spinlock<Waker>` while calling `waker.wake_by_ref()`.
- `pyo3 0.28.3`'s `AsyncioWaker::wake_by_ref` (at `pyo3-0.28.3/src/coroutine/waker.rs:43-51`) acquires the Python GIL inside `Python::attach`.
- Event-stream thread sends → holds Spinlock, waits for GIL.
- Python task polls `RecvStream` → holds GIL, waits for Spinlock.
- AB-BA deadlock.

**All three preconditions hold in adora:**
- `flume 0.10.14` is a direct dep of `dora-node-api` (`cargo tree -i flume:0.10.14`).
- `pyo3 0.28` still GILs inside the waker (I read the source — the upgrade did not fix this).
- Python async path is live: `recv_async` is exposed at `apis/python/node/src/lib.rs:286`; examples `python-async` and `python-recv-async` exercise it.

## Scope

Narrow on purpose. `flume` is used in 55 files across the workspace; only the EventStream's `EventItem` channel feeds the GIL-acquiring waker. Other flume channels (ack, drop signaling, thread-join) stay — they run on blocking threads with no async waker involvement.

Touched:
- `apis/rust/node/src/event_stream/thread.rs` — producer: `mpsc::Sender<EventItem>`, `blocking_send`, updated error match.
- `apis/rust/node/src/event_stream/mod.rs` — consumer: receiver field is raw `tokio::sync::mpsc::Receiver<EventItem>` (no stream wrapper — keeps `is_empty` direct); call sites: `.recv()` / `.try_recv()` / `.poll_recv(cx)` / `.is_empty()`. Zenoh subscriber threads also use `blocking_send`.
- `apis/rust/node/Cargo.toml` — add `sync` feature to tokio dep.
- `Cargo.toml` — bump workspace tokio minimum `1.24.2` → `1.28` (needed for `mpsc::Receiver::is_empty`, exposed through `EventStream::is_empty`). Lockfile already resolves 1.51.x; this just tightens the declared MSV.

Not touched: `ack_channel: flume::Sender<()>`, `drop_channel`, `EventStreamThreadHandle` internal join channel, drop-token pending receivers, daemon/runtime/bridge's own flume usage.

## Test plan

- [x] `cargo build -p dora-node-api` — clean
- [x] `cargo test -p dora-node-api` — 76 unit + 3 event_stream + 4 doctests pass
- [x] `cargo test --all --exclude <python>` — all workspace tests pass
- [x] `cargo clippy --all --exclude <python> -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] Manually run `python-recv-async` example under load to confirm no hang (optional; the fix is structural and test coverage is functional)
- [ ] CI green on all three platforms

## Notes on verification

No regression test was added for the deadlock itself — reproducing the AB-BA lock requires a real Python coroutine polling the receiver concurrently with a rust-thread sender, both going through pyo3's GIL-acquiring waker. That's a full integration test against the live binding, not a unit test. The functional unit tests (76 passing) cover the channel's functional behavior; the deadlock fix is structural and verified by code review.

Refs #265, #201.
