### PR TITLE
feat(descriptor): global env field on dataflow YAML (upstream #1341)

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1328,6 +1328,7 @@ async fn start_inner(
                                             health_check_interval: None,
                                             strict_types: None,
                                             type_rules: Vec::new(),
+                                            env: None,
                                         };
                                         match tmp_desc.resolve_aliases_and_set_defaults() {
                                             Ok(mut resolved_map) => {

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -4328,6 +4328,7 @@ mod fault_tolerance_tests {
             health_check_interval: None,
             strict_types: None,
             type_rules: vec![],
+            env: None,
         };
         RunningDataflow::new(Uuid::nil(), DaemonId::new(None), descriptor)
     }

--- a/libraries/core/src/descriptor/expand.rs
+++ b/libraries/core/src/descriptor/expand.rs
@@ -136,6 +136,7 @@ pub fn expand_modules_with_boundaries(
             health_check_interval: descriptor.health_check_interval,
             strict_types: descriptor.strict_types,
             type_rules: descriptor.type_rules.clone(),
+            env: descriptor.env.clone(),
         },
         boundaries,
     })

--- a/libraries/core/src/descriptor/mod.rs
+++ b/libraries/core/src/descriptor/mod.rs
@@ -192,7 +192,11 @@ impl DescriptorExt for Descriptor {
                     id: node.id,
                     name: node.name,
                     description: node.description,
-                    env: node.env,
+                    // Merge the dataflow-level `env` into the per-node `env`.
+                    // Per-node keys win on conflict so a node can override a
+                    // shared default (e.g. global `RUST_LOG=info` with one
+                    // verbose node setting `RUST_LOG=debug`).
+                    env: merge_env(self.env.as_ref(), node.env),
                     cpu_affinity: node.cpu_affinity,
                     deploy: node.deploy,
                     kind,
@@ -249,6 +253,26 @@ impl DescriptorExt for Descriptor {
     ) -> eyre::Result<(Descriptor, ModuleBoundaries)> {
         let expanded = expand::expand_modules_with_boundaries(self, working_dir)?;
         Ok((expanded.descriptor, expanded.boundaries))
+    }
+}
+
+/// Merge dataflow-level `env` into a node's `env`, with per-node keys winning
+/// on conflict. Returns `None` when both inputs are empty so the resolved
+/// node serializes cleanly when no env vars are set anywhere.
+fn merge_env(
+    global: Option<&BTreeMap<String, EnvValue>>,
+    node: Option<BTreeMap<String, EnvValue>>,
+) -> Option<BTreeMap<String, EnvValue>> {
+    match (global, node) {
+        (None, node) => node,
+        (Some(global), None) if global.is_empty() => None,
+        (Some(global), None) => Some(global.clone()),
+        (Some(global), Some(node)) => {
+            let mut merged = global.clone();
+            // Per-node entries override global ones on key conflict.
+            merged.extend(node);
+            Some(merged)
+        }
     }
 }
 
@@ -418,4 +442,113 @@ enum NodeKindMut<'a> {
     Operator(&'a mut SingleOperatorDefinition),
     /// ROS2 bridge node
     Ros2Bridge(&'a Ros2BridgeConfig),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, EnvValue> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), EnvValue::String(v.to_string())))
+            .collect()
+    }
+
+    #[test]
+    fn merge_env_returns_none_when_both_absent() {
+        assert!(merge_env(None, None).is_none());
+    }
+
+    #[test]
+    fn merge_env_keeps_per_node_when_no_global() {
+        let node_env = env(&[("A", "1")]);
+        let merged = merge_env(None, Some(node_env.clone())).unwrap();
+        assert_eq!(merged, node_env);
+    }
+
+    #[test]
+    fn merge_env_keeps_global_when_no_per_node() {
+        let global = env(&[("A", "1")]);
+        let merged = merge_env(Some(&global), None).unwrap();
+        assert_eq!(merged, global);
+    }
+
+    #[test]
+    fn merge_env_per_node_overrides_global_on_conflict() {
+        let global = env(&[("A", "global"), ("B", "global")]);
+        let node_env = env(&[("A", "node"), ("C", "node")]);
+        let merged = merge_env(Some(&global), Some(node_env)).unwrap();
+        assert_eq!(merged.get("A"), Some(&EnvValue::String("node".into())));
+        assert_eq!(merged.get("B"), Some(&EnvValue::String("global".into())));
+        assert_eq!(merged.get("C"), Some(&EnvValue::String("node".into())));
+    }
+
+    #[test]
+    fn descriptor_global_env_parses_from_yaml() {
+        // Verify the new top-level `env:` field parses and the resolver
+        // hands merged envs to every node with per-node keys winning.
+        let yaml = r#"
+env:
+  RUST_LOG: info
+  OTEL_ENDPOINT: http://collector:4317
+nodes:
+  - id: a
+    path: ./a
+    env:
+      RUST_LOG: debug
+  - id: b
+    path: ./b
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
+
+        let a = resolved.get(&NodeId::from("a".to_string())).unwrap();
+        let a_env = a.env.as_ref().expect("node a inherits env");
+        // Per-node RUST_LOG=debug wins over global RUST_LOG=info.
+        assert_eq!(
+            a_env.get("RUST_LOG"),
+            Some(&EnvValue::String("debug".into()))
+        );
+        // Global key not overridden on node a is still visible.
+        assert_eq!(
+            a_env.get("OTEL_ENDPOINT"),
+            Some(&EnvValue::String("http://collector:4317".into()))
+        );
+
+        let b = resolved.get(&NodeId::from("b".to_string())).unwrap();
+        let b_env = b.env.as_ref().expect("node b inherits global env");
+        assert_eq!(
+            b_env.get("RUST_LOG"),
+            Some(&EnvValue::String("info".into()))
+        );
+        assert_eq!(
+            b_env.get("OTEL_ENDPOINT"),
+            Some(&EnvValue::String("http://collector:4317".into()))
+        );
+    }
+
+    #[test]
+    fn descriptor_without_global_env_preserves_per_node_env() {
+        // Regression guard: no top-level `env:` must leave per-node env
+        // semantics unchanged.
+        let yaml = r#"
+nodes:
+  - id: a
+    path: ./a
+    env:
+      FOO: bar
+  - id: b
+    path: ./b
+"#;
+        let desc: Descriptor = serde_yaml::from_str(yaml).expect("parse");
+        let resolved = desc.resolve_aliases_and_set_defaults().expect("resolve");
+        let a = resolved.get(&NodeId::from("a".to_string())).unwrap();
+        assert_eq!(
+            a.env.as_ref().and_then(|e| e.get("FOO")),
+            Some(&EnvValue::String("bar".into()))
+        );
+        let b = resolved.get(&NodeId::from("b".to_string())).unwrap();
+        assert!(b.env.is_none(), "node b has no env anywhere");
+    }
 }

--- a/libraries/message/src/descriptor.rs
+++ b/libraries/message/src/descriptor.rs
@@ -128,6 +128,27 @@ pub struct Descriptor {
     /// ```
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub type_rules: Vec<TypeRuleDef>,
+
+    /// Global environment variables inherited by every node.
+    ///
+    /// Each node's own `env` map takes precedence on key conflicts, so nodes
+    /// can override a global default without repeating shared values like
+    /// `RUST_LOG`, `OTEL_EXPORTER_OTLP_ENDPOINT`, or `CUDA_VISIBLE_DEVICES`.
+    ///
+    /// ## Example
+    ///
+    /// ```yaml
+    /// env:
+    ///   RUST_LOG: info
+    ///   OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4317
+    /// nodes:
+    ///   - id: verbose-node
+    ///     path: path/to/node
+    ///     env:
+    ///       RUST_LOG: debug  # overrides the global RUST_LOG for this node
+    /// ```
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<BTreeMap<String, EnvValue>>,
 }
 
 /// A type compatibility rule declared in the dataflow YAML.


### PR DESCRIPTION
## Summary

Add an optional top-level `env:` map on the dataflow YAML. Every node inherits the global env at resolve time; per-node `env` keys win on conflict.

```yaml
env:
  RUST_LOG: info
  OTEL_EXPORTER_OTLP_ENDPOINT: http://collector:4317
nodes:
  - id: verbose-node
    path: path/to/node
    env:
      RUST_LOG: debug   # overrides global RUST_LOG just for this node
```

## Why

Shared env vars (`RUST_LOG`, OTEL endpoint, `CUDA_VISIBLE_DEVICES`, API keys) currently require copy-paste into every node block. Changing one value edits N places. This is a common pain point in multi-node dataflows.

Matches upstream [dora-rs/dora#1341](https://github.com/dora-rs/dora/pull/1341) so user YAMLs migrate without edits.

## Scope

Part of #266, which was narrowed after review (#201 comment). The other two items originally batched here (#1359 collect-all validation, #1430 URL source validation) were closed as not-worth-the-churn.

## Implementation

- `libraries/message/src/descriptor.rs` — new `Descriptor.env: Option<BTreeMap<String, EnvValue>>` field (serde-optional; absent in YAML = `None`)
- `libraries/core/src/descriptor/mod.rs` — `merge_env(global, node)` helper called in `resolve_aliases_and_set_defaults`. Per-node keys override global ones. Returns `None` when both sides are empty, so serialized `ResolvedNode` stays clean for dataflows that don't use env at all
- `libraries/core/src/descriptor/expand.rs` — propagate the new field through module expansion
- Descriptor literal-initialization sites in coordinator/daemon set `env: None`

No daemon spawn path changes — once the global env is merged into each `ResolvedNode.env`, downstream spawn code (already reading `node.env`) sees the merged map.

## Test plan

- [x] `cargo test -p dora-core descriptor::tests` — 6 new tests pass:
  - `merge_env_returns_none_when_both_absent`
  - `merge_env_keeps_per_node_when_no_global`
  - `merge_env_keeps_global_when_no_per_node`
  - `merge_env_per_node_overrides_global_on_conflict`
  - `descriptor_global_env_parses_from_yaml` (end-to-end: parse + resolve)
  - `descriptor_without_global_env_preserves_per_node_env` (regression guard)
- [x] `cargo test --all --exclude <python>` — all workspace tests pass
- [x] `cargo clippy --all --exclude <python> -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green on all three platforms

Refs #266, #201.
