### PR TITLE
docs: fix 'mis-read' typo unblocking Typos CI on main

### DIFF
--- a/docs/plan-consistency-sweep-2026-04-17.md
+++ b/docs/plan-consistency-sweep-2026-04-17.md
@@ -218,7 +218,7 @@ echo "upstream: $(gh api repos/dora-rs/dora/contents/Cargo.toml --jq .content | 
 
 # §6 Dep versions — scope to [workspace.dependencies] so you don't pick up a
 # [dev-dependencies] copy of the same key (which is exactly how the sweep's
-# first draft mis-read serde_yaml on upstream).
+# first draft misread serde_yaml on upstream).
 #
 # Note: don't use `awk '/^\[workspace.dependencies\]/,/^\[/'` — the `/^\[/`
 # end pattern matches the START line too, so awk exits immediately and emits


### PR DESCRIPTION
1-line docs fix. 'mis-read' triggered a typos CI failure on every downstream PR (flagged as misspelling of 'miss' / 'mist'). Replaced with 'misread' (standard spelling, no typo). Unblocks contributor-PR CI.

Verified locally: `rg 'mis-read'` returns zero hits after the change.