### PR TITLE
fix(qa): add explicit -g '*.rs' glob to unwrap-budget rg invocation

### DIFF
--- a/scripts/qa/unwrap-budget.sh
+++ b/scripts/qa/unwrap-budget.sh
@@ -53,6 +53,7 @@ count_unwraps() {
     total=$((total + n))
   done < <(
     rg --files --type rust \
+      -g '*.rs' \
       -g '!**/tests/**' \
       -g '!**/benches/**' \
       -g '!**/examples/**' \


### PR DESCRIPTION
Adds `-g '*.rs'` as an explicit positive file-type glob alongside
`--type rust` in `scripts/qa/unwrap-budget.sh`.

**Why:** On some older ripgrep versions (pre-15), an `rg --files`
invocation with only negative globs and no explicit positive glob can
yield unexpected empty results in certain shell/PATH environments.
The extra glob is redundant with `--type rust` on rg ≥15 but harmless
— a defensive belt-and-suspenders guard.

**Scope:** Single-line change in `scripts/qa/unwrap-budget.sh`.
No behaviour change on rg ≥15.

## Test plan

- [x] Ran `bash scripts/qa/unwrap-budget.sh` locally — correct count
      returned (157, budget 185)
- [x] Diff is exactly 1 line