### PR TITLE
docs(qa): document ripgrep as a prerequisite for qa-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ qa-adversarial:
 	@scripts/qa/adversarial.sh
 
 # One-shot tool installation
+# Note: ripgrep (rg) is also required by scripts/qa/unwrap-budget.sh.
+# Install it via your system package manager:
+#   macOS:  brew install ripgrep
+#   Ubuntu: apt-get install ripgrep
+#   Others: https://github.com/BurntSushi/ripgrep#installation
 
 qa-install:
 	cargo install cargo-audit cargo-deny cargo-llvm-cov cargo-mutants cargo-semver-checks


### PR DESCRIPTION
## Summary

`scripts/qa/unwrap-budget.sh` requires `ripgrep` (`rg`) but `make
qa-install` did not mention it, leaving new contributors confused when
the script fails silently.

Rather than adding `cargo install ripgrep` (slow, ~2-3 min compile;
most developers already have `rg` from their system package manager),
this PR adds a comment block above `qa-install` documenting the
external dependency with install instructions for the most common
platforms.

## Test plan

- [x] Comment-only change — no script behaviour affected
- [x] Verified `bash scripts/qa/unwrap-budget.sh` still runs correctly
