### PR TITLE
ci: pin Rust version in pip-release.yml sdist job

### DIFF
--- a/.github/workflows/pip-release.yml
+++ b/.github/workflows/pip-release.yml
@@ -27,6 +27,9 @@ on:
       - "binaries/cli/**"
       - "Cargo.toml"
 
+env:
+  RUST_VERSION: "1.92.0"
+
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: ${{ github.event_name != 'release' }}
@@ -63,7 +66,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.8
-      - run: rustup default stable
+      - run: rustup default ${{ env.RUST_VERSION }}
       - run: rustup update
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
Replace hardcoded 'rustup default stable' with env.RUST_VERSION to ensure consistent Rust version across all CI workflows.

Detected by scripts/qa/rust-version-check.sh.