### PR TITLE
fix(state): enforce strict runtime param delivery (carries #196 onto main)

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1179,6 +1179,9 @@ async fn start_inner(
                                 )?;
                                 let bytes = serde_json::to_vec(&value)
                                     .map_err(|e| eyre!("failed to serialize param value: {e}"))?;
+                                // Persist first (source of truth), then attempt synchronous
+                                // runtime forwarding. If forwarding fails, caller gets Error(...)
+                                // but persisted value will be replayed on catch-up/reconnect.
                                 store.put_node_param(&dataflow_id, &node_id, &key, &bytes)?;
 
                                 if let ParamTarget::Running { daemon_id } = target {
@@ -1238,6 +1241,9 @@ async fn start_inner(
                                     &dataflow_id,
                                     &node_id,
                                 )?;
+                                // Persist first (source of truth), then attempt synchronous
+                                // runtime forwarding. If forwarding fails, caller gets Error(...)
+                                // but delete is still reflected in persisted state/catch-up log.
                                 store.delete_node_param(&dataflow_id, &node_id, &key)?;
 
                                 if let ParamTarget::Running { daemon_id } = target {

--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1170,72 +1170,60 @@ async fn start_inner(
                             key,
                             value,
                         } => {
-                            let reply = match resolve_param_target(
-                                &running_dataflows,
-                                store.as_ref(),
-                                &dataflow_id,
-                                &node_id,
-                            ) {
-                                Ok(target) => match serde_json::to_vec(&value) {
-                                    Ok(bytes) => {
-                                        match store.put_node_param(
-                                            &dataflow_id,
-                                            &node_id,
-                                            &key,
-                                            &bytes,
-                                        ) {
-                                            Ok(()) => {
-                                                if let ParamTarget::Running { daemon_id } = target {
-                                                    if let Some(df) =
-                                                        running_dataflows.get_mut(&dataflow_id)
-                                                    {
-                                                        df.append_state_log(
-                                                            StateCatchUpOperation::SetParam {
-                                                                node_id: node_id.clone(),
-                                                                key: key.clone(),
-                                                                value: value.clone(),
-                                                            },
-                                                        );
+                            let reply: eyre::Result<ControlRequestReply> = async {
+                                let target = resolve_param_target(
+                                    &running_dataflows,
+                                    store.as_ref(),
+                                    &dataflow_id,
+                                    &node_id,
+                                )?;
+                                let bytes = serde_json::to_vec(&value)
+                                    .map_err(|e| eyre!("failed to serialize param value: {e}"))?;
+                                store.put_node_param(&dataflow_id, &node_id, &key, &bytes)?;
 
-                                                        if let Ok(msg) =
-                                                            serde_json::to_vec(&Timestamped {
-                                                                inner: DaemonCoordinatorEvent::SetParam {
-                                                                    dataflow_id,
-                                                                    node_id: node_id.clone(),
-                                                                    key: key.clone(),
-                                                                    value: value.clone(),
-                                                                },
-                                                                timestamp: clock.new_timestamp(),
-                                                            })
-                                                            && let Some(conn) =
-                                                                daemon_connections.get_mut(&daemon_id)
-                                                                && let Err(e) =
-                                                                    conn.send_and_receive(&msg).await
-                                                                {
-                                                                    tracing::warn!(
-                                                                        %node_id,
-                                                                        %daemon_id,
-                                                                        "param persisted in store; runtime forwarding is best-effort and failed: {e}"
-                                                                    );
-                                                                }
-                                                    } else {
-                                                        // Dataflow may have been removed after target resolution.
-                                                        tracing::warn!(
-                                                            %dataflow_id,
-                                                            %node_id,
-                                                            "param persisted in store; running dataflow disappeared before runtime forwarding"
-                                                        );
-                                                    }
-                                                }
-                                                Ok(ControlRequestReply::ParamSet)
-                                            }
-                                            Err(e) => Err(e),
-                                        }
-                                    }
-                                    Err(e) => Err(eyre!("failed to serialize param value: {e}")),
-                                },
-                                Err(e) => Err(e),
-                            };
+                                if let ParamTarget::Running { daemon_id } = target {
+                                    let df = running_dataflows.get_mut(&dataflow_id).ok_or_else(
+                                        || {
+                                            eyre!(
+                                                "param persisted in store but running dataflow `{dataflow_id}` disappeared before runtime forwarding for node `{node_id}`"
+                                            )
+                                        },
+                                    )?;
+                                    df.append_state_log(StateCatchUpOperation::SetParam {
+                                        node_id: node_id.clone(),
+                                        key: key.clone(),
+                                        value: value.clone(),
+                                    });
+
+                                    let msg = serde_json::to_vec(&Timestamped {
+                                        inner: DaemonCoordinatorEvent::SetParam {
+                                            dataflow_id,
+                                            node_id: node_id.clone(),
+                                            key: key.clone(),
+                                            value: value.clone(),
+                                        },
+                                        timestamp: clock.new_timestamp(),
+                                    })
+                                    .map_err(|e| {
+                                        eyre!("failed to serialize SetParam event for node `{node_id}`: {e}")
+                                    })?;
+
+                                    let conn =
+                                        daemon_connections.get_mut(&daemon_id).ok_or_else(|| {
+                                            eyre!(
+                                                "param persisted in store but daemon `{daemon_id}` is not connected"
+                                            )
+                                        })?;
+                                    let reply_raw = conn.send_and_receive(&msg).await.map_err(|e| {
+                                        eyre!(
+                                            "failed to forward SetParam to daemon `{daemon_id}` for node `{node_id}`: {e}"
+                                        )
+                                    })?;
+                                    ensure_set_param_forward_applied(&reply_raw, &node_id)?;
+                                }
+                                Ok(ControlRequestReply::ParamSet)
+                            }
+                            .await;
                             let _ = reply_sender.send(reply);
                         }
                         ControlRequest::DeleteParam {
@@ -1243,62 +1231,58 @@ async fn start_inner(
                             node_id,
                             key,
                         } => {
-                            let reply = match resolve_param_target(
-                                &running_dataflows,
-                                store.as_ref(),
-                                &dataflow_id,
-                                &node_id,
-                            ) {
-                                Ok(target) => {
-                                    match store.delete_node_param(&dataflow_id, &node_id, &key) {
-                                        Ok(()) => {
-                                            if let ParamTarget::Running { daemon_id } = target {
-                                                if let Some(df) =
-                                                    running_dataflows.get_mut(&dataflow_id)
-                                                {
-                                                    df.append_state_log(
-                                                        StateCatchUpOperation::DeleteParam {
-                                                            node_id: node_id.clone(),
-                                                            key: key.clone(),
-                                                        },
-                                                    );
+                            let reply: eyre::Result<ControlRequestReply> = async {
+                                let target = resolve_param_target(
+                                    &running_dataflows,
+                                    store.as_ref(),
+                                    &dataflow_id,
+                                    &node_id,
+                                )?;
+                                store.delete_node_param(&dataflow_id, &node_id, &key)?;
 
-                                                    if let Ok(msg) =
-                                                        serde_json::to_vec(&Timestamped {
-                                                            inner: DaemonCoordinatorEvent::DeleteParam {
-                                                                dataflow_id,
-                                                                node_id: node_id.clone(),
-                                                                key: key.clone(),
-                                                            },
-                                                            timestamp: clock.new_timestamp(),
-                                                        })
-                                                        && let Some(conn) =
-                                                            daemon_connections.get_mut(&daemon_id)
-                                                            && let Err(e) =
-                                                                conn.send_and_receive(&msg).await
-                                                            {
-                                                                tracing::warn!(
-                                                                    %node_id,
-                                                                    %daemon_id,
-                                                                    "param deleted in store; runtime forwarding is best-effort and failed: {e}"
-                                                                );
-                                                            }
-                                                } else {
-                                                    // Dataflow may have been removed after target resolution.
-                                                    tracing::warn!(
-                                                        %dataflow_id,
-                                                        %node_id,
-                                                        "param deleted in store; running dataflow disappeared before runtime forwarding"
-                                                    );
-                                                }
-                                            }
-                                            Ok(ControlRequestReply::ParamDeleted)
-                                        }
-                                        Err(e) => Err(e),
-                                    }
+                                if let ParamTarget::Running { daemon_id } = target {
+                                    let df = running_dataflows.get_mut(&dataflow_id).ok_or_else(
+                                        || {
+                                            eyre!(
+                                                "param deleted in store but running dataflow `{dataflow_id}` disappeared before runtime forwarding for node `{node_id}`"
+                                            )
+                                        },
+                                    )?;
+                                    df.append_state_log(StateCatchUpOperation::DeleteParam {
+                                        node_id: node_id.clone(),
+                                        key: key.clone(),
+                                    });
+
+                                    let msg = serde_json::to_vec(&Timestamped {
+                                        inner: DaemonCoordinatorEvent::DeleteParam {
+                                            dataflow_id,
+                                            node_id: node_id.clone(),
+                                            key: key.clone(),
+                                        },
+                                        timestamp: clock.new_timestamp(),
+                                    })
+                                    .map_err(|e| {
+                                        eyre!(
+                                            "failed to serialize DeleteParam event for node `{node_id}`: {e}"
+                                        )
+                                    })?;
+
+                                    let conn =
+                                        daemon_connections.get_mut(&daemon_id).ok_or_else(|| {
+                                            eyre!(
+                                                "param deleted in store but daemon `{daemon_id}` is not connected"
+                                            )
+                                        })?;
+                                    let reply_raw = conn.send_and_receive(&msg).await.map_err(|e| {
+                                        eyre!(
+                                            "failed to forward DeleteParam to daemon `{daemon_id}` for node `{node_id}`: {e}"
+                                        )
+                                    })?;
+                                    ensure_delete_param_forward_applied(&reply_raw, &node_id)?;
                                 }
-                                Err(e) => Err(e),
-                            };
+                                Ok(ControlRequestReply::ParamDeleted)
+                            }
+                            .await;
                             let _ = reply_sender.send(reply);
                         }
                         // --- Dynamic Topology ---
@@ -2683,6 +2667,36 @@ fn build_set_param_message_from_raw_json(
     .map_err(Into::into)
 }
 
+fn ensure_set_param_forward_applied(
+    reply_raw: &[u8],
+    node_id: &dora_core::config::NodeId,
+) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::SetParamResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::SetParamResult(Err(err)) => Err(eyre!(
+            "daemon failed to apply SetParam for node `{node_id}`: {err}"
+        )),
+        other => Err(eyre!(
+            "unexpected daemon reply for SetParam on node `{node_id}`: {other:?}"
+        )),
+    }
+}
+
+fn ensure_delete_param_forward_applied(
+    reply_raw: &[u8],
+    node_id: &dora_core::config::NodeId,
+) -> eyre::Result<()> {
+    match serde_json::from_slice(reply_raw)? {
+        DaemonCoordinatorReply::DeleteParamResult(Ok(())) => Ok(()),
+        DaemonCoordinatorReply::DeleteParamResult(Err(err)) => Err(eyre!(
+            "daemon failed to apply DeleteParam for node `{node_id}`: {err}"
+        )),
+        other => Err(eyre!(
+            "unexpected daemon reply for DeleteParam on node `{node_id}`: {other:?}"
+        )),
+    }
+}
+
 fn schedule_param_replay_for_ready_dataflow(
     dataflow_id: DataflowId,
     dataflow: &RunningDataflow,
@@ -3761,6 +3775,29 @@ mod tests {
         // But a daemon at seq 7 can
         let delta = df.state_log_delta(7).expect("should succeed");
         assert_eq!(delta.len(), 3); // entries 8, 9, 10
+    }
+
+    #[test]
+    fn set_param_forward_reply_reports_daemon_rejection() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Err(
+            "node `camera` channel full".to_string(),
+        )))
+        .unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let err = ensure_set_param_forward_applied(&reply, &node_id)
+            .expect_err("daemon rejection should fail strict forwarding");
+        assert!(err.to_string().contains("failed to apply SetParam"));
+    }
+
+    #[test]
+    fn delete_param_forward_reply_rejects_unexpected_reply_variant() {
+        let reply = serde_json::to_vec(&DaemonCoordinatorReply::SetParamResult(Ok(()))).unwrap();
+        let node_id: dora_core::config::NodeId = "camera".to_string().into();
+
+        let err = ensure_delete_param_forward_applied(&reply, &node_id)
+            .expect_err("unexpected reply variant should fail strict forwarding");
+        assert!(err.to_string().contains("unexpected daemon reply"));
     }
 }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -199,6 +199,47 @@ const METRICS_INTERVAL_SECS: f64 = METRICS_INTERVAL.as_secs_f64();
 /// patterns; messages are dropped with a warning when full.
 const ZENOH_PUBLISH_CHANNEL_CAPACITY: usize = 256;
 
+fn deliver_param_update_strict(
+    dataflow: &RunningDataflow,
+    node_id: &NodeId,
+    key: String,
+    value: serde_json::Value,
+    clock: &HLC,
+) -> eyre::Result<()> {
+    let channel = dataflow
+        .subscribe_channels
+        .get(node_id)
+        .ok_or_else(|| eyre!("node `{node_id}` not connected"))?;
+    match send_with_timestamp(channel, NodeEvent::ParamUpdate { key, value }, clock) {
+        Ok(true) => {
+            dataflow.inc_pending(node_id);
+            Ok(())
+        }
+        Ok(false) => Err(eyre!("node `{node_id}` channel full")),
+        Err(_) => Err(eyre!("node `{node_id}` channel closed")),
+    }
+}
+
+fn deliver_param_delete_strict(
+    dataflow: &RunningDataflow,
+    node_id: &NodeId,
+    key: String,
+    clock: &HLC,
+) -> eyre::Result<()> {
+    let channel = dataflow
+        .subscribe_channels
+        .get(node_id)
+        .ok_or_else(|| eyre!("node `{node_id}` not connected"))?;
+    match send_with_timestamp(channel, NodeEvent::ParamDeleted { key }, clock) {
+        Ok(true) => {
+            dataflow.inc_pending(node_id);
+            Ok(())
+        }
+        Ok(false) => Err(eyre!("node `{node_id}` channel full")),
+        Err(_) => Err(eyre!("node `{node_id}` channel closed")),
+    }
+}
+
 /// The Daemon manages running dataflows, node communication, and inter-daemon
 /// message routing. Fields are `pub(crate)` to enable `impl Daemon` blocks in
 /// submodules (e.g., `node_events.rs`, `dataflow_lifecycle.rs`) as part of the
@@ -1399,26 +1440,7 @@ impl Daemon {
             } => {
                 let result = match self.running.get(&dataflow_id) {
                     Some(dataflow) => {
-                        if let Some(channel) = dataflow.subscribe_channels.get(&node_id) {
-                            match send_with_timestamp(
-                                channel,
-                                NodeEvent::ParamUpdate { key, value },
-                                &self.clock,
-                            ) {
-                                Ok(true) => {
-                                    dataflow.inc_pending(&node_id);
-                                    Ok(())
-                                }
-                                Ok(false) => Ok(()), // event dropped (channel full)
-                                Err(_) => Err(eyre::eyre!("node `{node_id}` channel closed")),
-                            }
-                        } else {
-                            tracing::debug!(
-                                %node_id,
-                                "param update not deliverable: node not yet connected"
-                            );
-                            Ok(())
-                        }
+                        deliver_param_update_strict(dataflow, &node_id, key, value, &self.clock)
                     }
                     None => Err(eyre::eyre!("no running dataflow with ID `{dataflow_id}`")),
                 };
@@ -1437,26 +1459,7 @@ impl Daemon {
             } => {
                 let result = match self.running.get(&dataflow_id) {
                     Some(dataflow) => {
-                        if let Some(channel) = dataflow.subscribe_channels.get(&node_id) {
-                            match send_with_timestamp(
-                                channel,
-                                NodeEvent::ParamDeleted { key },
-                                &self.clock,
-                            ) {
-                                Ok(true) => {
-                                    dataflow.inc_pending(&node_id);
-                                    Ok(())
-                                }
-                                Ok(false) => Ok(()), // event dropped (channel full)
-                                Err(_) => Err(eyre::eyre!("node `{node_id}` channel closed")),
-                            }
-                        } else {
-                            tracing::debug!(
-                                %node_id,
-                                "param delete not deliverable: node not yet connected"
-                            );
-                            Ok(())
-                        }
+                        deliver_param_delete_strict(dataflow, &node_id, key, &self.clock)
                     }
                     None => Err(eyre::eyre!("no running dataflow with ID `{dataflow_id}`")),
                 };
@@ -4914,6 +4917,23 @@ mod fault_tolerance_tests {
     }
 
     #[test]
+    fn strict_param_update_fails_when_node_not_connected() {
+        let df = test_dataflow();
+        let clock = test_clock();
+        let node_id: NodeId = "node_missing".to_string().into();
+
+        let err = deliver_param_update_strict(
+            &df,
+            &node_id,
+            "threshold".into(),
+            serde_json::json!(1),
+            &clock,
+        )
+        .expect_err("strict delivery should fail when node channel is missing");
+        assert!(err.to_string().contains("not connected"));
+    }
+
+    #[test]
     fn param_delete_delivered_to_node() {
         let clock = test_clock();
         let (tx, mut rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
@@ -5021,6 +5041,32 @@ mod fault_tolerance_tests {
         );
 
         assert_eq!(applied_through, 0);
+    }
+
+    #[test]
+    fn strict_param_delete_fails_when_channel_full() {
+        let mut df = test_dataflow();
+        let clock = test_clock();
+        let node_id: NodeId = "node_a".to_string().into();
+        let (tx, _rx) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
+        df.subscribe_channels.insert(node_id.clone(), tx.clone());
+
+        // Saturate channel so strict delivery observes a dropped send.
+        for _ in 0..NODE_EVENT_CHANNEL_CAPACITY {
+            let sent = send_with_timestamp(
+                &tx,
+                NodeEvent::ParamDeleted {
+                    key: "prefill".into(),
+                },
+                &clock,
+            )
+            .unwrap();
+            assert!(sent);
+        }
+
+        let err = deliver_param_delete_strict(&df, &node_id, "threshold".into(), &clock)
+            .expect_err("strict delivery should fail when node channel is full");
+        assert!(err.to_string().contains("channel full"));
     }
 }
 

--- a/binaries/daemon/src/lib.rs
+++ b/binaries/daemon/src/lib.rs
@@ -21,7 +21,8 @@ use dora_message::{
     },
     coordinator_to_cli::DataflowResult,
     coordinator_to_daemon::{
-        BuildDataflowNodes, DaemonCoordinatorEvent, SpawnDataflowNodes, StateCatchUpOperation,
+        BuildDataflowNodes, DaemonCoordinatorEvent, SpawnDataflowNodes, StateCatchUpEntry,
+        StateCatchUpOperation,
     },
     daemon_to_coordinator::{
         CoordinatorRequest, DaemonCoordinatorReply, DaemonEvent, DataflowDaemonResult,
@@ -1873,58 +1874,22 @@ impl Daemon {
                     "state catch-up: applying {} entry(ies) (up to seq {max_seq})",
                     entries.len(),
                 );
-                for entry in &entries {
-                    match &entry.operation {
-                        StateCatchUpOperation::SetParam {
-                            node_id,
-                            key,
-                            value,
-                        } => {
-                            if let Some(dataflow) = self.running.get(&dataflow_id)
-                                && let Some(channel) = dataflow.subscribe_channels.get(node_id)
-                            {
-                                match send_with_timestamp(
-                                    channel,
-                                    NodeEvent::ParamUpdate {
-                                        key: key.clone(),
-                                        value: value.clone(),
-                                    },
-                                    &self.clock,
-                                ) {
-                                    Ok(true) => dataflow.inc_pending(node_id),
-                                    Ok(false) => {} // dropped (channel full)
-                                    Err(_) => {
-                                        tracing::warn!("catch-up: node `{node_id}` channel closed")
-                                    }
-                                }
-                            }
-                        }
-                        StateCatchUpOperation::DeleteParam { node_id, key } => {
-                            if let Some(dataflow) = self.running.get(&dataflow_id)
-                                && let Some(channel) = dataflow.subscribe_channels.get(node_id)
-                            {
-                                match send_with_timestamp(
-                                    channel,
-                                    NodeEvent::ParamDeleted { key: key.clone() },
-                                    &self.clock,
-                                ) {
-                                    Ok(true) => dataflow.inc_pending(node_id),
-                                    Ok(false) => {}
-                                    Err(_) => {
-                                        tracing::warn!("catch-up: node `{node_id}` channel closed")
-                                    }
-                                }
-                            }
-                        }
+                let applied_through = match self.running.get(&dataflow_id) {
+                    Some(dataflow) => apply_state_catch_up_entries(dataflow, &entries, &self.clock),
+                    None => {
+                        tracing::warn!(
+                            "state catch-up: dataflow `{dataflow_id}` no longer running on daemon"
+                        );
+                        0
                     }
-                }
-                // Send ack back to coordinator so it can prune the log.
-                if max_seq > 0
+                };
+                // Ack only the prefix that was actually accepted for delivery.
+                if applied_through > 0
                     && let Some(sender) = &self.coordinator_sender
                 {
                     let ack = DaemonEvent::StateCatchUpAck {
                         dataflow_id,
-                        ack_sequence: max_seq,
+                        ack_sequence: applied_through,
                     };
                     let stamped = Timestamped {
                         inner: CoordinatorRequest::Event {
@@ -3844,6 +3809,99 @@ impl Daemon {
     }
 }
 
+fn apply_state_catch_up_entries(
+    dataflow: &RunningDataflow,
+    entries: &[StateCatchUpEntry],
+    clock: &HLC,
+) -> u64 {
+    let mut applied_through = 0;
+
+    for entry in entries {
+        let delivered = match &entry.operation {
+            StateCatchUpOperation::SetParam {
+                node_id,
+                key,
+                value,
+            } => {
+                let Some(channel) = dataflow.subscribe_channels.get(node_id) else {
+                    tracing::warn!(
+                        "catch-up: node `{node_id}` not connected; stopping replay at seq {}",
+                        entry.sequence
+                    );
+                    break;
+                };
+                match send_with_timestamp(
+                    channel,
+                    NodeEvent::ParamUpdate {
+                        key: key.clone(),
+                        value: value.clone(),
+                    },
+                    clock,
+                ) {
+                    Ok(true) => {
+                        dataflow.inc_pending(node_id);
+                        true
+                    }
+                    Ok(false) => {
+                        tracing::warn!(
+                            "catch-up: node `{node_id}` channel full; stopping replay at seq {}",
+                            entry.sequence
+                        );
+                        false
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "catch-up: node `{node_id}` channel closed; stopping replay at seq {}",
+                            entry.sequence
+                        );
+                        false
+                    }
+                }
+            }
+            StateCatchUpOperation::DeleteParam { node_id, key } => {
+                let Some(channel) = dataflow.subscribe_channels.get(node_id) else {
+                    tracing::warn!(
+                        "catch-up: node `{node_id}` not connected; stopping replay at seq {}",
+                        entry.sequence
+                    );
+                    break;
+                };
+                match send_with_timestamp(
+                    channel,
+                    NodeEvent::ParamDeleted { key: key.clone() },
+                    clock,
+                ) {
+                    Ok(true) => {
+                        dataflow.inc_pending(node_id);
+                        true
+                    }
+                    Ok(false) => {
+                        tracing::warn!(
+                            "catch-up: node `{node_id}` channel full; stopping replay at seq {}",
+                            entry.sequence
+                        );
+                        false
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "catch-up: node `{node_id}` channel closed; stopping replay at seq {}",
+                            entry.sequence
+                        );
+                        false
+                    }
+                }
+            }
+        };
+
+        if !delivered {
+            break;
+        }
+        applied_through = entry.sequence;
+    }
+
+    applied_through
+}
+
 async fn read_last_n_lines(file: &mut File, mut tail: usize) -> io::Result<Vec<u8>> {
     let mut pos = file.seek(io::SeekFrom::End(0)).await?;
 
@@ -4888,6 +4946,81 @@ mod fault_tolerance_tests {
         let result =
             send_with_timestamp(&tx, NodeEvent::ParamDeleted { key: "rate".into() }, &clock);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn state_catch_up_stops_at_first_full_channel_and_returns_applied_prefix() {
+        let clock = test_clock();
+        let mut dataflow = test_dataflow();
+        let node_a: NodeId = "node_a".to_string().into();
+        let node_b: NodeId = "node_b".to_string().into();
+
+        let (tx_a, mut rx_a) = mpsc::channel(NODE_EVENT_CHANNEL_CAPACITY);
+        let (tx_b, _rx_b) = mpsc::channel::<Timestamped<NodeEvent>>(1);
+        tx_b.try_send(Timestamped {
+            inner: NodeEvent::Stop,
+            timestamp: clock.new_timestamp(),
+        })
+        .expect("prefill node_b channel");
+
+        dataflow.subscribe_channels.insert(node_a.clone(), tx_a);
+        dataflow.subscribe_channels.insert(node_b.clone(), tx_b);
+
+        let applied_through = apply_state_catch_up_entries(
+            &dataflow,
+            &[
+                StateCatchUpEntry {
+                    sequence: 1,
+                    operation: StateCatchUpOperation::SetParam {
+                        node_id: node_a.clone(),
+                        key: "threshold".into(),
+                        value: serde_json::json!(42),
+                    },
+                },
+                StateCatchUpEntry {
+                    sequence: 2,
+                    operation: StateCatchUpOperation::DeleteParam {
+                        node_id: node_b,
+                        key: "threshold".into(),
+                    },
+                },
+            ],
+            &clock,
+        );
+
+        assert_eq!(applied_through, 1);
+
+        let events = drain_events(&mut rx_a);
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            NodeEvent::ParamUpdate { key, value } => {
+                assert_eq!(key, "threshold");
+                assert_eq!(value, &serde_json::json!(42));
+            }
+            other => panic!("expected ParamUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn state_catch_up_returns_zero_when_first_entry_cannot_be_delivered() {
+        let clock = test_clock();
+        let dataflow = test_dataflow();
+        let node_id: NodeId = "node_a".to_string().into();
+
+        let applied_through = apply_state_catch_up_entries(
+            &dataflow,
+            &[StateCatchUpEntry {
+                sequence: 7,
+                operation: StateCatchUpOperation::SetParam {
+                    node_id,
+                    key: "threshold".into(),
+                    value: serde_json::json!(42),
+                },
+            }],
+            &clock,
+        );
+
+        assert_eq!(applied_through, 0);
     }
 }
 

--- a/tests/ws-cli-e2e.rs
+++ b/tests/ws-cli-e2e.rs
@@ -677,6 +677,43 @@ mod real_dataflow {
         }
     }
 
+    fn set_param_with_retry(
+        session: &WsSession,
+        dataflow_id: Uuid,
+        node_id: dora_message::id::NodeId,
+        key: String,
+        value: serde_json::Value,
+    ) {
+        let deadline = std::time::Instant::now() + Duration::from_secs(8);
+        loop {
+            let reply = super::send_request(
+                session,
+                &ControlRequest::SetParam {
+                    dataflow_id,
+                    node_id: node_id.clone(),
+                    key: key.clone(),
+                    value: value.clone(),
+                },
+            )
+            .unwrap();
+            match reply {
+                ControlRequestReply::ParamSet => return,
+                ControlRequestReply::Error(msg)
+                    if msg.contains("not connected")
+                        || msg.contains("channel full")
+                        || msg.contains("failed to apply SetParam") =>
+                {
+                    assert!(
+                        std::time::Instant::now() <= deadline,
+                        "set failed after retries for key `{key}`: {msg}"
+                    );
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+                other => panic!("set failed for key `{key}`: {other:?}"),
+            }
+        }
+    }
+
     /// Full lifecycle: start -> list (shows dataflow) -> stop -> destroy
     #[test]
     fn e2e_start_list_stop() {
@@ -788,19 +825,12 @@ mod real_dataflow {
         let node_id: dora_message::id::NodeId = "rust-node".to_string().into();
         let session = connect_session();
 
-        let reply = super::send_request(
+        set_param_with_retry(
             &session,
-            &ControlRequest::SetParam {
-                dataflow_id,
-                node_id: node_id.clone(),
-                key: "rate".into(),
-                value: serde_json::json!(100),
-            },
-        )
-        .unwrap();
-        assert!(
-            matches!(reply, ControlRequestReply::ParamSet),
-            "set failed: {reply:?}"
+            dataflow_id,
+            node_id.clone(),
+            "rate".into(),
+            serde_json::json!(100),
         );
 
         let reply = super::send_request(
@@ -884,19 +914,12 @@ mod real_dataflow {
         ];
 
         for (key, value) in &test_cases {
-            let reply = super::send_request(
+            set_param_with_retry(
                 &session,
-                &ControlRequest::SetParam {
-                    dataflow_id,
-                    node_id: node_id.clone(),
-                    key: key.to_string(),
-                    value: value.clone(),
-                },
-            )
-            .unwrap();
-            assert!(
-                matches!(reply, ControlRequestReply::ParamSet),
-                "set failed for {key}"
+                dataflow_id,
+                node_id.clone(),
+                key.to_string(),
+                value.clone(),
             );
         }
 


### PR DESCRIPTION
## Summary
- Carries forward @Bhanudahiyaa's work from #196 (closed as 38-commits-stale) onto current main, composed with [`1fbe91d7d`](https://github.com/dora-rs/adora/commit/1fbe91d7d) (ack catch-up only through delivered entries).
- Two-layer fix complete: strict direct-forward (this PR) + strict catch-up ack (already on main).
- Authorship preserved via cherry-pick: `Author: Bhanu Dahiya`.

## Why

Previously, `SetParam` / `DeleteParam` could report success to the CLI even when runtime delivery didn't happen (node not connected, channel full). Control plane and data plane diverged silently.

`1fbe91d7d` fixed one half — catch-up ack only advances through entries that were actually applied, so failed replays don't get silently pruned from the state log. System self-heals on next reconnect.

But user-visible semantics were still wrong: the CLI got `Ok` even when the direct forward failed. Healing only happened on next reconnect, which could be arbitrarily far out.

This PR adds the other half — strict direct-forward at the daemon + coordinator boundaries. Together:

| Layer | Strictness | Who |
|---|---|---|
| Coordinator → daemon direct forward | Returns error on not-connected / channel-full | this PR |
| Daemon strict helpers | `deliver_param_update_strict` / `deliver_param_delete_strict` | this PR |
| Coordinator reply validators | `ensure_set_param_forward_applied` / `ensure_delete_param_forward_applied` | this PR |
| Daemon catch-up replay | Only acks what was actually delivered | main (`1fbe91d7d`) |
| State log pruning | Only prunes through ack'd sequence | main (`1fbe91d7d`) |

## Changes

- `binaries/daemon/src/lib.rs`: add `deliver_param_update_strict` / `deliver_param_delete_strict`; `SetParam` / `DeleteParam` handlers return daemon errors on delivery failure; retain `apply_state_catch_up_entries` refactor from `1fbe91d7d`.
- `binaries/coordinator/src/lib.rs`: add `ensure_set_param_forward_applied` / `ensure_delete_param_forward_applied`; running-target mutation path requires `SetParamResult(Ok(()))` / `DeleteParamResult(Ok(()))`; daemon rejection or unexpected reply surfaces as `ControlRequestReply::Error(...)`; inline comments clarify persist-first-then-forward pattern.
- `tests/ws-cli-e2e.rs`: add `set_param_with_retry(...)` helper for transient startup windows; param-focused E2E tests updated.

## Conflict resolution (vs main)

The cherry-pick hit one structural conflict in `binaries/daemon/src/lib.rs` around the `DaemonCoordinatorEvent::StateCatchUp` handler:

- PR #196 originally clarified best-effort catch-up loop semantics via comments.
- `1fbe91d7d` replaced the inline loop with a call to `apply_state_catch_up_entries(...)` which returns `applied_through`.

Kept HEAD (the refactored `apply_state_catch_up_entries` call). The PR #196 comments documented semantics that no longer apply — main's refactor is stricter than best-effort. Preserved the coordinator-side comments that clarify the persist-first pattern since those are still accurate.

One test-region conflict (both sides added different tests to the same mod). Kept both: main's `state_catch_up_stops_at_first_full_channel_and_returns_applied_prefix`, main's `state_catch_up_returns_zero_when_first_entry_cannot_be_delivered`, and PR #196's `strict_param_delete_fails_when_channel_full`.

## Testing

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy -p dora-daemon -p dora-coordinator --no-deps -- -D warnings` — clean
- [x] `cargo test -p dora-daemon --lib` — 32 / 32 pass (includes new `strict_param_delete_fails_when_channel_full` + existing `state_catch_up_*` from `1fbe91d7d`)
- [x] `cargo test -p dora-coordinator --lib` — 40 / 40 pass (includes new validator-rejection tests from PR #196)
- Full CI will run on push; ws-cli-e2e param tests exercise the composed direct-forward + catch-up path.

## Attribution

Cherry-picked from closed #196 with original commit authorship preserved:
- `fix(state): enforce strict runtime param delivery for running nodes` — @Bhanudahiyaa
- `docs(state): clarify catch-up leniency and persistence semantics` — @Bhanudahiyaa

Merge strategy: prefer merge-commit (not squash) so the two original commits + their authorship stay visible in history. If the repo convention is squash, add a `Co-authored-by: Bhanu Dahiya <bhanudahiya8@gmail.com>` trailer to the squash commit.

Closes: supersedes #196. Refs #287 (consolidation epic — param-mutation correctness is relevant to 1.0 release claims).
