### PR TITLE
ci: pin newer cross images for all 4 cross-check targets

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,16 @@
 # Cross-compilation Docker images for `cross` (https://github.com/cross-rs/cross).
 #
-# The default i686-unknown-linux-gnu image ships an older glibc that cannot
-# run build scripts compiled on the host (num-traits needs GLIBC_2.25+).
-# Pin a newer image that ships glibc 2.31+.
+# The default images ship an older glibc that cannot run build scripts
+# compiled on the host (serde_core needs GLIBC_2.28+, num-traits needs
+# GLIBC_2.25+). Pin the `main` tag which ships glibc 2.31+.
 [target.i686-unknown-linux-gnu]
 image = "ghcr.io/cross-rs/i686-unknown-linux-gnu:main"
+
+[target.aarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:main"
+
+[target.aarch64-unknown-linux-musl]
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl:main"
+
+[target.armv7-unknown-linux-musleabihf]
+image = "ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main"


### PR DESCRIPTION
## Summary

Pin newer cross Docker images for all 4 cross-check targets, not just i686.

## Why

PR #272 fixed the i686 GLIBC mismatch but left the other 3 cross targets on default images. The `aarch64-unknown-linux-musl` target failed on the very next CI run with the same class of error (`serde_core` build script needs GLIBC_2.28+). Rather than playing whack-a-mole, pin all 4 targets to `main` tag (glibc 2.31+).

## Changes

`Cross.toml` -- add entries for `aarch64-unknown-linux-gnu`, `aarch64-unknown-linux-musl`, and `armv7-unknown-linux-musleabihf` alongside the existing `i686-unknown-linux-gnu`.

## Test plan

- [ ] All 4 cross-check jobs pass in CI
