### PR TITLE
chore(nightly): force GHA workflow re-index

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@ name: Nightly Regression
 # Triggers:
 #   - schedule: daily at 06:00 UTC
 #   - workflow_dispatch: manual run from Actions UI
+#   - push to main: re-run on every push (validates nightly jobs on each commit)
 
 on:
   schedule:


### PR DESCRIPTION
Trivial comment change to force GitHub Actions to re-parse the nightly workflow. The workflow index is stale after rapid pushes and rejects `workflow_dispatch` even though the trigger is defined.