### PR TITLE
refactor(cli): roll out expect_reply! across all call sites (-204 lines)

### DIFF
--- a/binaries/cli/src/command/build/distributed.rs
+++ b/binaries/cli/src/command/build/distributed.rs
@@ -3,13 +3,13 @@ use dora_message::{
     BuildId,
     cli_to_coordinator::ControlRequest,
     common::{GitSource, LogMessage},
-    coordinator_to_cli::ControlRequestReply,
     id::NodeId,
 };
 use eyre::{Context, bail};
 use std::collections::BTreeMap;
 
 use crate::{
+    common::{expect_reply, send_control_request},
     output::{LogOutputConfig, print_log_message},
     session::DataflowSession,
     ws_client::WsSession,
@@ -23,32 +23,19 @@ pub fn build_distributed_dataflow(
     local_working_dir: Option<std::path::PathBuf>,
     uv: bool,
 ) -> eyre::Result<BuildId> {
-    let build_id = {
-        let reply_raw = session
-            .request(
-                &serde_json::to_vec(&ControlRequest::Build {
-                    session_id: dataflow_session.session_id,
-                    dataflow,
-                    git_sources: git_sources.clone(),
-                    prev_git_sources: dataflow_session.git_sources.clone(),
-                    local_working_dir,
-                    uv,
-                })
-                .unwrap(),
-            )
-            .wrap_err("failed to send start dataflow message")?;
-
-        let result: ControlRequestReply =
-            serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-        match result {
-            ControlRequestReply::DataflowBuildTriggered { build_id } => {
-                println!("dataflow build triggered: {build_id}");
-                build_id
-            }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected start dataflow reply: {other:?}"),
-        }
-    };
+    let reply = send_control_request(
+        session,
+        &ControlRequest::Build {
+            session_id: dataflow_session.session_id,
+            dataflow,
+            git_sources: git_sources.clone(),
+            prev_git_sources: dataflow_session.git_sources.clone(),
+            local_working_dir,
+            uv,
+        },
+    )?;
+    let build_id = expect_reply!(reply, DataflowBuildTriggered { build_id })?;
+    println!("dataflow build triggered: {build_id}");
     Ok(build_id)
 }
 
@@ -84,21 +71,13 @@ pub fn wait_until_dataflow_built(
         }
     });
 
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::WaitForBuild { build_id }).unwrap())
-        .wrap_err("failed to send WaitForBuild message")?;
-
-    let result: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
+    let reply = send_control_request(session, &ControlRequest::WaitForBuild { build_id })?;
+    let (build_id, result) = expect_reply!(reply, DataflowBuildFinished { build_id, result })?;
     match result {
-        ControlRequestReply::DataflowBuildFinished { build_id, result } => match result {
-            Ok(()) => {
-                println!("dataflow build finished successfully");
-                Ok(build_id)
-            }
-            Err(err) => bail!("{err}"),
-        },
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected start dataflow reply: {other:?}"),
+        Ok(()) => {
+            println!("dataflow build finished successfully");
+            Ok(build_id)
+        }
+        Err(err) => bail!("{err}"),
     }
 }

--- a/binaries/cli/src/command/cluster/mod.rs
+++ b/binaries/cli/src/command/cluster/mod.rs
@@ -1,11 +1,12 @@
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, DaemonInfo},
-};
-use eyre::{Context, bail};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::DaemonInfo};
+use eyre::Context;
 use std::collections::BTreeMap;
 
-use crate::{command::Executable, ws_client::WsSession};
+use crate::{
+    command::Executable,
+    common::{expect_reply, send_control_request},
+    ws_client::WsSession,
+};
 
 use self::config::MachineConfig;
 
@@ -45,16 +46,8 @@ impl Executable for Cluster {
 }
 
 pub(crate) fn query_connected_daemons(session: &WsSession) -> eyre::Result<Vec<DaemonInfo>> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::ConnectedMachines).unwrap())
-        .wrap_err("failed to send ConnectedMachines request")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match reply {
-        ControlRequestReply::ConnectedDaemons(daemons) => Ok(daemons),
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected reply: {other:?}"),
-    }
+    let reply = send_control_request(session, &ControlRequest::ConnectedMachines)?;
+    Ok(expect_reply!(reply, ConnectedDaemons(daemons))?)
 }
 
 // ---------------------------------------------------------------------------

--- a/binaries/cli/src/command/cluster/restart.rs
+++ b/binaries/cli/src/command/cluster/restart.rs
@@ -1,13 +1,11 @@
 use std::{net::SocketAddr, path::PathBuf};
 
 use clap::Args;
-use eyre::{Context, bail};
-
-use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
+use dora_message::cli_to_coordinator::ControlRequest;
 
 use crate::{
     command::{Executable, default_tracing},
-    common::connect_to_coordinator,
+    common::{connect_to_coordinator, expect_reply, send_control_request},
 };
 
 use super::config::ClusterConfig;
@@ -46,19 +44,9 @@ impl Executable for Restart {
             grace_duration: None,
             force: false,
         };
-        let reply_raw = session
-            .request(&serde_json::to_vec(&request).unwrap())
-            .wrap_err("failed to send Restart request")?;
-        let reply: ControlRequestReply =
-            serde_json::from_slice(&reply_raw).wrap_err("failed to parse Restart reply")?;
-
-        match reply {
-            ControlRequestReply::DataflowRestarted { old_uuid, new_uuid } => {
-                println!("dataflow restarted: {old_uuid} -> {new_uuid}");
-            }
-            ControlRequestReply::Error(err) => bail!("failed to restart dataflow: {err}"),
-            other => bail!("unexpected reply: {other:?}"),
-        }
+        let reply = send_control_request(&session, &request)?;
+        let (old_uuid, new_uuid) = expect_reply!(reply, DataflowRestarted { old_uuid, new_uuid })?;
+        println!("dataflow restarted: {old_uuid} -> {new_uuid}");
 
         Ok(())
     }

--- a/binaries/cli/src/command/doctor.rs
+++ b/binaries/cli/src/command/doctor.rs
@@ -5,13 +5,13 @@ use termcolor::{Color, ColorChoice, ColorSpec, WriteColor};
 
 use crate::{
     command::{Executable, default_tracing},
-    common::{CoordinatorOptions, connect_to_coordinator, query_running_dataflows},
+    common::{
+        CoordinatorOptions, connect_to_coordinator, expect_reply, query_running_dataflows,
+        send_control_request,
+    },
     ws_client::WsSession,
 };
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, DataflowStatus},
-};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::DataflowStatus};
 use eyre::Context;
 
 /// Run comprehensive system diagnostics.
@@ -226,41 +226,20 @@ fn warn(stdout: &mut termcolor::StandardStream, msg: &str) -> eyre::Result<()> {
 }
 
 fn check_daemon(session: &WsSession) -> eyre::Result<bool> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::DaemonConnected).unwrap())
-        .wrap_err("failed to send DaemonConnected")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match reply {
-        ControlRequestReply::DaemonConnected(running) => Ok(running),
-        other => eyre::bail!("unexpected reply: {other:?}"),
-    }
+    let reply = send_control_request(session, &ControlRequest::DaemonConnected)?;
+    Ok(expect_reply!(reply, DaemonConnected(running))?)
 }
 
 fn check_connected_machines(
     session: &WsSession,
 ) -> eyre::Result<Vec<dora_message::coordinator_to_cli::DaemonInfo>> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::ConnectedMachines).unwrap())
-        .wrap_err("failed to send ConnectedMachines")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match reply {
-        ControlRequestReply::ConnectedDaemons(daemons) => Ok(daemons),
-        other => eyre::bail!("unexpected reply: {other:?}"),
-    }
+    let reply = send_control_request(session, &ControlRequest::ConnectedMachines)?;
+    Ok(expect_reply!(reply, ConnectedDaemons(daemons))?)
 }
 
 fn check_node_health(session: &WsSession) -> eyre::Result<(usize, usize, usize, usize)> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::GetNodeInfo).unwrap())
-        .wrap_err("failed to send GetNodeInfo")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    let nodes = match reply {
-        ControlRequestReply::NodeInfoList(infos) => infos,
-        other => eyre::bail!("unexpected reply: {other:?}"),
-    };
+    let reply = send_control_request(session, &ControlRequest::GetNodeInfo)?;
+    let nodes = expect_reply!(reply, NodeInfoList(infos))?;
 
     let total = nodes.len();
     let mut healthy = 0usize;

--- a/binaries/cli/src/command/inspect/top.rs
+++ b/binaries/cli/src/command/inspect/top.rs
@@ -9,12 +9,8 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, NodeInfo},
-    id::NodeId,
-};
-use eyre::{Context, eyre};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::NodeInfo, id::NodeId};
+use eyre::eyre;
 use ratatui::{
     Frame, Terminal,
     backend::{Backend, CrosstermBackend},
@@ -24,7 +20,9 @@ use ratatui::{
 };
 use uuid::Uuid;
 
-use crate::common::{CoordinatorOptions, connect_to_coordinator};
+use crate::common::{
+    CoordinatorOptions, connect_to_coordinator, expect_reply, send_control_request,
+};
 
 use super::super::{Executable, default_tracing};
 
@@ -278,23 +276,10 @@ impl App {
 
 fn query_once(coordinator_addr: std::net::SocketAddr) -> eyre::Result<()> {
     let session = connect_to_coordinator(coordinator_addr)?;
-
-    let request = ControlRequest::GetNodeInfo;
-    let reply_raw = session
-        .request(&serde_json::to_vec(&request).unwrap())
-        .wrap_err("failed to send request to coordinator")?;
-
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-
-    match reply {
-        ControlRequestReply::NodeInfoList(infos) => {
-            println!("{}", serde_json::to_string_pretty(&infos).unwrap());
-            Ok(())
-        }
-        ControlRequestReply::Error(err) => Err(eyre!("coordinator error: {err}")),
-        _ => Err(eyre!("unexpected reply from coordinator")),
-    }
+    let reply = send_control_request(&session, &ControlRequest::GetNodeInfo)?;
+    let infos = expect_reply!(reply, NodeInfoList(infos))?;
+    println!("{}", serde_json::to_string_pretty(&infos).unwrap());
+    Ok(())
 }
 
 fn run_app<B: Backend>(
@@ -309,23 +294,8 @@ fn run_app<B: Backend>(
     let session = connect_to_coordinator(coordinator_addr)?;
 
     // Query node info once initially
-    let request = ControlRequest::GetNodeInfo;
-    let reply_raw = session
-        .request(&serde_json::to_vec(&request).unwrap())
-        .wrap_err("failed to send initial request to coordinator")?;
-
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-
-    let mut node_infos = match reply {
-        ControlRequestReply::NodeInfoList(infos) => infos,
-        ControlRequestReply::Error(err) => {
-            return Err(eyre!("coordinator error: {err}"));
-        }
-        _ => {
-            return Err(eyre!("unexpected reply from coordinator"));
-        }
-    };
+    let reply = send_control_request(&session, &ControlRequest::GetNodeInfo)?;
+    let mut node_infos = expect_reply!(reply, NodeInfoList(infos))?;
     app.update_stats(node_infos.clone());
 
     loop {
@@ -371,25 +341,8 @@ fn run_app<B: Backend>(
         // Update data if refresh interval has passed
         if last_update.elapsed() >= refresh_duration {
             // Query node info every refresh interval to get updated metrics
-            let request = ControlRequest::GetNodeInfo;
-            let reply_raw = session
-                .request(&serde_json::to_vec(&request).unwrap())
-                .wrap_err("failed to send request to coordinator")?;
-
-            let reply: ControlRequestReply =
-                serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-
-            match reply {
-                ControlRequestReply::NodeInfoList(infos) => {
-                    node_infos = infos;
-                }
-                ControlRequestReply::Error(err) => {
-                    return Err(eyre!("coordinator error: {err}"));
-                }
-                _ => {
-                    return Err(eyre!("unexpected reply from coordinator"));
-                }
-            }
+            let reply = send_control_request(&session, &ControlRequest::GetNodeInfo)?;
+            node_infos = expect_reply!(reply, NodeInfoList(infos))?;
 
             // Update stats with current node info
             app.update_stats(node_infos.clone());

--- a/binaries/cli/src/command/logs.rs
+++ b/binaries/cli/src/command/logs.rs
@@ -6,7 +6,10 @@ use std::{
 
 use super::{Executable, default_tracing};
 use crate::{
-    common::{CoordinatorOptions, resolve_dataflow_identifier_interactive},
+    common::{
+        CoordinatorOptions, expect_reply, resolve_dataflow_identifier_interactive,
+        send_control_request,
+    },
     output::{
         LogFormat, LogOutputConfig, parse_jsonl_line, parse_log_filter, parse_log_level_str,
         print_log_message,
@@ -15,10 +18,7 @@ use crate::{
 };
 use chrono::{DateTime, Utc};
 use clap::Args;
-use dora_message::{
-    cli_to_coordinator::ControlRequest, common::LogMessage,
-    coordinator_to_cli::ControlRequestReply, id::NodeId,
-};
+use dora_message::{cli_to_coordinator::ControlRequest, common::LogMessage, id::NodeId};
 use duration_str::parse as parse_duration_str;
 use eyre::{Context, Result, bail};
 use uuid::Uuid;
@@ -807,28 +807,21 @@ pub fn logs(
     config: &LogOutputConfig,
 ) -> Result<()> {
     let logs = {
-        let reply_raw = session
-            .request(
-                &serde_json::to_vec(&ControlRequest::Logs {
-                    uuid: Some(uuid),
-                    name: None,
-                    node: node.to_string(),
-                    tail: if since.is_some() || until.is_some() || grep.is_some() {
-                        // Fetch all logs when filtering client-side, apply tail after
-                        None
-                    } else {
-                        tail
-                    },
-                })
-                .wrap_err("failed to serialize Logs request")?,
-            )
-            .wrap_err("failed to send Logs request message")?;
-
-        let reply = serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-        match reply {
-            ControlRequestReply::Logs(data) => data,
-            other => bail!("unexpected reply to daemon logs: {other:?}"),
-        }
+        let reply = send_control_request(
+            session,
+            &ControlRequest::Logs {
+                uuid: Some(uuid),
+                name: None,
+                node: node.to_string(),
+                tail: if since.is_some() || until.is_some() || grep.is_some() {
+                    // Fetch all logs when filtering client-side, apply tail after
+                    None
+                } else {
+                    tail
+                },
+            },
+        )?;
+        expect_reply!(reply, Logs(data))?
     };
 
     // Unified filter pipeline: parse -> time_filter -> grep -> tail -> print

--- a/binaries/cli/src/command/node/info.rs
+++ b/binaries/cli/src/command/node/info.rs
@@ -7,18 +7,18 @@ use tabwriter::TabWriter;
 
 use crate::{
     command::{Executable, default_tracing},
-    common::{CoordinatorOptions, resolve_dataflow_identifier_interactive},
+    common::{
+        CoordinatorOptions, expect_reply, resolve_dataflow_identifier_interactive,
+        send_control_request,
+    },
     formatting::OutputFormat,
     ws_client::WsSession,
 };
 use dora_core::config::InputMapping;
 use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, NodeInfo},
-    descriptor::Descriptor,
+    cli_to_coordinator::ControlRequest, coordinator_to_cli::NodeInfo, descriptor::Descriptor,
     id::NodeId,
 };
-use eyre::{Context, bail};
 
 /// Show detailed information about a specific node.
 ///
@@ -122,18 +122,8 @@ fn info(
     let dataflow_uuid = resolve_dataflow_identifier_interactive(session, dataflow_filter)?;
 
     // Get descriptor
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::Info { dataflow_uuid }).unwrap())
-        .wrap_err("failed to send Info request")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    let (dataflow_name, descriptor) = match reply {
-        ControlRequestReply::DataflowInfo {
-            name, descriptor, ..
-        } => (name, descriptor),
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected reply: {other:?}"),
-    };
+    let reply = send_control_request(session, &ControlRequest::Info { dataflow_uuid })?;
+    let (dataflow_name, descriptor) = expect_reply!(reply, DataflowInfo { name, descriptor })?;
 
     // Find the node in the descriptor
     let node_desc = descriptor
@@ -198,16 +188,8 @@ fn fetch_node_metrics(
     dataflow_uuid: uuid::Uuid,
     node_id: &NodeId,
 ) -> eyre::Result<Option<NodeInfo>> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::GetNodeInfo).unwrap())
-        .wrap_err("failed to send GetNodeInfo request")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    let node_infos = match reply {
-        ControlRequestReply::NodeInfoList(infos) => infos,
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected reply: {other:?}"),
-    };
+    let reply = send_control_request(session, &ControlRequest::GetNodeInfo)?;
+    let node_infos = expect_reply!(reply, NodeInfoList(infos))?;
 
     Ok(node_infos
         .into_iter()

--- a/binaries/cli/src/command/node/list.rs
+++ b/binaries/cli/src/command/node/list.rs
@@ -7,15 +7,11 @@ use uuid::Uuid;
 
 use crate::{
     command::{Executable, default_tracing},
-    common::CoordinatorOptions,
+    common::{CoordinatorOptions, expect_reply, send_control_request},
     formatting::OutputFormat,
     ws_client::WsSession,
 };
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, NodeInfo},
-};
-use eyre::{Context, bail};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::NodeInfo};
 
 /// List all currently running nodes and their status.
 ///
@@ -76,18 +72,8 @@ fn list(
     quiet: bool,
 ) -> eyre::Result<()> {
     // Request node information from coordinator
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::GetNodeInfo).unwrap())
-        .wrap_err("failed to send GetNodeInfo request")?;
-
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-
-    let node_infos = match reply {
-        ControlRequestReply::NodeInfoList(infos) => infos,
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected reply: {other:?}"),
-    };
+    let reply = send_control_request(session, &ControlRequest::GetNodeInfo)?;
+    let node_infos = expect_reply!(reply, NodeInfoList(infos))?;
 
     // Filter by dataflow if specified
     let filtered_nodes: Vec<NodeInfo> = if let Some(ref filter) = dataflow_filter {

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -2,22 +2,20 @@
 //!
 //! The `dora start` command does not run any build commands, nor update git dependencies or similar. Use `dora build` for that.
 
-use super::{Executable, default_tracing};
+use super::{default_tracing, Executable};
 use crate::{
     command::start::attach::attach_dataflow,
     common::{
-        CoordinatorOptions, connect_to_coordinator, local_working_dir, resolve_dataflow,
-        write_events_to,
+        connect_to_coordinator, expect_reply, local_working_dir, resolve_dataflow,
+        send_control_request, write_events_to, CoordinatorOptions,
     },
-    output::{LogOutputConfig, print_log_message},
+    output::{print_log_message, LogOutputConfig},
     session::DataflowSession,
     ws_client::WsSession,
 };
 use dora_core::descriptor::{Descriptor, DescriptorExt};
-use dora_message::{
-    cli_to_coordinator::ControlRequest, common::LogMessage, coordinator_to_cli::ControlRequestReply,
-};
-use eyre::{Context, bail};
+use dora_message::{cli_to_coordinator::ControlRequest, common::LogMessage};
+use eyre::Context;
 use std::{io::IsTerminal, net::SocketAddr, path::PathBuf};
 use uuid::Uuid;
 
@@ -140,31 +138,21 @@ fn start_dataflow(
 
     let dataflow_id = {
         let dataflow = dataflow_descriptor.clone();
-        let reply_raw = session
-            .request(
-                &serde_json::to_vec(&ControlRequest::Start {
-                    build_id: dataflow_session.build_id,
-                    session_id: dataflow_session.session_id,
-                    dataflow,
-                    name,
-                    local_working_dir,
-                    uv,
-                    write_events_to: write_events_to(),
-                })
-                .unwrap(),
-            )
-            .wrap_err("failed to send start dataflow message")?;
-
-        let result: ControlRequestReply =
-            serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-        match result {
-            ControlRequestReply::DataflowStartTriggered { uuid } => {
-                println!("dataflow start triggered: {uuid}");
-                uuid
-            }
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected start dataflow reply: {other:?}"),
-        }
+        let reply = send_control_request(
+            &session,
+            &ControlRequest::Start {
+                build_id: dataflow_session.build_id,
+                session_id: dataflow_session.session_id,
+                dataflow,
+                name,
+                local_working_dir,
+                uv,
+                write_events_to: write_events_to(),
+            },
+        )?;
+        let uuid = expect_reply!(reply, DataflowStartTriggered { uuid })?;
+        println!("dataflow start triggered: {uuid}");
+        uuid
     };
     Ok((dataflow, dataflow_descriptor, session, dataflow_id))
 }
@@ -202,21 +190,12 @@ fn wait_until_dataflow_started(
         }
     });
 
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::WaitForSpawn { dataflow_id }).unwrap())
-        .wrap_err("failed to send start dataflow message")?;
-
-    let result: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match result {
-        ControlRequestReply::DataflowSpawned { uuid } => {
-            println!("dataflow started: {uuid}");
-        }
-        ControlRequestReply::Error(err) => bail!(
-            "dataflow failed to start: {err}\n\n  \
-             hint: if nodes require building, run `dora build <dataflow.yml>` first"
-        ),
-        other => bail!("unexpected start dataflow reply: {other:?}"),
-    }
+    let reply = send_control_request(session, &ControlRequest::WaitForSpawn { dataflow_id })
+        .wrap_err(
+            "dataflow failed to start\n\n  \
+             hint: if nodes require building, run `dora build <dataflow.yml>` first",
+        )?;
+    let uuid = expect_reply!(reply, DataflowSpawned { uuid })?;
+    println!("dataflow started: {uuid}");
     Ok(())
 }

--- a/binaries/cli/src/command/system/status.rs
+++ b/binaries/cli/src/command/system/status.rs
@@ -1,14 +1,12 @@
 use crate::command::{Executable, default_tracing};
 use crate::common::CoordinatorOptions;
 use crate::common::connect_to_coordinator;
+use crate::common::{expect_reply, send_control_request};
 use crate::formatting::OutputFormat;
 use crate::ws_client::WsSession;
 use dora_core::descriptor::Descriptor;
 use dora_core::descriptor::DescriptorExt;
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, DataflowStatus},
-};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::DataflowStatus};
 use eyre::{Context, bail};
 use serde::Serialize;
 use std::path::PathBuf;
@@ -166,35 +164,18 @@ pub fn check_environment(coordinator_addr: SocketAddr, format: OutputFormat) -> 
 }
 
 pub fn daemon_running(session: &WsSession) -> Result<bool, eyre::ErrReport> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::DaemonConnected).unwrap())
-        .wrap_err("failed to send DaemonConnected message")?;
-
-    let reply = serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    let running = match reply {
-        ControlRequestReply::DaemonConnected(running) => running,
-        other => bail!("unexpected reply to daemon connection check: {other:?}"),
-    };
-
-    Ok(running)
+    let reply = send_control_request(session, &ControlRequest::DaemonConnected)?;
+    Ok(expect_reply!(reply, DaemonConnected(running))?)
 }
 
 fn query_running_dataflow_count(session: &WsSession) -> Result<usize, eyre::ErrReport> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::List).unwrap())
-        .wrap_err("failed to send List message")?;
-
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-
-    match reply {
-        ControlRequestReply::DataflowList(list) => Ok(list
-            .0
-            .iter()
-            .filter(|d| d.status == DataflowStatus::Running)
-            .count()),
-        other => bail!("unexpected reply to list request: {other:?}"),
-    }
+    let reply = send_control_request(session, &ControlRequest::List)?;
+    let list = expect_reply!(reply, DataflowList(list))?;
+    Ok(list
+        .0
+        .iter()
+        .filter(|d| d.status == DataflowStatus::Running)
+        .count())
 }
 
 /// Check system health and connectivity to coordinator and daemon.

--- a/binaries/cli/src/command/trace.rs
+++ b/binaries/cli/src/command/trace.rs
@@ -1,10 +1,10 @@
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, TraceSummary},
-};
-use eyre::{Context, bail};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::TraceSummary};
 
-use crate::{command::Executable, ws_client::WsSession};
+use crate::{
+    command::Executable,
+    common::{expect_reply, send_control_request},
+    ws_client::WsSession,
+};
 
 mod list;
 mod view;
@@ -26,16 +26,8 @@ impl Executable for Trace {
 }
 
 pub(crate) fn fetch_traces(session: &WsSession) -> eyre::Result<Vec<TraceSummary>> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::GetTraces).unwrap())
-        .wrap_err("failed to send GetTraces request")?;
-    let reply: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match reply {
-        ControlRequestReply::TraceList(t) => Ok(t),
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected reply: {other:?}"),
-    }
+    let reply = send_control_request(session, &ControlRequest::GetTraces)?;
+    Ok(expect_reply!(reply, TraceList(t))?)
 }
 
 pub(super) fn format_duration_us(us: u64) -> String {

--- a/binaries/cli/src/command/trace/view.rs
+++ b/binaries/cli/src/command/trace/view.rs
@@ -1,15 +1,12 @@
 use std::collections::HashMap;
 
 use clap::Args;
-use dora_message::{
-    cli_to_coordinator::ControlRequest,
-    coordinator_to_cli::{ControlRequestReply, TraceSpan},
-};
-use eyre::{Context, bail};
+use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::TraceSpan};
+use eyre::bail;
 
 use crate::{
     command::{Executable, default_tracing, trace::format_duration_us},
-    common::CoordinatorOptions,
+    common::{CoordinatorOptions, expect_reply, send_control_request},
     ws_client::WsSession,
 };
 
@@ -37,17 +34,8 @@ impl Executable for View {
 
         let trace_id = resolve_trace_id(&session, &self.trace_id)?;
 
-        let reply_raw = session
-            .request(&serde_json::to_vec(&ControlRequest::GetTraceSpans { trace_id }).unwrap())
-            .wrap_err("failed to send GetTraceSpans request")?;
-        let reply: ControlRequestReply =
-            serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-
-        let spans = match reply {
-            ControlRequestReply::TraceSpans(s) => s,
-            ControlRequestReply::Error(err) => bail!("{err}"),
-            other => bail!("unexpected reply: {other:?}"),
-        };
+        let reply = send_control_request(&session, &ControlRequest::GetTraceSpans { trace_id })?;
+        let spans = expect_reply!(reply, TraceSpans(s))?;
 
         if spans.is_empty() {
             println!("No spans found for this trace.");

--- a/binaries/cli/src/command/up.rs
+++ b/binaries/cli/src/command/up.rs
@@ -2,7 +2,7 @@ use super::system::status::daemon_running;
 use super::{Executable, default_tracing};
 use crate::{
     LOCALHOST,
-    common::{connect_to_coordinator, connect_with_retry},
+    common::{connect_to_coordinator, connect_with_retry, send_control_request},
 };
 use dora_core::topics::DORA_COORDINATOR_PORT_WS_DEFAULT;
 use dora_message::{cli_to_coordinator::ControlRequest, coordinator_to_cli::ControlRequestReply};
@@ -102,20 +102,13 @@ pub(crate) fn down(
         )
     })?;
     // send destroy command to dora-coordinator
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::Destroy).unwrap())
-        .wrap_err("failed to send destroy message")?;
-    let result: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match result {
+    let reply = send_control_request(&session, &ControlRequest::Destroy)?;
+    match reply {
         ControlRequestReply::DestroyOk => {
             println!("Coordinator and daemons destroyed successfully");
         }
-        ControlRequestReply::Error(err) => {
-            bail!("Destroy command failed with error: {}", err);
-        }
-        _ => {
-            bail!("Unexpected reply from dora-coordinator");
+        other => {
+            bail!("unexpected reply to Destroy: {other:?}");
         }
     }
 

--- a/binaries/cli/src/common.rs
+++ b/binaries/cli/src/common.rs
@@ -74,10 +74,22 @@ macro_rules! expect_reply {
             )),
         }
     };
-    // Struct variant: ControlRequestReply::Foo { a, b }
+    // Struct variant with one field: ControlRequestReply::Foo { a, .. }
+    ($reply:expr, $variant:ident { $field:ident }) => {
+        match $reply {
+            dora_message::coordinator_to_cli::ControlRequestReply::$variant { $field, .. } => {
+                Ok($field)
+            }
+            other => Err(eyre::eyre!(
+                "unexpected reply (expected {}): {other:?}",
+                stringify!($variant)
+            )),
+        }
+    };
+    // Struct variant with multiple fields: ControlRequestReply::Foo { a, b, .. }
     ($reply:expr, $variant:ident { $($field:ident),+ $(,)? }) => {
         match $reply {
-            dora_message::coordinator_to_cli::ControlRequestReply::$variant { $($field),+ } => {
+            dora_message::coordinator_to_cli::ControlRequestReply::$variant { $($field),+ , .. } => {
                 Ok(($($field),+))
             }
             other => Err(eyre::eyre!(
@@ -222,20 +234,15 @@ pub(crate) fn local_working_dir(
 }
 
 pub(crate) fn cli_and_daemon_on_same_machine(session: &WsSession) -> eyre::Result<bool> {
-    let reply_raw = session
-        .request(&serde_json::to_vec(&ControlRequest::CliAndDefaultDaemonOnSameMachine).unwrap())
-        .wrap_err("failed to send start dataflow message")?;
-
-    let result: ControlRequestReply =
-        serde_json::from_slice(&reply_raw).wrap_err("failed to parse reply")?;
-    match result {
-        ControlRequestReply::CliAndDefaultDaemonIps {
+    let reply = send_control_request(session, &ControlRequest::CliAndDefaultDaemonOnSameMachine)?;
+    let (default_daemon, cli) = expect_reply!(
+        reply,
+        CliAndDefaultDaemonIps {
             default_daemon,
-            cli,
-        } => Ok(default_daemon.is_some() && default_daemon == cli),
-        ControlRequestReply::Error(err) => bail!("{err}"),
-        other => bail!("unexpected start dataflow reply: {other:?}"),
-    }
+            cli
+        }
+    )?;
+    Ok(default_daemon.is_some() && default_daemon == cli)
 }
 
 pub(crate) fn write_events_to() -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

Roll out `send_control_request()` + `expect_reply!()` across all CLI command call sites that were still using raw `session.request(&serde_json::to_vec(...))`.

**14 files changed, -204 lines net.**

## Why

Closes the follow-up from #182 (closed as won't-fix for the jsonrpsee migration). The `expect_reply!` macro from PR #181 was only used in 2 of 20+ call sites. This PR completes the rollout, eliminating the repetitive serialize/deserialize/match boilerplate that was the actual pain point.

Each converted site goes from ~10 lines:
```rust
let reply_raw = session
    .request(&serde_json::to_vec(&ControlRequest::Foo).unwrap())
    .wrap_err("...")?;
let reply: ControlRequestReply = serde_json::from_slice(&reply_raw).wrap_err("...")?;
match reply {
    ControlRequestReply::Bar(x) => x,
    ControlRequestReply::Error(err) => bail!("{err}"),
    other => bail!("unexpected: {other:?}"),
}
```
to 2 lines:
```rust
let reply = send_control_request(session, &ControlRequest::Foo)?;
let x = expect_reply!(reply, Bar(x))?;
```

## Macro improvements

- Added `..` to struct variant patterns for forward-compatibility with new fields
- Split single-field and multi-field struct arms to avoid clippy `double_parens` warning

## Files converted

build/distributed.rs, cluster/mod.rs, cluster/restart.rs, doctor.rs, inspect/top.rs, logs.rs, node/info.rs, node/list.rs, start/mod.rs, system/status.rs, trace.rs, trace/view.rs, up.rs, common.rs (macro improvements)

## Not converted (intentional)

- `run.rs` -- fire-and-forget Destroy/Stop commands where reply is ignored
- `start/attach.rs` -- streaming control loop with dynamic request variants

## Test plan

- [x] `cargo check -p dora-cli` -- clean
- [x] `cargo clippy -p dora-cli -- -D warnings` -- clean
- [x] `cargo fmt --all -- --check` -- clean
- [ ] CI green
