### PR TITLE
ci(nightly): fix 3 regression failures (#249)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -288,12 +288,26 @@ jobs:
           echo "$out" | grep -q 'Active dataflows:' || { echo "ERROR: missing dataflow summary"; exit 1; }
       - name: Run a dataflow through the cluster
         run: |
-          # Use `dora start` + `dora stop`, not `dora run`: a coordinator
-          # is already running from `dora up` above. `dora run` starts an
-          # embedded coordinator on the same port → "Address already in use".
+          # Use `dora start`, not `dora run`: a coordinator is already
+          # running from `dora up`. `dora run` starts an embedded
+          # coordinator on the same port → "Address already in use".
+          #
+          # rust-dataflow is finite (~1s), so poll until it finishes
+          # rather than sleeping + calling `dora stop` on something
+          # that's already done.
           dora start examples/rust-dataflow/dataflow.yml --detach
-          sleep 12
-          dora stop --name rust-dataflow
+          for i in $(seq 1 30); do
+            sleep 1
+            if ! dora list 2>/dev/null | grep -q rust-dataflow; then
+              echo "dataflow completed after ${i}s"
+              break
+            fi
+            if [ "$i" -eq 30 ]; then
+              echo "ERROR: dataflow did not finish within 30s"
+              dora stop --name rust-dataflow || true
+              exit 1
+            fi
+          done
       - name: cluster down tears everything down cleanly
         run: |
           dora cluster down

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -230,8 +230,10 @@ jobs:
       - name: Record rust-dataflow
         run: |
           # `dora record <yaml>` instruments the dataflow and runs it;
-          # recording written to `recording_<timestamp>.adorec`.
-          timeout 20s dora record examples/rust-dataflow/dataflow.yml -o run.adorec || true
+          # recording written to the specified output path.
+          # Nodes are pre-built above so the 30s timeout covers only runtime.
+          # Don't swallow errors (no `|| true`) — real failures should surface.
+          timeout 30s dora record examples/rust-dataflow/dataflow.yml -o run.adorec
           test -f run.adorec || { echo "record did not produce run.adorec"; exit 1; }
           echo "recording size: $(wc -c < run.adorec) bytes"
       - name: Replay
@@ -285,7 +287,13 @@ jobs:
           test "$daemon_lines" -ge 1 || { echo "ERROR: no daemons listed"; exit 1; }
           echo "$out" | grep -q 'Active dataflows:' || { echo "ERROR: missing dataflow summary"; exit 1; }
       - name: Run a dataflow through the cluster
-        run: dora run examples/rust-dataflow/dataflow.yml --stop-after 10s
+        run: |
+          # Use `dora start` + `dora stop`, not `dora run`: a coordinator
+          # is already running from `dora up` above. `dora run` starts an
+          # embedded coordinator on the same port → "Address already in use".
+          dora start examples/rust-dataflow/dataflow.yml --detach
+          sleep 12
+          dora stop --name rust-dataflow
       - name: cluster down tears everything down cleanly
         run: |
           dora cluster down

--- a/tests/example-smoke.rs
+++ b/tests/example-smoke.rs
@@ -537,10 +537,13 @@ fn smoke_local_python_multiple_arrays() {
 
 #[test]
 fn smoke_local_python_concurrent_rw() {
+    // 15s gives more headroom on slow CI runners — this example has two
+    // Python nodes in circular data dependency with threaded publish/read,
+    // and each publishes every 1s; 10s was too tight under load.
     run_smoke_test_local(
         "local-python-concurrent-rw",
         "examples/python-concurrent-rw/dataflow.yml",
-        10,
+        15,
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes the 3 nightly regression failures tracked in #249.

### 1. Cluster lifecycle smoke -- port collision

`dora up` starts a long-running coordinator on port 6013. Then `dora run` at line 288 tries to start an *embedded* coordinator on the same port: "Address already in use (os error 98)".

Fix: use `dora start --detach` + `dora stop` so the existing coordinator is reused.

### 2. Record/replay -- timeout + swallowed errors

`timeout 20s dora record ... || true` silently swallows the timeout. Nodes are already pre-built, so 20s should cover runtime only, but slow CI runners sometimes need more.

Fix: increase to 30s, remove `|| true` so real errors surface.

### 3. Python concurrent RW -- timing on slow runners

Two Python nodes in circular data dependency, each publishing every 1s. With `--stop-after 10s`, slow CI runners don't give enough time for the publish/read cycle to stabilize.

Fix: increase `stop_after` from 10s to 15s.

## Test plan

- [x] `cargo fmt --all -- --check` -- clean
- [ ] Nightly CI validates all 3 fixes (next scheduled run or manual trigger)

Closes #249.
