### PR TITLE
fix: use current_exe() instead of which("dora") to locate runtime binary

### DIFF
--- a/binaries/daemon/src/spawn/spawner.rs
+++ b/binaries/daemon/src/spawn/spawner.rs
@@ -297,8 +297,9 @@ impl Spawner {
                         ]);
                         Some(cmd)
                     } else {
-                        let mut cmd =
-                            Command::new(which::which("dora").wrap_err("failed to get dora path")?);
+                        let current_exe = std::env::current_exe()
+                            .wrap_err("failed to get current executable path")?;
+                        let mut cmd = Command::new(current_exe);
                         cmd = cmd.arg("runtime");
                         Some(cmd)
                     }


### PR DESCRIPTION
## Summary

The daemon was using `which::which("dora")` to resolve the binary path
for spawning runtime nodes. This resolves to whichever `dora` appears
first in `$PATH`, which may be a different version than the running
daemon — causing version skew between the daemon and the runtime it
spawns.

Changed to `std::env::current_exe()` so the daemon always invokes its
own binary with the `runtime` subcommand, guaranteeing version
consistency.

## Root cause

`binaries/daemon/src/spawn/spawner.rs` called `which::which("dora")`
while the same file already used `std::env::current_exe()` elsewhere
for other purposes. The inconsistency meant a system-installed `dora`
could be picked up instead of the locally-built one.

## Exposed by

Running `examples/c++-dataflow` with a locally-built binary while a
different version of `dora` was present in `$PATH` — runtime nodes
failed with "No such file or directory".

## Test results

- `examples/c++-dataflow`: runtime nodes spawn correctly,
  `internal counter: 1` on first tick ✅