### PR TITLE
ci: fix all CI failures on main (typos, audit, benchmark, cross, c-dataflow, shutdown race, timeout)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,12 +202,17 @@ jobs:
           Remove-Item "C:\Android" -Force -Recurse
           Remove-Item "C:\hostedtoolcache\windows\go" -Force -Recurse
           Remove-Item "C:\hostedtoolcache\windows\CodeQL" -Force -Recurse
-      # No `cargo install --path binaries/cli` here: every example in this
-      # job calls into `dora_cli` as a library (via `examples/*/run.rs`).
-      # The `dora` CLI binary is not on PATH and not required.
-      - name: Build examples
+      # Examples call dora_cli as a library (via `examples/*/run.rs`) but the
+      # daemon still spawns runtime nodes as child processes via
+      # `which::which("dora")`. Build the CLI binary and add it to PATH so
+      # C/C++ runtime-node examples can find it.
+      - name: Build examples + CLI binary
         timeout-minutes: 30
-        run: cargo build --examples
+        shell: bash
+        run: |
+          cargo build --examples
+          cargo build -p dora-cli
+          echo "${{ github.workspace }}/target/debug" >> $GITHUB_PATH
       - name: Rust Dataflow example
         timeout-minutes: 30
         run: cargo run --example rust-dataflow
@@ -259,7 +264,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
-    timeout-minutes: 60
+    # Windows builds + Python Dynamic Node tests are slower than other
+    # platforms; 60 min is not enough when the runner is under load.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5857,9 +5857,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,7 @@
+# Cross-compilation Docker images for `cross` (https://github.com/cross-rs/cross).
+#
+# The default i686-unknown-linux-gnu image ships an older glibc that cannot
+# run build scripts compiled on the host (num-traits needs GLIBC_2.25+).
+# Pin a newer image that ships glibc 2.31+.
+[target.i686-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/i686-unknown-linux-gnu:main"

--- a/_typos.toml
+++ b/_typos.toml
@@ -15,3 +15,5 @@ criticals = "criticals"
 unparseable = "unparseable"
 # abbreviation for "serialize"
 ser = "ser"
+# AB-BA is a standard term for lock-ordering deadlocks (not a typo of "BY"/"BE")
+BA = "BA"

--- a/binaries/coordinator/src/handlers.rs
+++ b/binaries/coordinator/src/handlers.rs
@@ -185,7 +185,13 @@ pub(crate) async fn handle_destroy(
         .await?;
     }
 
-    destroy_daemons(daemon_connections, clock.new_timestamp()).await
+    destroy_daemons(daemon_connections, clock.new_timestamp()).await?;
+    // Brief grace period so daemons have time to flush final messages and
+    // close their WS connections before the coordinator shuts down the
+    // listener. Without this, daemons see "Connection refused" when they
+    // try to send a final acknowledgement or reconnect during teardown.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    Ok(())
 }
 
 pub(crate) async fn send_heartbeat_message(

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -93,6 +93,7 @@ pub mod bench_support {
             health_check_interval: None,
             strict_types: None,
             type_rules: vec![],
+            env: None,
         };
         let mut df = RunningDataflow::new(Uuid::nil(), DaemonId::new(None), descriptor);
 


### PR DESCRIPTION
## Summary

Fixes all 7 CI failures on main -- 3 introduced by recent upstream-backport PRs and 4 pre-existing.

### Fixes introduced by our PRs (commit 1)

- **Typos**: add `BA` to `_typos.toml` -- `AB-BA` is a standard term for lock-ordering deadlocks
- **Audit**: bump `rustls-webpki` 0.103.11 to 0.103.12 (RUSTSEC-2026-0098, RUSTSEC-2026-0099)
- **Benchmark compile**: add missing `env: None` to `Descriptor` literal at `daemon/src/lib.rs:88`

### Pre-existing fixes (commit 2)

- **Cross-check i686**: create `Cross.toml` pinning a newer Docker image for `i686-unknown-linux-gnu`. Default image ships glibc < 2.25; `num-traits` build scripts need 2.25+.
- **Windows C Dataflow**: build `dora-cli` binary and add `target/debug` to `$GITHUB_PATH`. C/C++ examples use runtime nodes that spawn child processes via `which::which("dora")`.
- **Multi-daemon shutdown race**: add 200ms grace period after `destroy_daemons()` in coordinator (`handlers.rs`). WS listener was shutting down before daemons finished flushing, causing "Connection refused" on macOS/Ubuntu CI.
- **CLI Tests timeout**: increase job timeout from 60 to 90 minutes. Windows builds + Python Dynamic Node tests exceed 60 min under load.

## Test plan

- [x] `cargo check --all` -- clean
- [x] `cargo test -p dora-daemon` -- 28/28 pass
- [x] `cargo clippy -p dora-coordinator -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [ ] CI: all 7 previously-failing jobs should now pass
