### PR TITLE
fix: prevent auto-recovery race and handle LogSubscribe for finished dataflows

### DIFF
--- a/binaries/coordinator/src/lib.rs
+++ b/binaries/coordinator/src/lib.rs
@@ -1585,6 +1585,11 @@ async fn start_inner(
                             send_log_message(&mut dataflow.log_subscribers, &message).await;
                         }
                         let _ = found_tx.send(true);
+                    } else if archived_dataflows.contains_key(&dataflow_id) {
+                        // Dataflow already finished before the CLI could subscribe.
+                        // Acknowledge the subscription so the CLI doesn't error, then
+                        // drop `sender` immediately — the closed channel signals EOF.
+                        let _ = found_tx.send(true);
                     } else {
                         let _ = found_tx.send(false);
                     }
@@ -2044,6 +2049,10 @@ async fn start_inner(
                     if let Some(last) = df.last_recovery_attempt.get(&daemon_id)
                         && now.duration_since(*last) < RECOVERY_BACKOFF
                     {
+                        continue;
+                    }
+                    // Skip if a spawn is already in-flight for this daemon
+                    if df.pending_spawn_results.contains(&daemon_id) {
                         continue;
                     }
                     // Collect nodes assigned to this daemon


### PR DESCRIPTION
## Summary

Two bugs found while running `examples/cpu-affinity-probe`, a
short-lived probe node that exits immediately after printing its CPU
affinity mask.

**Bug 1 — auto-recovery race condition**

When a daemon first connects, it sends a `DaemonStatusReport` with zero
running dataflows because the spawn is still in-flight. The
auto-recovery block in the coordinator event loop treated this as a
missing dataflow and triggered a redundant re-spawn, producing
`failed to send SpawnNodeResult` errors.

Fix: skip auto-recovery for a given daemon if
`pending_spawn_results` already contains it, indicating a spawn is
already in-flight.

**Bug 2 — LogSubscribe for already-finished dataflows**

The probe node exits before the CLI can subscribe to its logs. The
`LogSubscribe` handler only checked `running_dataflows`, so it returned
`found=false` for an already-finished dataflow, causing the CLI to
error with "failed to subscribe to logs" instead of receiving a clean
EOF.

Fix: check `archived_dataflows` before returning `found=false`. If the
dataflow is archived, return `found=true` and drop the sender
immediately — the closed channel signals EOF to the CLI.

## Exposed by

Running `examples/cpu-affinity-probe` — the node exits in under 100ms,
reliably triggering both the spawn race and the log-subscribe timing
window.

## Test results

- `examples/cpu-affinity-probe`: no ERROR lines, dataflow exits
  cleanly ✅