### PR TITLE
docs: document daemon kill-on-disconnect limitation (#260)

### DIFF
--- a/guide/src/operations/distributed.md
+++ b/guide/src/operations/distributed.md
@@ -553,6 +553,7 @@ This means a node that crashes immediately will only be re-spawned once every 30
 
 - Auto-recovery only applies to dataflows started via `dora start` (coordinator-managed). Local `dora run` dataflows are not tracked by the coordinator.
 - Recovery re-spawns all nodes assigned to the reconnecting daemon, not individual nodes. For per-node restart on crash, use [restart policies](fault-tolerance.md#restart-policies).
+- **Known issue ([#260](https://github.com/dora-rs/adora/issues/260)):** when the daemon's WebSocket connection to the coordinator drops, the daemon currently kills all running node processes before reconnecting. This means the coordinator's auto-recovery path re-spawns the nodes from scratch rather than reclaiming still-running processes. The net effect is a brief disruption (nodes restart) rather than seamless continuity. A fix to preserve running processes across reconnect cycles is planned.
 
 ---
 

--- a/guide/src/operations/fault-tolerance.md
+++ b/guide/src/operations/fault-tolerance.md
@@ -867,6 +867,8 @@ The node processes one batch, exits with code 0, waits 10s, then restarts to pro
 
 **Use `--store redb` for production deployments**. The redb backend ensures the coordinator retains dataflow history across crashes and restarts. The in-memory default is fine for development but loses all state on exit. The redb file is small (proportional to the number of dataflow records) and adds negligible overhead.
 
+**Known limitation:** when the coordinator disconnects, the daemon currently kills running node processes before reconnecting ([#260](https://github.com/dora-rs/adora/issues/260)). Dataflow *records* survive coordinator restart (via redb), but running *processes* are restarted from scratch. Seamless process reclaim across reconnect is planned.
+
 **Combine features for defense in depth**:
 - `restart_policy` + `restart_delay` -> recover from node crashes
 - `health_check_timeout` -> recover from hung nodes


### PR DESCRIPTION
Documents the known limitation where the daemon kills running node processes on coordinator WS disconnect. Adds notes to:

- **distributed.md** (Auto-Recovery > Limitations): explains that nodes restart from scratch rather than being reclaimed
- **fault-tolerance.md** (Best Practices): clarifies that dataflow *records* survive coordinator restart (via redb) but running *processes* do not

README and introduction already note this as "partial"; these docs fill in the specific mechanism and link to #260.

Refs #260.