### PR TITLE
fix: handle empty parent path when resolving dataflow working directory

### DIFF
--- a/binaries/cli/src/command/build/mod.rs
+++ b/binaries/cli/src/command/build/mod.rs
@@ -145,6 +145,7 @@ pub fn build(
     }
     let working_dir = dataflow_path
         .parent()
+        .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
     let dataflow_descriptor = Descriptor::blocking_read(&dataflow_path)
         .wrap_err_with(|| {

--- a/binaries/cli/src/command/expand.rs
+++ b/binaries/cli/src/command/expand.rs
@@ -25,6 +25,7 @@ impl Executable for Expand {
         let working_dir = self
             .dataflow
             .parent()
+            .filter(|p| !p.as_os_str().is_empty())
             .unwrap_or_else(|| std::path::Path::new("."));
         let descriptor = Descriptor::blocking_read(&self.dataflow)
             .with_context(|| format!("failed to read dataflow at `{}`", self.dataflow.display()))?

--- a/binaries/cli/src/command/graph.rs
+++ b/binaries/cli/src/command/graph.rs
@@ -87,6 +87,7 @@ pub fn visualize_as_html(dataflow: &Path) -> eyre::Result<String> {
 pub fn visualize_as_mermaid(dataflow: &Path) -> eyre::Result<String> {
     let working_dir = dataflow
         .parent()
+        .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
     let raw = Descriptor::blocking_read(dataflow)
         .with_context(|| format!("failed to read dataflow at `{}`", dataflow.display()))?;

--- a/binaries/cli/src/command/run.rs
+++ b/binaries/cli/src/command/run.rs
@@ -177,6 +177,7 @@ impl Executable for Run {
 
         let working_dir = dataflow_path
             .parent()
+            .filter(|p| !p.as_os_str().is_empty())
             .unwrap_or_else(|| std::path::Path::new("."));
         let mut dataflow_descriptor = Descriptor::blocking_read(&dataflow_path)
             .wrap_err_with(|| {

--- a/binaries/cli/src/command/start/mod.rs
+++ b/binaries/cli/src/command/start/mod.rs
@@ -114,6 +114,7 @@ fn start_dataflow(
     let dataflow = resolve_dataflow(dataflow).context("could not resolve dataflow")?;
     let working_dir = dataflow
         .parent()
+        .filter(|p| !p.as_os_str().is_empty())
         .unwrap_or_else(|| std::path::Path::new("."));
     let mut dataflow_descriptor = Descriptor::blocking_read(&dataflow)
         .wrap_err_with(|| {

--- a/binaries/cli/src/command/validate.rs
+++ b/binaries/cli/src/command/validate.rs
@@ -25,6 +25,7 @@ impl Executable for Validate {
         let working_dir = self
             .dataflow
             .parent()
+            .filter(|p| !p.as_os_str().is_empty())
             .unwrap_or_else(|| std::path::Path::new("."));
 
         println!("Validating {}...", self.dataflow.display());


### PR DESCRIPTION
## Summary

`Path::parent()` returns `Some("")` for bare filenames like
`"dataflow.yml"`, not `None`. The existing `.unwrap_or(Path::new("."))`
fallback only triggers on `None`, so `canonicalize("")` fails with
"No such file or directory" when the CLI tries to expand module
references.

Added `.filter(|p| !p.as_os_str().is_empty())` before the fallback
in all 6 affected call sites: `run`, `build`, `start`, `expand`,
`graph`, and `validate`.

## Root cause

Rust's `Path::parent()` on a relative path with no directory component
(e.g. `"dataflow.yml"`) returns `Some("")` rather than `None`. The
empty string cannot be canonicalized, causing module expansion to fail
at `libraries/core/src/descriptor/expand.rs:96`.

## Exposed by

Running `examples/module-dataflow` — `dora run dataflow.yml` from the
example directory triggers the empty base_dir path, failing with:

    failed to expand modules in dataflow descriptor
      failed to resolve base directory:
      No such file or directory (os error 2)

## Test results

- `examples/module-dataflow`: sender → doubler → filter → receiver
  pipeline runs correctly after fix ✅