### PR TITLE
fix(security): address 3 P1 findings from 1.0 audit (SEC-01, SEC-02, SEC-03)

### DIFF
--- a/apis/c/node/src/lib.rs
+++ b/apis/c/node/src/lib.rs
@@ -180,9 +180,12 @@ pub unsafe extern "C" fn read_dora_input_data(
             dora_node_api::arrow::datatypes::DataType::UInt8 => {
                 let array: &UInt8Array = data.as_primitive();
                 let ptr = array.values().as_ptr();
+                // Use the actual buffer length, not metadata.type_info.len
+                // which comes from remote nodes and could exceed the buffer.
+                let len = array.values().len();
                 unsafe {
                     *out_ptr = ptr;
-                    *out_len = metadata.type_info.len;
+                    *out_len = len;
                 }
             }
             dora_node_api::arrow::datatypes::DataType::Null => unsafe {

--- a/libraries/extensions/download/src/lib.rs
+++ b/libraries/extensions/download/src/lib.rs
@@ -69,14 +69,23 @@ where
         .await
         .wrap_err_with(|| format!("failed to download from `{url}`"))?;
 
-    // Verify integrity if a digest was provided
+    // Verify integrity if a digest was provided.
+    // Without a digest, the download is vulnerable to MITM or CDN compromise
+    // since the downloaded binary may be executed or dlopen-ed.
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let actual_hash = format!("{:x}", hasher.finalize());
     if let Some(expected) = expected_sha256 {
-        let mut hasher = Sha256::new();
-        hasher.update(&bytes);
-        let actual = format!("{:x}", hasher.finalize());
-        if actual != expected {
-            eyre::bail!("SHA-256 mismatch for `{url}`: expected {expected}, got {actual}");
+        if actual_hash != expected {
+            eyre::bail!("SHA-256 mismatch for `{url}`: expected {expected}, got {actual_hash}");
         }
+    } else {
+        tracing::warn!(
+            url = %url,
+            sha256 = %actual_hash,
+            "downloading without integrity verification — \
+             consider adding sha256 to the source definition"
+        );
     }
 
     let path = target_dir.join(filename);

--- a/libraries/recording/src/lib.rs
+++ b/libraries/recording/src/lib.rs
@@ -6,6 +6,9 @@ use uuid::Uuid;
 const MAGIC: &[u8; 8] = b"DORAREC\x00";
 const FOOTER_MAGIC: &[u8; 8] = b"DORAEND\x00";
 const FORMAT_VERSION: u16 = 1;
+/// Maximum size for a single record or YAML descriptor in a `.drec` file.
+/// Guards against OOM from crafted files with `u32::MAX` length fields.
+const MAX_RECORD_BYTES: usize = 64 * 1024 * 1024; // 64 MB
 
 /// Header written at the start of a `.drec` file.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,9 +56,16 @@ impl<W: Write> RecordingWriter<W> {
     pub fn write_entry(&mut self, entry: &RecordEntry) -> eyre::Result<()> {
         let node_id_bytes = entry.node_id.as_bytes();
         let output_id_bytes = entry.output_id.as_bytes();
-        let record_len: u32 =
-            (2 + node_id_bytes.len() + 2 + output_id_bytes.len() + 8 + 4 + entry.event_bytes.len())
-                as u32;
+        // Compute as usize first to avoid u32 truncation before the cap check.
+        let record_len_usize =
+            2 + node_id_bytes.len() + 2 + output_id_bytes.len() + 8 + 4 + entry.event_bytes.len();
+        if record_len_usize > MAX_RECORD_BYTES {
+            eyre::bail!(
+                "record too large to write: {record_len_usize} bytes (max {MAX_RECORD_BYTES})"
+            );
+        }
+        let record_len = u32::try_from(record_len_usize)
+            .map_err(|_| eyre::eyre!("record length {record_len_usize} exceeds u32::MAX"))?;
 
         self.writer.write_all(&record_len.to_le_bytes())?;
         self.writer
@@ -136,6 +146,9 @@ impl<R: Read> RecordingReader<R> {
         }
 
         let record_len = u32::from_le_bytes(len_buf) as usize;
+        if record_len > MAX_RECORD_BYTES {
+            eyre::bail!("record too large: {record_len} bytes (max {MAX_RECORD_BYTES})");
+        }
         let mut record_buf = vec![0u8; record_len];
         self.reader
             .read_exact(&mut record_buf)
@@ -179,6 +192,12 @@ fn read_array<const N: usize>(buf: &[u8], pos: &mut usize) -> eyre::Result<[u8; 
 }
 
 fn write_header<W: Write>(w: &mut W, header: &RecordingHeader) -> eyre::Result<()> {
+    if header.descriptor_yaml.len() > MAX_RECORD_BYTES {
+        eyre::bail!(
+            "descriptor YAML too large to write: {} bytes (max {MAX_RECORD_BYTES})",
+            header.descriptor_yaml.len()
+        );
+    }
     w.write_all(MAGIC)?;
     w.write_all(&header.version.to_le_bytes())?;
     w.write_all(&header.start_nanos.to_le_bytes())?;
@@ -216,6 +235,9 @@ fn read_header<R: Read>(r: &mut R) -> eyre::Result<RecordingHeader> {
     let mut yaml_len_buf = [0u8; 4];
     r.read_exact(&mut yaml_len_buf)?;
     let yaml_len = u32::from_le_bytes(yaml_len_buf) as usize;
+    if yaml_len > MAX_RECORD_BYTES {
+        eyre::bail!("descriptor YAML too large: {yaml_len} bytes (max {MAX_RECORD_BYTES})");
+    }
 
     let mut descriptor_yaml = vec![0u8; yaml_len];
     r.read_exact(&mut descriptor_yaml)?;
@@ -371,5 +393,55 @@ mod tests {
 
         let reader = RecordingReader::open(std::io::Cursor::new(&buf)).unwrap();
         assert!(reader.header().descriptor_yaml.is_empty());
+    }
+
+    #[test]
+    fn writer_rejects_oversized_record() {
+        let header = sample_header();
+        let big_entry = sample_entry("n", "o", 0, &vec![0u8; MAX_RECORD_BYTES + 1]);
+        let mut buf = Vec::new();
+        let mut writer = RecordingWriter::new(&mut buf, &header).unwrap();
+        let err = writer.write_entry(&big_entry).unwrap_err();
+        assert!(
+            err.to_string().contains("too large"),
+            "expected 'too large' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn writer_rejects_oversized_descriptor_yaml() {
+        let header = RecordingHeader {
+            version: FORMAT_VERSION,
+            start_nanos: 0,
+            dataflow_id: Uuid::nil(),
+            descriptor_yaml: vec![0u8; MAX_RECORD_BYTES + 1],
+        };
+        let mut buf = Vec::new();
+        let result = RecordingWriter::new(&mut buf, &header);
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(
+            err.to_string().contains("too large"),
+            "expected 'too large' error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reader_rejects_oversized_record_len() {
+        // Craft a file with a valid header followed by a record_len > MAX_RECORD_BYTES.
+        let header = sample_header();
+        let mut buf = Vec::new();
+        write_header(&mut buf, &header).unwrap();
+        // Write a fake record_len that exceeds the cap.
+        let fake_len: u32 = (MAX_RECORD_BYTES as u32) + 1;
+        buf.extend_from_slice(&fake_len.to_le_bytes());
+        buf.extend_from_slice(&vec![0u8; fake_len as usize]); // pad so read_exact doesn't fail first
+
+        let mut reader = RecordingReader::open(std::io::Cursor::new(&buf)).unwrap();
+        let err = reader.next_entry().unwrap_err();
+        assert!(
+            err.to_string().contains("too large"),
+            "expected 'too large' error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes 3 P1 security findings from the fresh 2026-04-16 audit gating the dora 1.0 release.

### SEC-01: Download integrity warning

`download_file` had SHA-256 verification implemented but never activated (all 4 call sites passed `expected_sha256: None`). Downloaded shared libraries are `dlopen`-ed or executed without integrity checks.

Fix: always compute SHA-256 and log a warning when no expected digest is provided. This surfaces the supply-chain risk without breaking existing workflows. Strict enforcement (refuse downloads without a hash) is deferred to 1.1.

### SEC-02: Recording format OOM

`record_len` and `yaml_len` are u32 fields read from `.drec` files. A crafted file with `0xFFFFFFFF` would allocate 4 GB, causing OOM.

Fix: cap both at `MAX_RECORD_BYTES` (64 MB) before allocation.

### SEC-03: C API heap over-read

`read_dora_input_data` set `*out_len = metadata.type_info.len` where the metadata comes from a remote node. If `type_info.len` exceeds the actual Arrow buffer length, the C caller reads past the allocation.

Fix: use `array.values().len()` (actual buffer size) instead of the metadata-reported length.

## Audit context

Full audit found 0 P0, 3 P1, 2 P2 findings. All P0 gates (memory safety, code execution, auth) passed. The 2 P2 findings (shared lib signature verification, streaming downloads) are deferred to 1.1.

## Test plan

- [x] `cargo check -p dora-recording -p dora-node-api-c -p dora-download` -- clean
- [x] `cargo clippy` on all 3 crates -- clean
- [x] `cargo test -p dora-recording` -- 7/7 pass
- [x] `cargo fmt --all -- --check` -- clean
- [ ] CI green
