### PR TITLE
fix(nightly): fix YAML parse error that broke all nightly runs since #257

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,10 @@ on:
   schedule:
     - cron: "0 6 * * *"
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/nightly.yml"
 
 permissions:
   contents: read
@@ -532,7 +536,7 @@ jobs:
         run: |
           chmod +x ./cli-bin/dora
           echo "$PWD/cli-bin" >> "$GITHUB_PATH"
-      - name: Run cpu-affinity-probe fixture (cpu_affinity: [0, 1])
+      - name: "Run cpu-affinity-probe fixture (cpu_affinity: [0, 1])"
         run: |
           cd examples/cpu-affinity-probe
           out=$(dora run dataflow.yml --stop-after 3s 2>&1)


### PR DESCRIPTION
## Summary

Fixes the nightly workflow YAML parse error that broke all nightly runs since #257.

## Root cause

Line 535: `- name: Run cpu-affinity-probe fixture (cpu_affinity: [0, 1])` -- the `: [0, 1]` inside parentheses is parsed by YAML as a mapping value, not a literal string. This silently broke the entire nightly workflow file. GitHub Actions reported "workflow file issue" on every run but gave no useful error message.

Introduced in commit 5787a453 (PR #257), unnoticed because:
- The nightly only runs on schedule (06:00 UTC daily)
- Push events to main didn't trigger it
- The "workflow file issue" errors on push-triggered runs looked like GHA index caching, not a real parse failure

## Fixes

1. **Quote the step name**: `"Run cpu-affinity-probe fixture (cpu_affinity: [0, 1])"` -- YAML now treats it as a string literal
2. **Add push trigger for workflow changes**: `on.push.paths: [".github/workflows/nightly.yml"]` so future YAML syntax errors are caught immediately on the push that introduces them (per phil-opp's feedback on #274)

## Validation

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml')); print('valid')"
valid
```

Reopens #249 (nightly was not actually fixed by #274 -- the YAML error preceded our changes).
